### PR TITLE
Add index of design documents

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,30 @@
+# Design Docs
+Generally, design docs are on Google docs:
+
+## Conventions
+* [Versioning of Constraint Templates](https://docs.google.com/document/d/1vB_2wm60WCVLXoegMrupqwqKAuW6gbwEIxg3vBQj6cs/edit)
+
+## In Development
+* [Metrics Design Issue](https://github.com/open-policy-agent/gatekeeper/issues/157#issuecomment-553015292)
+
+## Proposed
+* [Logging Design Doc](https://docs.google.com/document/d/1ap7AKOupNcR_42s8mkSh5FV9eteXTd4VCqelKst73VY/edit)
+* [Namespace-Scoped Constraints](https://docs.google.com/document/d/1-pY7B5C6R0fjUbDu8izlcP7MSUDVDHv5XK16BFyTGRc/edit#heading=h.w8j68o8vjdts)
+* [Mutation Revised Design Doc](https://docs.google.com/document/d/1G7WgZKx1Y3VOTUjrqn7DjDaZgSKCIZowILm_I6psrw0/edit#heading=h.mtvdjag5uj9)
+   * [Mutation Initial Design Doc](https://docs.google.com/document/d/1qTHwqoUX8AL2jodyWKB_2szrGDwhi14Ra_LlQ-ogtck/edit#heading=h.iu1ppjy7g7j)
+
+## Implemented
+* [V3 Accepted Design](https://docs.google.com/document/d/1yC4wgpVoJj6ngYnSTtO-HeaIBl05gla562sD7qKPy3M/edit#heading=h.z0bjqzl81dpe)
+   * [Initial v3 Design Proposal](https://docs.google.com/document/d/1S4C5BHZDoAqw5m5aVWrr8b8fe4H3I2jymmKitoTia2Y/edit#heading=h.p63jc1w6w88d)
+   * [Initial v3 Design Proposal -- Detailed Design](https://docs.google.com/document/d/1oZR9b52z_EQkhit9A-ApFvz3tqsn9ckzvPyxKw1pBTo/edit)
+* [Architecture Diagram](https://docs.google.com/document/d/1It-Mpz36ygqrElmh2hZ3DvDIqKYyKUZN6V4d7UTlEG8/edit#heading=h.rzuko1admjwd)
+* [Audit Design Doc](https://docs.google.com/document/d/1EnVOOaLZ_fWxo02ZmgnvTE2PtTRbyyhKjioPe-_In28/edit)
+* [Dry-Run Design Doc](https://docs.google.com/document/d/17nJDJxjY_XHV8zrMNdOi2hFgfm6XKGJi0QyznsbhQ70/edit#heading=h.z0bjqzl81dpe)
+* [Constraint Framework Client Interface](https://docs.google.com/document/d/1NDOgu8F_yQqrxRRVTDiCXGXMsajA3Jtp-lwGrZsDFcI/edit#)
+
+## Roadmap (in development)
+* [GA Development Path](https://docs.google.com/document/d/1Lolr_jUkVlGSyk4iGhajx1LXWsWRXhLeu3L7s3lLDGY/edit#heading=h.9aae3wnhx5k3)
+* [Post-MVP Features Doc](https://docs.google.com/document/d/1t61-fcFdbNA0o1kTQd-oS2rkaUsouN4Kg6ImW8agfbk/edit#heading=h.57n2tr53h5l)
+
+## Roadmap (complete)
+* [MVP for Alpha](https://docs.google.com/document/d/1EPb3zg-hknAK7WqYh96XIXCEXG9mQqr_Cqn8VuEGoLI/edit#heading=h.vu8n6esi249)


### PR DESCRIPTION
I thought it'd be a good idea to start indexing design documents in
a central location.

I've included all the design docs I'm aware of/could find in my
history. Apologies if I've missed any.

Signed-off-by: Max Smythe <smythe@google.com>