### PR TITLE
Bump version to 3.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ REPOSITORY ?= $(REGISTRY)/open-policy-agent/gatekeeper
 
 IMG := $(REPOSITORY):latest
 
-VERSION := v2.1.0
+VERSION := v3.0.0
 
 BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./build/get-build-timestamp.sh)


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

For cutting our first release after the constraint framework integration, per weekly meeting on April 16, 2019. 