### PR TITLE
Add verify release stage to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,11 @@ jobs:
             repo: open-policy-agent/gatekeeper
             branch: master # only push release image tag for tags on master
             tags: true
+      branches:
+        only:
+          # Pushes and PR to the master branch
+          - master
+
     - stage: "verify release"
       if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,22 +9,8 @@ services:
 
 jobs:
   include:
-    - stage: "build, unit test"
+    - stage: "build, unit test, dev deploy"
       script: make
-    - stage: "e2e"
-      before_script:
-      - make e2e-bootstrap
-      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
-      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
-      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
-      script:
-      - make deploy 
-      - make test-e2e
-      - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
-    - stage: "dev deploy"
-      if: repo = open-policy-agent/gatekeeper AND type != pull_request
-      script: 
-      - make manager
       deploy:
         - provider: script
           skip_cleanup: true
@@ -33,13 +19,19 @@ jobs:
             repo: open-policy-agent/gatekeeper
             branch: master # only push dev image tag for master commits
             tags: false
-    - stage: "release deploy, verify release"
+    - stage: "e2e"
+      script:
+      - make e2e-bootstrap
+      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
+      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
+      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
+      - make deploy 
+      - make test-e2e
+      - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
+    - stage: "release deploy"
       if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
       script: 
       - make manager
-      before_deploy:
-        - make e2e-bootstrap
-        - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
       deploy:
         - provider: script
           skip_cleanup: true
@@ -48,6 +40,14 @@ jobs:
             repo: open-policy-agent/gatekeeper
             branch: master # only push release image tag for tags on master
             tags: true
+    - stage: "verify release"
+      if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
+      script: 
+      - make manager
+      before_deploy:
+        - make e2e-bootstrap
+        - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+      deploy:
         - provider: script
           skip_cleanup: true
           script: make e2e-verify-release IMG=quay.io/open-policy-agent/gatekeeper:${TRAVIS_TAG} USE_LOCAL_IMG=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,48 +9,49 @@ services:
 
 jobs:
   include:
-    - stage: e2e
+    - stage: "build, unit test"
+      script: make
+    - stage: "e2e"
       before_script:
-      - KIND_VERSION=0.4.0
-      - KUSTOMIZE_VERSION=3.0.2
-      # Download and install kind
-      - curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output kind && chmod +x kind && sudo mv kind /usr/local/bin/
-      # Create kind cluster
-      - |
-        if [ $(kind get clusters) ]; then
-          export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-        else
-          kind create cluster
-        fi
-      # Get kubeconfig
-      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
-      # Build image and tag as gatekeeper-e2e:latest
-      - make docker-build REPOSITORY=gatekeeper-e2e
-      # Load Gatekeeper image into kind cluster
-      - kind load docker-image --name kind gatekeeper-e2e:latest
-      # Download and install kubectl
-      - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
-      # Download and install kustomize
-      - curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 --output kustomize && chmod +x kustomize && sudo mv kustomize /usr/local/bin/
+      - make e2e-bootstrap
+      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
+      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
+      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
       script:
-      - make deploy
+      - make deploy 
       - make test-e2e
       - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
-    - stage: "build, test, deploy"
-      script: make
+    - stage: "dev deploy"
+      if: repo = open-policy-agent/gatekeeper AND type != pull_request
+      script: 
+      - make manager
       deploy:
         - provider: script
           skip_cleanup: true
           script: make travis-dev-deploy
           on:
             repo: open-policy-agent/gatekeeper
-            branch: master
+            branch: master # only push dev image tag for master commits
             tags: false
+    - stage: "release deploy, verify release"
+      if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
+      script: 
+      - make manager
+      before_deploy:
+        - make e2e-bootstrap
+        - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+      deploy:
         - provider: script
           skip_cleanup: true
-          script: make travis-dev-release
+          script: make travis-release-deploy IMG=quay.io/open-policy-agent/gatekeeper:${TRAVIS_TAG} VERSION=${TRAVIS_TAG}
           on:
             repo: open-policy-agent/gatekeeper
-            branch: master
+            branch: master # only push release image tag for tags on master
             tags: true
-
+        - provider: script
+          skip_cleanup: true
+          script: make e2e-verify-release IMG=quay.io/open-policy-agent/gatekeeper:${TRAVIS_TAG} USE_LOCAL_IMG=false
+          on:
+            repo: open-policy-agent/gatekeeper
+            branch: master # only run verify e2e on the released image tag for tags on master
+            tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ services:
 
 jobs:
   include:
-    - stage: "build, unit test, e2e, dev deploy"
+    - stage: "build, unit test, e2e, dev deploy on master, release deploy"
       script: 
       - make
-      # - make e2e-bootstrap
-      # - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
-      # - make e2e-build-load-image IMG=gatekeeper-e2e:latest
-      # - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
-      # - make deploy 
-      # - make test-e2e
-      # - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
+      - make e2e-bootstrap
+      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
+      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
+      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
+      - make deploy 
+      - make test-e2e
+      - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
       deploy:
         - provider: script
           skip_cleanup: true
@@ -27,22 +27,12 @@ jobs:
             repo: open-policy-agent/gatekeeper
             branch: master # only push dev image tag for master commits
             tags: false
-    - stage: "release deploy"
-      script: 
-      - make manager
-      deploy:
         - provider: script
           skip_cleanup: true
           script: make travis-release-deploy IMG=quay.io/open-policy-agent/gatekeeper:${TRAVIS_TAG} VERSION=${TRAVIS_TAG}
           on:
             repo: open-policy-agent/gatekeeper
-            branch: master # only push release image tag for tags on master
-            tags: true
-      branches:
-        only:
-          # Pushes and PR to the master branch
-          - master
-
+            tags: true # only push release image tag for tags
     - stage: "verify release"
       if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
       script:
@@ -54,5 +44,4 @@ jobs:
           script: make e2e-verify-release IMG=quay.io/open-policy-agent/gatekeeper:${TRAVIS_TAG} USE_LOCAL_IMG=false
           on:
             repo: open-policy-agent/gatekeeper
-            branch: e2e # only run verify e2e on the released image tag for tags on master
-            tags: true
+            tags: true # only run verify e2e on the released image tag for tags

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ services:
 
 jobs:
   include:
-    - stage: "build, unit test, e2e, dev deploy, release deploy"
+    - stage: "build, unit test, e2e, dev deploy"
       script: 
       - make
       # - make e2e-bootstrap
@@ -27,6 +27,10 @@ jobs:
             repo: open-policy-agent/gatekeeper
             branch: master # only push dev image tag for master commits
             tags: false
+    - stage: "release deploy"
+      script: 
+      - make manager
+      deploy:
         - provider: script
           skip_cleanup: true
           script: make travis-release-deploy IMG=quay.io/open-policy-agent/gatekeeper:${TRAVIS_TAG} VERSION=${TRAVIS_TAG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,16 @@ services:
 
 jobs:
   include:
-    - stage: "build, unit test, dev deploy"
-      script: make
+    - stage: "build, unit test, e2e, dev deploy, release deploy"
+      script: 
+      - make
+      - make e2e-bootstrap
+      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
+      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
+      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
+      - make deploy 
+      - make test-e2e
+      - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
       deploy:
         - provider: script
           skip_cleanup: true
@@ -19,20 +27,6 @@ jobs:
             repo: open-policy-agent/gatekeeper
             branch: master # only push dev image tag for master commits
             tags: false
-    - stage: "e2e"
-      script:
-      - make e2e-bootstrap
-      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
-      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
-      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
-      - make deploy 
-      - make test-e2e
-      - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
-    - stage: "release deploy"
-      if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
-      script: 
-      - make manager
-      deploy:
         - provider: script
           skip_cleanup: true
           script: make travis-release-deploy IMG=quay.io/open-policy-agent/gatekeeper:${TRAVIS_TAG} VERSION=${TRAVIS_TAG}
@@ -42,8 +36,6 @@ jobs:
             tags: true
     - stage: "verify release"
       if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
-      script: 
-      - make manager
       before_deploy:
         - make e2e-bootstrap
         - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
@@ -53,5 +45,5 @@ jobs:
           script: make e2e-verify-release IMG=quay.io/open-policy-agent/gatekeeper:${TRAVIS_TAG} USE_LOCAL_IMG=false
           on:
             repo: open-policy-agent/gatekeeper
-            branch: master # only run verify e2e on the released image tag for tags on master
+            branch: e2e # only run verify e2e on the released image tag for tags on master
             tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ jobs:
     - stage: "build, unit test, e2e, dev deploy, release deploy"
       script: 
       - make
-      - make e2e-bootstrap
-      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
-      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
-      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
-      - make deploy 
-      - make test-e2e
-      - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
+      # - make e2e-bootstrap
+      # - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
+      # - make e2e-build-load-image IMG=gatekeeper-e2e:latest
+      # - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
+      # - make deploy 
+      # - make test-e2e
+      # - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
       deploy:
         - provider: script
           skip_cleanup: true
@@ -36,9 +36,9 @@ jobs:
             tags: true
     - stage: "verify release"
       if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
-      before_deploy:
-        - make e2e-bootstrap
-        - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+      script:
+      - make e2e-bootstrap
+      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
       deploy:
         - provider: script
           skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ IMG := $(REPOSITORY):latest
 
 VERSION := v3.0.4-beta.1
 
+USE_LOCAL_IMG ?= false
+KIND_VERSION=0.4.0
+KUSTOMIZE_VERSION=3.0.2
+
 BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./build/get-build-timestamp.sh)
 BUILD_HOSTNAME := $(shell ./build/get-build-hostname.sh)
@@ -47,6 +51,24 @@ test:
 test-e2e:
 	bats -t test/bats/test.bats
 
+e2e-bootstrap:
+	# Download and install kind
+	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output kind && chmod +x kind && sudo mv kind /usr/local/bin/
+	# Download and install kubectl
+	curl -LO https://storage.googleapis.com/kubernetes-release/release/$$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv kubectl /usr/local/bin/
+	# Download and install kustomize
+	curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VERSION}/kustomize_${KUSTOMIZE_VERSION}_linux_amd64 --output kustomize && chmod +x kustomize && sudo mv kustomize /usr/local/bin/
+	# Check for existing kind cluster
+	if [ $$(kind get clusters) ]; then kind delete cluster; fi
+	# Create a new kind cluster
+	kind create cluster
+
+e2e-build-load-image: docker-build
+	kind load docker-image --name kind ${IMG}
+
+e2e-verify-release: patch-image deploy test-e2e
+	echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system gatekeeper-controller-manager-0 manager
+
 # Build manager binary
 manager: generate fmt vet
 	go build -o bin/manager  -ldflags $(LDFLAGS) github.com/open-policy-agent/gatekeeper/cmd/manager
@@ -65,6 +87,7 @@ install: manifests
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
+	kubectl get node
 	touch -a ./overlays/dev/manager_image_patch.yaml
 	kubectl apply -f config/crds
 	kubectl apply -f vendor/github.com/open-policy-agent/frameworks/constraint/deploy
@@ -113,14 +136,14 @@ docker-push-release:  docker-tag-release
 # Build the docker image
 docker-build:
 	docker build --pull . -t ${IMG}
+
+# Update manager_image_patch.yaml with image tag
+patch-image:
 	@echo "updating kustomize image patch file for manager resource"
-
 	@test -s ./overlays/dev/manager_image_patch.yaml || bash -c 'echo -e ${MANAGER_IMAGE_PATCH} > ./overlays/dev/manager_image_patch.yaml'
-
-ifeq ($(TRAVIS),true)
+ifeq ($(USE_LOCAL_IMG),true)
 	@sed -i '/^        name: manager/a \ \ \ \ \ \ \ \ imagePullPolicy: IfNotPresent' ./overlays/dev/manager_image_patch.yaml
 endif
-
 	@sed -i'' -e 's@image: .*@image: '"${IMG}"'@' ./overlays/dev/manager_image_patch.yaml
 
 docker-build-ci:
@@ -132,13 +155,15 @@ docker-push:
 
 release:
 	@sed -i -e 's/^VERSION := .*/VERSION := ${NEWVERSION}/' ./Makefile
+
+release-manifest:
 	@sed -i'' -e 's@image: $(REPOSITORY):.*@image: $(REPOSITORY):'"$(NEWVERSION)"'@' ./config/manager/manager.yaml ./deploy/gatekeeper.yaml
 
 # Travis Dev Deployment
 travis-dev-deploy: docker-login docker-build-ci docker-push-dev
 
 # Travis Release
-travis-dev-release: docker-login docker-build-ci docker-push-release
+travis-release-deploy: docker-login docker-build-ci docker-push-release
 
 # Delete gatekeeper from a cluster. Note this is not a complete uninstall, just a dev convenience
 uninstall:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Currently the most reliable way of installing Gatekeeper is to build and install
    * cd to the repository directory
    * run `make docker-build REPOSITORY=<YOUR DESIRED DESTINATION DOCKER IMAGE>`
    * run `make docker-push-release REPOSITORY=<YOUR DESIRED DESTINATION DOCKER IMAGE>`
+   * run `make patch-image REPOSITORY=<YOUR DESIRED DESTINATION DOCKER IMAGE>`
    * make sure your kubectl context is set to the desired installation cluster
    * run `make deploy`
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,26 +34,27 @@ Publishing involves creating a release tag and creating a new *Release* on GitHu
 	git diff
 	```
 
-## Building
+## Building and releasing
 
-1. Commit the changes and push to remote repository.
+1. Commit the changes and push to remote repository to create a pull request.
 
 	```
 	git commit -a -s -m "Prepare <version> release"
     git commit --amend --signoff
-	git push origin master
+	git push <FORK> <FEATURE-BRANCH>
 	```
 
-1. Tag repository with release version and push tags to remote repository.
+1. Once the PR is merged to master, tag master with release version and push tags to remote repository.
 
 	```
 	git tag -a <NEWVERSION> -m '<NEWVERSION>'
 	git push origin <NEWVERSION>
 	```
 
-1. Pushing the release tag will trigger the Travis-CI pipeline to run `make travis-dev-release`. 
+1. Pushing the release tag will trigger the Travis-CI pipeline to run `make travis-release-deploy`. 
 This will build the `quay.io/open-policy-agent/gatekeeper` image automatically, Then publish the new release image tag and the `latest` image tag 
-to the `quay.io/open-policy-agent/gatekeeper` repository.
+to the `quay.io/open-policy-agent/gatekeeper` repository. 
+Upon completion of `make travis-release-deploy`, the `make e2e-verify-release` deploy step will run e2e tests to verify the new released tag.
 
 ## Publishing
 
@@ -63,3 +64,23 @@ to the `quay.io/open-policy-agent/gatekeeper` repository.
 	- Release title: <NEWVERSION>
     - Update release message with Features, Bug Fixes, Breaking Changes, etc.
 	- Click `Publish release` will automatically include the binaries from the tag.
+
+## Update deployment versioning
+
+1. Execute the release-manifest target to update deployment yamls. Give the semantic version of the release:
+
+	```
+	make release-manifest NEWVERSION=v3.0.4-beta.x
+	```
+1. Preview the changes:
+
+	```
+	git diff
+	```
+1. Commit the changes and push to remote repository to create a pull request.
+
+	```
+	git commit -a -s -m "Bump deployment <version>"
+    git commit --amend --signoff
+	git push <FORK> <FEATURE-BRANCH>
+	```


### PR DESCRIPTION
- Update RELEASE doc
- Add e2e after a new tag is released

A sample build when we push a tag: https://travis-ci.org/open-policy-agent/gatekeeper/builds/583049644