### PR TITLE
add second check if watchmanager started

### DIFF
--- a/demo/agilebank/demo.sh
+++ b/demo/agilebank/demo.sh
@@ -5,9 +5,6 @@
 clear
 
 kubectl apply -f sync.yaml >> /dev/null
-kubectl apply -f remediation/k8sbannedimagetags_template.yaml >> /dev/null
-sleep 1
-kubectl apply -f remediation/ban_latest_tag.yaml >> /dev/null
 
 echo "===== ENTER developer ====="
 echo
@@ -88,17 +85,18 @@ echo
 NO_WAIT=true
 p "All is well with the world, until the big outage. The bank is down for hours."
 read
-p "We must never again use the :latest tag in production!"
-echo
-NO_WAIT=false
 
 echo "===== ENTER admin ====="
 echo
-
-pe "cat remediation/k8sbannedimagetags_template.yaml"
+p "We had no idea there were resources in the cluster without resource limits. Now they are causing issues in production!"
 echo
+p "We need to get all the resources in the cluster that lack resource limits."
+read
+p "Let's check out the audit results of the container-must-have-limits constraint!"
+read
 
-pe "kubectl get k8sbannedimagetags -oyaml"
+NO_WAIT=false
+pe "kubectl get k8scontainerlimits.constraints.gatekeeper.sh  container-must-have-limits -o yaml"
 echo
 
 p "THE END"
@@ -107,5 +105,4 @@ kubectl delete -f good_resources
 kubectl delete ns advanced-transaction-system
 kubectl delete -f constraints
 kubectl delete -f templates
-kubectl delete -f remediation/ban_latest_tag.yaml
-kubectl delete -f remediation/k8sbannedimagetags_template.yaml
+kubectl delete -f sync.yaml

--- a/pkg/watch/manager.go
+++ b/pkg/watch/manager.go
@@ -130,8 +130,8 @@ func (wm *WatchManager) updateManager() (bool, error) {
 		return false, errp.Wrap(err, "could not filter pending resources, not restarting watch manager")
 	}
 
-	if len(readyToAdd) == 0 && len(removed) == 0 && len(changed) == 0 {
-		log.Info("no resources ready to watch and nothing to remove")
+	if wm.started == true && len(readyToAdd) == 0 && len(removed) == 0 && len(changed) == 0 {
+		log.Info("All changes are pending additions, not restarting watch manager")
 		return false, nil
 	}
 

--- a/pkg/watch/manager.go
+++ b/pkg/watch/manager.go
@@ -123,7 +123,7 @@ func (wm *WatchManager) updateManager() (bool, error) {
 	for k, _ := range changed {
 		a = append(c, k.String())
 	}
-	log.Info("Watcher registry found changes, attempting to apply them", "add", a, "remove", r, "change", c)
+	log.Info("Watcher registry found changes and/or needs restarting", "started", wm.started, "add", a, "remove", r, "change", c)
 
 	readyToAdd, err := wm.filterPendingResources(added)
 	if err != nil {
@@ -131,7 +131,7 @@ func (wm *WatchManager) updateManager() (bool, error) {
 	}
 
 	if wm.started == true && len(readyToAdd) == 0 && len(removed) == 0 && len(changed) == 0 {
-		log.Info("All changes are pending additions, not restarting watch manager")
+		log.Info("Only changes are pending additions; not restarting watch manager")
 		return false, nil
 	}
 

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -22,13 +22,13 @@ func newForTest(fn func(*rest.Config) (Discovery, error)) *WatchManager {
 		newMgrFn:     newFakeMgr,
 		stopper:      make(chan struct{}),
 		stopped:      make(chan struct{}),
+		started:      true,
 		managedKinds: newRecordKeeper(),
 		watchedKinds: make(map[schema.GroupVersionKind]watchVitals),
 		cfg:          nil,
 		newDiscovery: fn,
 	}
 	close(wm.stopped)
-	wm.started = true
 	wm.managedKinds.mgr = wm
 	return wm
 }
@@ -272,6 +272,7 @@ func TestRegistrar(t *testing.T) {
 	if err := reg.AddWatch(makeGvk("FooCRD")); err != nil {
 		t.Fatalf("Error adding watch: %s", err)
 	}
+
 	t.Run("Single Add Waits For CRD Available", func(t *testing.T) {
 		wm.newDiscovery = newDiscoveryFactory(true)
 		expectedAdded := newChange("FooCRD", reg)

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -303,7 +303,6 @@ func TestRegistrar(t *testing.T) {
 	}
 
 	t.Run("Single Add Waits For CRD Available", func(t *testing.T) {
-		wm.started = true
 		wm.newDiscovery = newDiscoveryFactory(true)
 		expectedAdded := newChange("FooCRD", reg)
 		added, removed, changed, err := wm.gatherChanges(wm.managedKinds.Get())

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -27,9 +27,9 @@ func newForTest(fn func(*rest.Config) (Discovery, error)) *WatchManager {
 		cfg:          nil,
 		newDiscovery: fn,
 	}
-	wm.managedKinds.mgr = wm
 	close(wm.stopped)
 	wm.started = true
+	wm.managedKinds.mgr = wm
 	return wm
 }
 

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -122,12 +122,11 @@ func makeGvk(k string) schema.GroupVersionKind {
 }
 
 func waitForWatchManagerStart(wm *WatchManager) bool {
-	for i := 0; i < 10; {
+	for i := 0; i < 10; i++ {
 		if wm.started == true {
 			return true
 		}
 		time.Sleep(10 * time.Millisecond)
-		i++
 	}
 	return false
 }

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -274,6 +274,7 @@ func TestRegistrar(t *testing.T) {
 	}
 
 	t.Run("Single Add Waits For CRD Available", func(t *testing.T) {
+		wm.started = true
 		wm.newDiscovery = newDiscoveryFactory(true)
 		expectedAdded := newChange("FooCRD", reg)
 		added, removed, changed, err := wm.gatherChanges(wm.managedKinds.Get())

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -155,6 +155,8 @@ func TestRegistrar(t *testing.T) {
 		}
 	})
 
+	wm.started = true
+
 	t.Run("Second add watch does nothing", func(t *testing.T) {
 		if err := reg.AddWatch(makeGvk("FooCRD")); err != nil {
 			t.Fatalf("Error adding second watch: %s", err)

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -155,9 +155,8 @@ func TestRegistrar(t *testing.T) {
 		}
 	})
 
-	wm.started = true
-
 	t.Run("Second add watch does nothing", func(t *testing.T) {
+		wm.started = true
 		if err := reg.AddWatch(makeGvk("FooCRD")); err != nil {
 			t.Fatalf("Error adding second watch: %s", err)
 		}
@@ -272,6 +271,7 @@ func TestRegistrar(t *testing.T) {
 		t.Fatalf("Error adding watch: %s", err)
 	}
 	t.Run("Single Add Waits For CRD Available", func(t *testing.T) {
+		wm.started = true
 		wm.newDiscovery = newDiscoveryFactory(true)
 		expectedAdded := newChange("FooCRD", reg)
 		added, removed, changed, err := wm.gatherChanges(wm.managedKinds.Get())

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -334,4 +334,15 @@ func TestRegistrar(t *testing.T) {
 			t.Errorf("Manager should have updated now that CRD is found")
 		}
 	})
+
+	t.Run("Manager restarts when not started", func(t *testing.T) {
+		wm.started = false
+		b, err := wm.updateManager()
+		if err != nil {
+			t.Errorf("Could not update manager: %s", err)
+		}
+		if b == false {
+			t.Errorf("Manager not restarted")
+		}
+	})
 }


### PR DESCRIPTION
Another `wm.started` check needed so that watch manager can eventually restart. Gets stuck in a stopped state forever otherwise.

Signed-off-by: Craig Tabita <ctab@google.com>