### PR TITLE
Fixed a broken link for the Rego

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,22 @@ sudo: required
 language: go
 go_import_path: github.com/open-policy-agent/gatekeeper
 go:
-- "1.13.x"
+  - "1.13.x"
 
 services:
-- docker
+  - docker
 
 jobs:
   include:
     - stage: "build, unit test, e2e, dev deploy on master, release deploy"
-      script: 
-      - make
-      - make e2e-bootstrap
-      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")" 
-      - make e2e-build-load-image IMG=gatekeeper-e2e:latest
-      - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
-      - make deploy 
-      - make test-e2e
-      - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system -l control-plane=controller-manager
+      script:
+        - make
+        - make e2e-bootstrap
+        - make e2e-build-load-image IMG=gatekeeper-e2e:latest
+        - make patch-image IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
+        - make deploy
+        - make test-e2e
+        - echo -e '\n\n======= manager logs =======\n\n' && kubectl logs -n gatekeeper-system -l control-plane=controller-manager
       deploy:
         - provider: script
           skip_cleanup: true
@@ -36,8 +35,8 @@ jobs:
     - stage: "verify release"
       if: repo = open-policy-agent/gatekeeper AND type != pull_request AND tag IS present
       script:
-      - make e2e-bootstrap
-      - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
+        - make e2e-bootstrap
+        - export KUBECONFIG="$(kind get kubeconfig-path --name="kind")"
       deploy:
         - provider: script
           skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ IMG := $(REPOSITORY):latest
 VERSION := v3.0.4-beta.2
 
 USE_LOCAL_IMG ?= false
-KIND_VERSION=0.4.0
+KIND_VERSION=0.6.0
 KUSTOMIZE_VERSION=3.0.2
 
 BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
@@ -73,7 +73,7 @@ e2e-bootstrap:
 	# Check for existing kind cluster
 	if [ $$(kind get clusters) ]; then kind delete cluster; fi
 	# Create a new kind cluster
-	kind create cluster
+	TERM=dumb kind create cluster
 
 e2e-build-load-image: docker-build
 	kind load docker-image --name kind ${IMG}

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Gatekeeper uses the [OPA Constraint Framework](https://github.com/open-policy-ag
 
 ### Constraint Templates
 
-Before you can define a constraint, you must first define a `ConstraintTemplate`, which describes both the [Rego](https://www.openpolicyagent.org/docs/v0.10.7/how-do-i-write-policies/) that enforces the constraint and the schema of the constraint. The schema of the constraint allows an admin to fine-tune the behavior of a constraint, much like arguments to a function.
+Before you can define a constraint, you must first define a `ConstraintTemplate`, which describes both the [Rego](https://www.openpolicyagent.org/docs/v0.15.1/policy-language/) that enforces the constraint and the schema of the constraint. The schema of the constraint allows an admin to fine-tune the behavior of a constraint, much like arguments to a function.
 
 Here is an example constraint template that requires all labels described by the constraint to be present:
 


### PR DESCRIPTION
The link had been directing to a 404 Not Found page. I believe this started whenever v0.10.x was aged out.  I've replaced the broken link (https://www.openpolicyagent.org/docs/v0.10.7/how-do-i-write-policies/) with what appears to be what the link was headed to (https://www.openpolicyagent.org/docs/v0.15.1/policy-language/). I'm using the most recent version, but /latest/ also works.