### PR TITLE
library: remove all spec.crd.spec.names except kind

### DIFF
--- a/library/general/allowedrepos/template.yaml
+++ b/library/general/allowedrepos/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sAllowedRepos
-        listKind: K8sAllowedReposList
-        plural: k8sallowedrepos
-        singular: k8sallowedrepos
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/general/containerlimits/template.yaml
+++ b/library/general/containerlimits/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sContainerLimits
-        listKind: K8sContainerLimitsList
-        plural: k8scontainerlimits
-        singular: k8scontainerlimits
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/general/httpsonly/template.yaml
+++ b/library/general/httpsonly/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sHttpsOnly
-        listKind: K8sHttpsOnlyList
-        plural: k8shttpsonly
-        singular: k8shttpsonly
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/library/general/requiredlabels/template.yaml
+++ b/library/general/requiredlabels/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sRequiredLabels
-        listKind: K8sRequiredLabelsList
-        plural: k8srequiredlabels
-        singular: k8srequiredlabels
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/general/uniqueingresshost/template.yaml
+++ b/library/general/uniqueingresshost/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sUniqueIngressHost
-        listKind: K8sUniqueIngressHostList
-        plural: k8suniqueingresshost
-        singular: k8suniqueingresshost
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/library/general/uniqueserviceselector/template.yaml
+++ b/library/general/uniqueserviceselector/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sUniqueServiceSelector
-        listKind: K8sUniqueServiceSelectorList
-        plural: k8suniqueserviceselector
-        singular: k8suniqueserviceselector
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/library/pod-security-policy/allow-privilege-escalation/template.yaml
+++ b/library/pod-security-policy/allow-privilege-escalation/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPAllowPrivilegeEscalationContainer
-        listKind: K8sPSPAllowPrivilegeEscalationContainerList
-        plural: k8spspallowprivilegeescalationcontainer
-        singular: k8spspallowprivilegeescalationcontainer
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/library/pod-security-policy/apparmor/template.yaml
+++ b/library/pod-security-policy/apparmor/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPAppArmor
-        listKind: K8sPSPAppArmorList
-        plural: k8spspapparmor
-        singular: k8spspapparmor
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/flexvolume-drivers/template.yaml
+++ b/library/pod-security-policy/flexvolume-drivers/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPFlexVolumes
-        listKind: K8sPSPFlexVolumesList
-        plural: k8spspflexvolumes
-        singular: k8spspflexvolumes
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/forbidden-sysctls/template.yaml
+++ b/library/pod-security-policy/forbidden-sysctls/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPForbiddenSysctls
-        listKind: K8sPSPForbiddenSysctlsList
-        plural: k8spspforbiddensysctls
-        singular: k8spspforbiddensysctls
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/fsgroup/template.yaml
+++ b/library/pod-security-policy/fsgroup/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPFSGroup
-        listKind: K8sPSPFSGroupList
-        plural: k8spspfsgroup
-        singular: k8spspfsgroup
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/host-filesystem/template.yaml
+++ b/library/pod-security-policy/host-filesystem/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPHostFilesystem
-        listKind: K8sPSPHostFilesystemList
-        plural: k8spsphostfilesystem
-        singular: k8spsphostfilesystem
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/host-namespaces/template.yaml
+++ b/library/pod-security-policy/host-namespaces/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPHostNamespace
-        listKind: K8sPSPHostNamespaceList
-        plural: k8spsphostnamespace
-        singular: k8spsphostnamespace
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/library/pod-security-policy/host-network-ports/template.yaml
+++ b/library/pod-security-policy/host-network-ports/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPHostNetworkingPorts
-        listKind: K8sPSPHostNetworkingPortsList
-        plural: k8spsphostnetworkingports
-        singular: k8spsphostnetworkingports
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/privileged-containers/template.yaml
+++ b/library/pod-security-policy/privileged-containers/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPPrivilegedContainer
-        listKind: K8sPSPPrivilegedContainerList
-        plural: k8spspprivilegedcontainer
-        singular: k8spspprivilegedcontainer
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/library/pod-security-policy/proc-mount/template.yaml
+++ b/library/pod-security-policy/proc-mount/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPProcMount
-        listKind: K8sPSPProcMountList
-        plural: k8spspprocmount
-        singular: k8spspprocmount
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/read-only-root-filesystem/template.yaml
+++ b/library/pod-security-policy/read-only-root-filesystem/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPReadOnlyRootFilesystem
-        listKind: K8sPSPReadOnlyRootFilesystemContainerList
-        plural: k8spspreadonlyfilesystem
-        singular: k8spspreadonlyfilesystem
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPSeccomp
-        listKind: K8sPSPSeccompList
-        plural: k8spspseccomp
-        singular: k8spspseccomp
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/selinux/template.yaml
+++ b/library/pod-security-policy/selinux/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPSELinux
-        listKind: K8sPSPSELinuxList
-        plural: k8spspselinux
-        singular: k8spspselinux
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:

--- a/library/pod-security-policy/users/template.yaml
+++ b/library/pod-security-policy/users/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPAllowedUsers
-        listKind: K8sPSPAllowedUsersList
-        plural: k8spspallowedusers
-        singular: k8spspallowedusers
       validation:
         openAPIV3Schema:
           properties:

--- a/library/pod-security-policy/volumes/template.yaml
+++ b/library/pod-security-policy/volumes/template.yaml
@@ -7,9 +7,6 @@ spec:
     spec:
       names:
         kind: K8sPSPVolumeTypes
-        listKind: K8sPSPVolumeTypesList
-        plural: k8spspvolumetypes
-        singular: k8spspvolumetypes
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:


### PR DESCRIPTION
From https://github.com/open-policy-agent/gatekeeper/issues/170, I understand that only name is required.

As it stands, I'm getting a new generation for each template every time I run `kubectl apply` (which I run regularly as part of my CD):
```
-  generation: 250
+  generation: 251
   name: k8srequiredlabels
   resourceVersion: "102333523"
   selfLink: /apis/templates.gatekeeper.sh/v1beta1/constrainttemplates/k8srequiredlabels
@@ -17,6 +17,9 @@
     spec:
       names:
         kind: K8sRequiredLabels
+        listKind: K8sRequiredLabelsList
+        plural: k8srequiredlabels
+        singular: k8srequiredlabels
       validation:
         openAPIV3Schema:
           properties:
```