### PR TITLE
Image package update and run as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,15 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/open
 
 # Copy the controller-manager into a thin image
 FROM ubuntu:latest
-WORKDIR /root/
+
+# Update image and add a non-root user
+RUN apt update && apt upgrade -y \
+    && useradd -rm -u 1000 -U manager
+
+WORKDIR /home/manager/
 COPY --from=builder /go/src/github.com/open-policy-agent/gatekeeper/manager .
+RUN chown manager:manager manager
+
+USER 1000
+
 ENTRYPOINT ["./manager"]

--- a/Dockerfile_ci
+++ b/Dockerfile_ci
@@ -1,4 +1,12 @@
 FROM ubuntu:latest
-WORKDIR /root/
+
+RUN apt update && apt upgrade -y \
+    && useradd -rm -u 1000 -U manager
+
+WORKDIR /home/manager/
 COPY bin/manager .
+RUN chown manager:manager manager
+
+USER 1000
+
 ENTRYPOINT ["./manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -20,6 +20,7 @@ spec:
     controller-tools.k8s.io: "1.0"
   ports:
   - port: 443
+    targetPort: 8443
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -42,10 +43,9 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      - command:
-        - /root/manager
-        args:
+      - args:
           - "--auditInterval=30"
+          - "--port=8443"
           # - "--alsologtostderr"
           # - "--stderrthreshold=INFO"
           # - "-v=100"
@@ -72,7 +72,7 @@ spec:
             cpu: 100m
             memory: 256Mi
         ports:
-        - containerPort: 443
+        - containerPort: 8443
           name: webhook-server
           protocol: TCP
         volumeMounts:

--- a/deploy/gatekeeper.yaml
+++ b/deploy/gatekeeper.yaml
@@ -295,6 +295,7 @@ metadata:
 spec:
   ports:
   - port: 443
+    targetPort: 8443
   selector:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
@@ -322,8 +323,7 @@ spec:
       containers:
       - args:
         - --auditInterval=30
-        command:
-        - /root/manager
+        - --port=8443
         env:
         - name: POD_NAMESPACE
           valueFrom:
@@ -340,7 +340,7 @@ spec:
         imagePullPolicy: Always
         name: manager
         ports:
-        - containerPort: 443
+        - containerPort: 8443
           name: webhook-server
           protocol: TCP
         resources:


### PR DESCRIPTION
**Changes:**
- Update base packages in the docker image build for vulnerability patches
- Configure image to run with a non-root UID so the deployment no longer needs to run privileged
- Update deployment files with listening port override to 8443