### PR TITLE
Change OPA client from interface to concrete type

### DIFF
--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -56,7 +56,7 @@ var CfgKey = types.NamespacedName{Namespace: "gatekeeper-system", Name: "config"
 var log = logf.Log.WithName("controller")
 
 type Adder struct {
-	Opa          opa.Client
+	Opa          *opa.Client
 	WatchManager *watch.WatchManager
 }
 
@@ -70,7 +70,7 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	return add(mgr, r)
 }
 
-func (a *Adder) InjectOpa(o opa.Client) {
+func (a *Adder) InjectOpa(o *opa.Client) {
 	a.Opa = o
 }
 
@@ -79,7 +79,7 @@ func (a *Adder) InjectWatchManager(wm *watch.WatchManager) {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opa opa.Client, wm *watch.WatchManager) (reconcile.Reconciler, error) {
+func newReconciler(mgr manager.Manager, opa *opa.Client, wm *watch.WatchManager) (reconcile.Reconciler, error) {
 	syncAdder := syncc.Adder{Opa: opa}
 	w, err := wm.NewRegistrar(
 		ctrlName,
@@ -119,7 +119,7 @@ var _ reconcile.Reconciler = &ReconcileConfig{}
 type ReconcileConfig struct {
 	client.Client
 	scheme  *runtime.Scheme
-	opa     opa.Client
+	opa     *opa.Client
 	watcher *watch.Registrar
 	watched *watchSet
 	fc      *finalizerCleanup

--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -40,7 +40,7 @@ var log = logf.Log.WithName("controller").WithValues("metaKind", "Constraint")
 const project = "gatekeeper.sh"
 
 type Adder struct {
-	Opa opa.Client
+	Opa *opa.Client
 }
 
 // Add creates a new Constraint Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -51,7 +51,7 @@ func (a *Adder) Add(mgr manager.Manager, gvk schema.GroupVersionKind) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, gvk schema.GroupVersionKind, opa opa.Client) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, gvk schema.GroupVersionKind, opa *opa.Client) reconcile.Reconciler {
 	return &ReconcileConstraint{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
@@ -86,7 +86,7 @@ var _ reconcile.Reconciler = &ReconcileConstraint{}
 type ReconcileConstraint struct {
 	client.Client
 	scheme *runtime.Scheme
-	opa    opa.Client
+	opa    *opa.Client
 	gvk    schema.GroupVersionKind
 	log    logr.Logger
 }

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -49,7 +49,7 @@ const (
 var log = logf.Log.WithName("controller").WithValues("kind", "ConstraintTemplate")
 
 type Adder struct {
-	Opa          opa.Client
+	Opa          *opa.Client
 	WatchManager *watch.WatchManager
 }
 
@@ -63,7 +63,7 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	return add(mgr, r)
 }
 
-func (a *Adder) InjectOpa(o opa.Client) {
+func (a *Adder) InjectOpa(o *opa.Client) {
 	a.Opa = o
 }
 
@@ -72,7 +72,7 @@ func (a *Adder) InjectWatchManager(wm *watch.WatchManager) {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, opa opa.Client, wm *watch.WatchManager) (reconcile.Reconciler, error) {
+func newReconciler(mgr manager.Manager, opa *opa.Client, wm *watch.WatchManager) (reconcile.Reconciler, error) {
 	constraintAdder := constraint.Adder{Opa: opa}
 	w, err := wm.NewRegistrar(
 		ctrlName,
@@ -112,7 +112,7 @@ type ReconcileConstraintTemplate struct {
 	client.Client
 	scheme  *runtime.Scheme
 	watcher *watch.Registrar
-	opa     opa.Client
+	opa     *opa.Client
 }
 
 // Reconcile reads that state of the cluster for a ConstraintTemplate object and makes changes based on the state read

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -24,7 +24,7 @@ import (
 )
 
 type Injector interface {
-	InjectOpa(opa.Client)
+	InjectOpa(*opa.Client)
 	InjectWatchManager(*watch.WatchManager)
 	Add(mgr manager.Manager) error
 }
@@ -37,7 +37,7 @@ var Injectors []Injector
 var AddToManagerFuncs []func(manager.Manager) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager, client opa.Client) error {
+func AddToManager(m manager.Manager, client *opa.Client) error {
 
 	wm := watch.New(context.Background(), m.GetConfig())
 

--- a/pkg/controller/sync/sync_controller.go
+++ b/pkg/controller/sync/sync_controller.go
@@ -42,7 +42,7 @@ const (
 )
 
 type Adder struct {
-	Opa opa.Client
+	Opa *opa.Client
 }
 
 // Add creates a new Sync Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
@@ -53,7 +53,7 @@ func (a *Adder) Add(mgr manager.Manager, gvk schema.GroupVersionKind) error {
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, gvk schema.GroupVersionKind, opa opa.Client) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, gvk schema.GroupVersionKind, opa *opa.Client) reconcile.Reconciler {
 	return &ReconcileSync{
 		Client: mgr.GetClient(),
 		scheme: mgr.GetScheme(),
@@ -88,7 +88,7 @@ var _ reconcile.Reconciler = &ReconcileSync{}
 type ReconcileSync struct {
 	client.Client
 	scheme *runtime.Scheme
-	opa    opa.Client
+	opa    *opa.Client
 	gvk    schema.GroupVersionKind
 	log    logr.Logger
 }

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -53,7 +53,7 @@ var (
 // below: notations add permissions kube-mgmt needs. Access cannot yet be restricted on a namespace-level granularity
 // +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch
 // +kubebuilder:rbac:groups=,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
-func AddPolicyWebhook(mgr manager.Manager, opa opa.Client) error {
+func AddPolicyWebhook(mgr manager.Manager, opa *opa.Client) error {
 	validatingWh, err := builder.NewWebhookBuilder().
 		Validating().
 		Name(*webhookName).
@@ -114,7 +114,7 @@ func AddPolicyWebhook(mgr manager.Manager, opa opa.Client) error {
 var _ admission.Handler = &validationHandler{}
 
 type validationHandler struct {
-	opa    opa.Client
+	opa    *opa.Client
 	client client.Client
 
 	// for testing

--- a/pkg/webhook/policy_test.go
+++ b/pkg/webhook/policy_test.go
@@ -130,7 +130,7 @@ spec:
 `
 )
 
-func makeOpaClient() (client.Client, error) {
+func makeOpaClient() (*client.Client, error) {
 	target := &target.K8sValidationTarget{}
 	driver := local.New(local.Tracing(false))
 	backend, err := client.NewBackend(client.Driver(driver))

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -16,18 +16,18 @@ limitations under the License.
 package webhook
 
 import (
-	"github.com/open-policy-agent/frameworks/constraint/pkg/client"
+	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, client.Client) error
+var AddToManagerFuncs []func(manager.Manager, *opa.Client) error
 
 // AddToManager adds all Controllers to the Manager
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
-func AddToManager(m manager.Manager, opa client.Client) error {
+func AddToManager(m manager.Manager, opa *opa.Client) error {
 	for _, f := range AddToManagerFuncs {
 		if err := f(m, opa); err != nil {
 			return err

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/backend.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/backend.go
@@ -37,11 +37,11 @@ func NewBackend(opts ...BackendOpt) (*Backend, error) {
 }
 
 // NewClient creates a new client for the supplied backend
-func (b *Backend) NewClient(opts ...ClientOpt) (Client, error) {
+func (b *Backend) NewClient(opts ...ClientOpt) (*Client, error) {
 	if b.hasClient {
 		return nil, errors.New("Currently only one client per backend is supported")
 	}
-	c := &client{
+	c := &Client{
 		backend:     b,
 		constraints: make(map[string]*constraintEntry),
 	}

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/client.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/client.go
@@ -21,31 +21,6 @@ import (
 
 const constraintGroup = "constraints.gatekeeper.sh"
 
-type Client interface {
-	AddData(context.Context, interface{}) (*types.Responses, error)
-	RemoveData(context.Context, interface{}) (*types.Responses, error)
-
-	CreateCRD(context.Context, *v1alpha1.ConstraintTemplate) (*apiextensionsv1beta1.CustomResourceDefinition, error)
-	AddTemplate(context.Context, *v1alpha1.ConstraintTemplate) (*types.Responses, error)
-	RemoveTemplate(context.Context, *v1alpha1.ConstraintTemplate) (*types.Responses, error)
-
-	AddConstraint(context.Context, *unstructured.Unstructured) (*types.Responses, error)
-	RemoveConstraint(context.Context, *unstructured.Unstructured) (*types.Responses, error)
-	ValidateConstraint(context.Context, *unstructured.Unstructured) error
-
-	// Reset the state of OPA
-	Reset(context.Context) error
-
-	// Review makes sure the provided object satisfies all stored constraints
-	Review(context.Context, interface{}, ...QueryOpt) (*types.Responses, error)
-
-	// Audit makes sure the cached state of the system satisfies all stored constraints
-	Audit(context.Context, ...QueryOpt) (*types.Responses, error)
-
-	// Dump dumps the state of OPA to aid in debugging
-	Dump(context.Context) (string, error)
-}
-
 type UnrecognizedConstraintError struct {
 	s string
 }
@@ -68,14 +43,14 @@ func (e ErrorMap) Error() string {
 	return b.String()
 }
 
-type ClientOpt func(*client) error
+type ClientOpt func(*Client) error
 
 // Client options
 
 var targetNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9.]*$`)
 
 func Targets(ts ...TargetHandler) ClientOpt {
-	return func(c *client) error {
+	return func(c *Client) error {
 		var errs Errors
 		handlers := make(map[string]TargetHandler, len(ts))
 		for _, t := range ts {
@@ -134,14 +109,12 @@ type TargetHandler interface {
 	ValidateConstraint(*unstructured.Unstructured) error
 }
 
-var _ Client = &client{}
-
 type constraintEntry struct {
 	CRD     *apiextensionsv1beta1.CustomResourceDefinition
 	Targets []string
 }
 
-type client struct {
+type Client struct {
 	backend        *Backend
 	targets        map[string]TargetHandler
 	constraintsMux sync.RWMutex
@@ -158,7 +131,7 @@ func createDataPath(target, subpath string) string {
 }
 
 // AddData inserts the provided data into OPA for every target that can handle the data.
-func (c *client) AddData(ctx context.Context, data interface{}) (*types.Responses, error) {
+func (c *Client) AddData(ctx context.Context, data interface{}) (*types.Responses, error) {
 	resp := types.NewResponses()
 	errMap := make(ErrorMap)
 	for target, h := range c.targets {
@@ -183,7 +156,7 @@ func (c *client) AddData(ctx context.Context, data interface{}) (*types.Response
 }
 
 // RemoveData removes data from OPA for every target that can handle the data.
-func (c *client) RemoveData(ctx context.Context, data interface{}) (*types.Responses, error) {
+func (c *Client) RemoveData(ctx context.Context, data interface{}) (*types.Responses, error) {
 	resp := types.NewResponses()
 	errMap := make(ErrorMap)
 	for target, h := range c.targets {
@@ -213,7 +186,7 @@ func createTemplatePath(target, name string) string {
 }
 
 // CreateCRD creates a CRD from template
-func (c *client) CreateCRD(ctx context.Context, templ *v1alpha1.ConstraintTemplate) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
+func (c *Client) CreateCRD(ctx context.Context, templ *v1alpha1.ConstraintTemplate) (*apiextensionsv1beta1.CustomResourceDefinition, error) {
 	if err := validateTargets(templ); err != nil {
 		return nil, err
 	}
@@ -262,7 +235,7 @@ func (c *client) CreateCRD(ctx context.Context, templ *v1alpha1.ConstraintTempla
 // AddTemplate adds the template source code to OPA and registers the CRD with the client for
 // schema validation on calls to AddConstraint. It also returns a copy of the CRD describing
 // the constraint.
-func (c *client) AddTemplate(ctx context.Context, templ *v1alpha1.ConstraintTemplate) (*types.Responses, error) {
+func (c *Client) AddTemplate(ctx context.Context, templ *v1alpha1.ConstraintTemplate) (*types.Responses, error) {
 	resp := types.NewResponses()
 	crd, err := c.CreateCRD(ctx, templ)
 	if err != nil {
@@ -301,7 +274,7 @@ func (c *client) AddTemplate(ctx context.Context, templ *v1alpha1.ConstraintTemp
 
 // RemoveTemplate removes the template source code from OPA and removes the CRD from the validation
 // registry.
-func (c *client) RemoveTemplate(ctx context.Context, templ *v1alpha1.ConstraintTemplate) (*types.Responses, error) {
+func (c *Client) RemoveTemplate(ctx context.Context, templ *v1alpha1.ConstraintTemplate) (*types.Responses, error) {
 	resp := types.NewResponses()
 	if err := validateTargets(templ); err != nil {
 		return resp, err
@@ -355,7 +328,7 @@ func createConstraintPath(target string, constraint *unstructured.Unstructured) 
 }
 
 // getConstraintEntry returns the constraint entry for a given constraint
-func (c *client) getConstraintEntry(constraint *unstructured.Unstructured, lock bool) (*constraintEntry, error) {
+func (c *Client) getConstraintEntry(constraint *unstructured.Unstructured, lock bool) (*constraintEntry, error) {
 	kind := constraint.GetKind()
 	if kind == "" {
 		return nil, fmt.Errorf("Constraint %s has no kind", constraint.GetName())
@@ -372,7 +345,7 @@ func (c *client) getConstraintEntry(constraint *unstructured.Unstructured, lock 
 }
 
 // AddConstraint validates the constraint and, if valid, inserts it into OPA
-func (c *client) AddConstraint(ctx context.Context, constraint *unstructured.Unstructured) (*types.Responses, error) {
+func (c *Client) AddConstraint(ctx context.Context, constraint *unstructured.Unstructured) (*types.Responses, error) {
 	c.constraintsMux.RLock()
 	defer c.constraintsMux.RUnlock()
 	resp := types.NewResponses()
@@ -405,7 +378,7 @@ func (c *client) AddConstraint(ctx context.Context, constraint *unstructured.Uns
 }
 
 // RemoveConstraint removes a constraint from OPA
-func (c *client) RemoveConstraint(ctx context.Context, constraint *unstructured.Unstructured) (*types.Responses, error) {
+func (c *Client) RemoveConstraint(ctx context.Context, constraint *unstructured.Unstructured) (*types.Responses, error) {
 	c.constraintsMux.RLock()
 	defer c.constraintsMux.RUnlock()
 	resp := types.NewResponses()
@@ -435,7 +408,7 @@ func (c *client) RemoveConstraint(ctx context.Context, constraint *unstructured.
 
 // validateConstraint is an internal function that allows us to toggle whether we use a read lock
 // when validating a constraint
-func (c *client) validateConstraint(constraint *unstructured.Unstructured, lock bool) error {
+func (c *Client) validateConstraint(constraint *unstructured.Unstructured, lock bool) error {
 	entry, err := c.getConstraintEntry(constraint, lock)
 	if err != nil {
 		return err
@@ -454,12 +427,12 @@ func (c *client) validateConstraint(constraint *unstructured.Unstructured, lock 
 
 // ValidateConstraint returns an error if the constraint is not recognized or does not conform to
 // the registered CRD for that constraint.
-func (c *client) ValidateConstraint(ctx context.Context, constraint *unstructured.Unstructured) error {
+func (c *Client) ValidateConstraint(ctx context.Context, constraint *unstructured.Unstructured) error {
 	return c.validateConstraint(constraint, true)
 }
 
 // init initializes the OPA backend for the client
-func (c *client) init() error {
+func (c *Client) init() error {
 	for _, t := range c.targets {
 		hooks := fmt.Sprintf(`hooks["%s"]`, t.GetName())
 		templMap := map[string]string{"Target": t.GetName()}
@@ -508,7 +481,8 @@ func (c *client) init() error {
 	return nil
 }
 
-func (c *client) Reset(ctx context.Context) error {
+// Reset the state of OPA
+func (c *Client) Reset(ctx context.Context) error {
 	c.constraintsMux.Lock()
 	defer c.constraintsMux.Unlock()
 	for name := range c.targets {
@@ -542,7 +516,8 @@ func Tracing(enabled bool) QueryOpt {
 	}
 }
 
-func (c *client) Review(ctx context.Context, obj interface{}, opts ...QueryOpt) (*types.Responses, error) {
+// Review makes sure the provided object satisfies all stored constraints
+func (c *Client) Review(ctx context.Context, obj interface{}, opts ...QueryOpt) (*types.Responses, error) {
 	cfg := &queryCfg{}
 	for _, opt := range opts {
 		opt(cfg)
@@ -581,7 +556,8 @@ TargetLoop:
 	return responses, errMap
 }
 
-func (c *client) Audit(ctx context.Context, opts ...QueryOpt) (*types.Responses, error) {
+// Audit makes sure the cached state of the system satisfies all stored constraints
+func (c *Client) Audit(ctx context.Context, opts ...QueryOpt) (*types.Responses, error) {
 	cfg := &queryCfg{}
 	for _, opt := range opts {
 		opt(cfg)
@@ -611,6 +587,7 @@ TargetLoop:
 	return responses, errMap
 }
 
-func (c *client) Dump(ctx context.Context) (string, error) {
+// Dump dumps the state of OPA to aid in debugging
+func (c *Client) Dump(ctx context.Context) (string, error) {
 	return c.backend.driver.Dump(ctx)
 }

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/e2e_tests.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/e2e_tests.go
@@ -60,9 +60,9 @@ func newConstraint(kind, name string, params map[string]string) *unstructured.Un
 	return c
 }
 
-var tests = map[string]func(Client) error{
+var tests = map[string]func(*Client) error{
 
-	"Add Template": func(c Client) error {
+	"Add Template": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 violation[{"msg": "DENIED", "details": {}}] {
 	"always" == "always"
@@ -70,7 +70,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return errors.Wrap(err, "AddTemplate")
 	},
 
-	"Deny All": func(c Client) error {
+	"Deny All": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 violation[{"msg": "DENIED", "details": {}}] {
 	"always" == "always"
@@ -101,7 +101,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Deny All Audit x2": func(c Client) error {
+	"Deny All Audit x2": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 	violation[{"msg": "DENIED", "details": {}}] {
 		"always" == "always"
@@ -142,7 +142,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Deny All Audit": func(c Client) error {
+	"Deny All Audit": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 	violation[{"msg": "DENIED", "details": {}}] {
 		"always" == "always"
@@ -180,7 +180,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Autoreject All": func(c Client) error {
+	"Autoreject All": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 violation[{"msg": "DENIED", "details": {}}] {
 	"always" == "always"
@@ -245,7 +245,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Remove Data": func(c Client) error {
+	"Remove Data": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 	violation[{"msg": "DENIED", "details": {}}] {
 		"always" == "always"
@@ -309,7 +309,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Remove Constraint": func(c Client) error {
+	"Remove Constraint": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 	violation[{"msg": "DENIED", "details": {}}] {
 		"always" == "always"
@@ -358,7 +358,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Remove Template": func(c Client) error {
+	"Remove Template": func(c *Client) error {
 		tmpl := newConstraintTemplate("Foo", `package foo
 	violation[{"msg": "DENIED", "details": {}}] {
 		"always" == "always"
@@ -408,7 +408,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Tracing Off": func(c Client) error {
+	"Tracing Off": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 violation[{"msg": "DENIED", "details": {}}] {
 	"always" == "always"
@@ -438,7 +438,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Tracing On": func(c Client) error {
+	"Tracing On": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 violation[{"msg": "DENIED", "details": {}}] {
 	"always" == "always"
@@ -468,7 +468,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Audit Tracing Enabled": func(c Client) error {
+	"Audit Tracing Enabled": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 	violation[{"msg": "DENIED", "details": {}}] {
 		"always" == "always"
@@ -506,7 +506,7 @@ violation[{"msg": "DENIED", "details": {}}] {
 		return nil
 	},
 
-	"Audit Tracing Disabled": func(c Client) error {
+	"Audit Tracing Disabled": func(c *Client) error {
 		_, err := c.AddTemplate(ctx, newConstraintTemplate("Foo", `package foo
 	violation[{"msg": "DENIED", "details": {}}] {
 		"always" == "always"

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/probe_client.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/probe_client.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Probe struct {
-	client Client
+	client *Client
 }
 
 func NewProbe(d drivers.Driver) (*Probe, error) {


### PR DESCRIPTION
**DO NOT MERGE!!!**

wdyt about changing the type of the Client from an interface to a concrete type? Per https://github.com/golang/go/wiki/CodeReviewComments#interfaces, interfaces should typically be declared by the _user_ of a type, not the _implementer_ of the type.