### PR TITLE
kustomize the template library

### DIFF
--- a/library/general/allowedrepos/kustomization.yaml
+++ b/library/general/allowedrepos/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/containerlimits/kustomization.yaml
+++ b/library/general/containerlimits/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/httpsonly/kustomization.yaml
+++ b/library/general/httpsonly/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/kustomization.yaml
+++ b/library/general/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - allowedrepos
+  - containerlimits
+  - httpsonly
+  - requiredlabels
+  - uniqueingresshost
+  - uniqueserviceselector

--- a/library/general/requiredlabels/kustomization.yaml
+++ b/library/general/requiredlabels/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/uniqueingresshost/kustomization.yaml
+++ b/library/general/uniqueingresshost/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/general/uniqueserviceselector/kustomization.yaml
+++ b/library/general/uniqueserviceselector/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/kustomization.yaml
+++ b/library/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - general
+  - pod-security-policy

--- a/library/pod-security-policy/allow-privilege-escalation/kustomization.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/apparmor/kustomization.yaml
+++ b/library/pod-security-policy/apparmor/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/flexvolume-drivers/kustomization.yaml
+++ b/library/pod-security-policy/flexvolume-drivers/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/forbidden-sysctls/kustomization.yaml
+++ b/library/pod-security-policy/forbidden-sysctls/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/fsgroup/kustomization.yaml
+++ b/library/pod-security-policy/fsgroup/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/host-filesystem/kustomization.yaml
+++ b/library/pod-security-policy/host-filesystem/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/host-namespaces/kustomization.yaml
+++ b/library/pod-security-policy/host-namespaces/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/host-network-ports/kustomization.yaml
+++ b/library/pod-security-policy/host-network-ports/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/kustomization.yaml
+++ b/library/pod-security-policy/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+  - allow-privilege-escalation
+  - apparmor
+  - flexvolume-drivers
+  - forbidden-sysctls
+  - fsgroup
+  - host-filesystem
+  - host-namespaces
+  - host-network-ports
+  - privileged-containers
+  - proc-mount
+  - read-only-root-filesystem
+  - seccomp
+  - selinux
+  - users
+  - volumes

--- a/library/pod-security-policy/privileged-containers/kustomization.yaml
+++ b/library/pod-security-policy/privileged-containers/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/proc-mount/kustomization.yaml
+++ b/library/pod-security-policy/proc-mount/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/read-only-root-filesystem/kustomization.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/seccomp/kustomization.yaml
+++ b/library/pod-security-policy/seccomp/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/selinux/kustomization.yaml
+++ b/library/pod-security-policy/selinux/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/users/kustomization.yaml
+++ b/library/pod-security-policy/users/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml

--- a/library/pod-security-policy/volumes/kustomization.yaml
+++ b/library/pod-security-policy/volumes/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - template.yaml


### PR DESCRIPTION
Add `kustomization.yaml` files for the entire library, the general/pod-security-policy libraries and the individual templates. This allows you to reference the library as a whole, only the templates
you're interested in or pull in templates from different tags.