### PR TITLE
Add namespace spec to deployment template

### DIFF
--- a/deploy/gatekeeper-constraint.yaml
+++ b/deploy/gatekeeper-constraint.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: gatekeeper-system
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
Signed-off-by: Lachlan Evenson <lachlan.evenson@microsoft.com>

Running through the https://github.com/open-policy-agent/gatekeeper#deploying-a-release-using-prebuilt-image yields the following error:

```sh
$ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper-constraint.yaml
clusterrolebinding.rbac.authorization.k8s.io/manager-rolebinding created
clusterrole.rbac.authorization.k8s.io/manager-role created
validatingwebhookconfiguration.admissionregistration.k8s.io/validating-webhook-configuration created
customresourcedefinition.apiextensions.k8s.io/constrainttemplates.templates.gatekeeper.sh created
customresourcedefinition.apiextensions.k8s.io/configs.config.gatekeeper.sh created
Error from server (NotFound): error when creating "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper-constraint.yaml": namespaces "gatekeeper-system" not found
Error from server (NotFound): error when creating "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper-constraint.yaml": namespaces "gatekeeper-system" not found
Error from server (NotFound): error when creating "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper-constraint.yaml": namespaces "gatekeeper-system" not found
```

This PR add the explicit namespace creation