### PR TITLE
add control-plane label to exclude gk ns

### DIFF
--- a/deploy/gatekeeper.yaml
+++ b/deploy/gatekeeper.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: gatekeeper-system
+  labels:
+    control-plane: controller-manager
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

validating webhook config currently excludes namespace with `control-plane` label

```yaml
namespaceSelector:
    matchExpressions:
    - key: control-plane
      operator: DoesNotExist
```