### PR TITLE
Add enforcementAction to status

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -65,7 +65,7 @@ type StatusViolation struct {
 	Name              string `json:"name"`
 	Namespace         string `json:"namespace,omitempty"`
 	Message           string `json:"message"`
-	EnforcementAction string `json:"enforcementaction"`
+	EnforcementAction string `json:"enforcementAction"`
 }
 
 // New creates a new manager for audit
@@ -275,12 +275,12 @@ func (ucloop *updateConstraintLoop) updateConstraintStatus(ctx context.Context, 
 	unstructured.SetNestedField(instance.Object, timestamp, "status", "auditTimestamp")
 	// update constraint status violations
 	if len(violations) == 0 {
-		_, found, err := unstructured.NestedSlice(instance.Object, "status", "violationsByAction")
+		_, found, err := unstructured.NestedSlice(instance.Object, "status", "violations")
 		if err != nil {
 			return err
 		}
 		if found {
-			unstructured.RemoveNestedField(instance.Object, "status", "violationsByAction")
+			unstructured.RemoveNestedField(instance.Object, "status", "violations")
 			log.Info("removed status violations", "constraintName", constraintName)
 		}
 		err = ucloop.client.Update(ctx, instance)
@@ -288,7 +288,7 @@ func (ucloop *updateConstraintLoop) updateConstraintStatus(ctx context.Context, 
 			return err
 		}
 	} else {
-		unstructured.SetNestedSlice(instance.Object, violations, "status", "violationsByAction")
+		unstructured.SetNestedSlice(instance.Object, violations, "status", "violations")
 		log.Info("update constraint", "object", instance)
 		err = ucloop.client.Update(ctx, instance)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

@timothyhinrichs @maxsmythe 
Per our discussion for the [Dry Run design proposal](https://docs.google.com/document/d/17nJDJxjY_XHV8zrMNdOi2hFgfm6XKGJi0QyznsbhQ70/edit?usp=sharing), this PR updates the status field of Constraint object to include the `enforcementAction` the violation resulted from.

Example of a Constraint's status field as a result of this PR:
```yaml
status:
  auditTimestamp: "2019-07-10T06:06:29Z"
  byPod:
  - enforced: true
    id: gatekeeper-controller-manager-0
  violations:
  - enforcementAction: deny
    kind: Pod
    message: 'you must provide labels: {"gatekeeper"}'
    name: nginx-4rfps
    namespace: test
  - enforcementAction: deny
    kind: Pod
    message: 'you must provide labels: {"gatekeeper"}'
    name: nginx-xrxjk
    namespace: test
```
Once we have implemented the dry run feature, it could be something like:
Constraint for prod
```yaml
apiVersion: constraints.gatekeeper.sh/v1alpha1
kind: K8sRequiredLabels
metadata:
  name: pod-must-have-gk-prod
spec:
  enforcementAction: dryrun
  match:
    kinds:
      - apiGroups: [""]
        kinds: ["Pod"]
    namespaces:
      - "production"
  parameters:
    labels: ["gatekeeper"]
status:
  auditTimestamp: "2019-07-10T06:06:29Z"
  byPod:
  - enforced: true
    id: gatekeeper-controller-manager-0
  violations:
  - enforcementAction: dryrun
    kind: Pod
    message: 'you must provide labels: {"gatekeeper"}'
    name: nginx-xrxjk
    namespace: production
```

Constraint for dev
```yaml
apiVersion: constraints.gatekeeper.sh/v1alpha1
kind: K8sRequiredLabels
metadata:
  name: pod-must-have-gk-dev
spec:
  enforcementAction: deny
  match:
    kinds:
      - apiGroups: [""]
        kinds: ["Pod"]
    namespaces:
      - "dev"
  parameters:
    labels: ["gatekeeper"]
status:
  auditTimestamp: "2019-07-10T06:06:29Z"
  byPod:
  - enforced: true
    id: gatekeeper-controller-manager-0
  violations:
  - enforcementAction: deny
    kind: Pod
    message: 'you must provide labels: {"gatekeeper"}'
    name: nginx-xrxjk
    namespace: dev
```