### PR TITLE
Update kind to v0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,22 @@ sudo: required
 language: go
 go_import_path: github.com/open-policy-agent/gatekeeper
 go:
-- "1.13.x"
+  - "1.13.x"
 
 services:
-- docker
+  - docker
 
 jobs:
   include:
     - stage: "build, unit test, e2e, dev deploy on master, release deploy"
-      script: 
-      - make
-      - make e2e-bootstrap
-      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
-      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
-      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
-      - make deploy 
-      - make test-e2e
-      - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system -l control-plane=controller-manager
+      script:
+        - make
+        - make e2e-bootstrap
+        - make e2e-build-load-image IMG=gatekeeper-e2e:latest
+        - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
+        - make deploy
+        - make test-e2e
+        - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system -l control-plane=controller-manager
       deploy:
         - provider: script
           skip_cleanup: true
@@ -36,8 +35,8 @@ jobs:
     - stage: "verify release"
       if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
       script:
-      - make e2e-bootstrap
-      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+        - make e2e-bootstrap
+        - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
       deploy:
         - provider: script
           skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ e2e-bootstrap:
 	# Check for existing kind cluster
 	if [ $$(kind get clusters) ]; then kind delete cluster; fi
 	# Create a new kind cluster
-	kind create cluster
+	TERM=dumb kind create cluster
 
 e2e-build-load-image: docker-build
 	kind load docker-image --name kind ${IMG}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMG := $(REPOSITORY):latest
 VERSION := v3.0.4-beta.2
 
 USE_LOCAL_IMG ?= false
-KIND_VERSION=0.4.0
+KIND_VERSION=0.6.0
 KUSTOMIZE_VERSION=3.0.2
 
 BUILD_COMMIT := $(shell ./build/get-build-commit.sh)


### PR DESCRIPTION
- Updates k8s node image to v.1.16.3
- removed deprecated `kind get kubeconfig-path`