### PR TITLE
Move resources field to values.yaml

### DIFF
--- a/chart/gatekeeper-operator/generate_helm_template.sh
+++ b/chart/gatekeeper-operator/generate_helm_template.sh
@@ -3,20 +3,14 @@ scriptdir="$(dirname "$0")"
 cd "$scriptdir"
 cp ./../../deploy/gatekeeper.yaml ${PWD}/helm-modifications/_temp.yaml
 kustomize build helm-modifications -o templates/gatekeeper.yaml
-sed -i -E "s/HELMSUBST_DEPLOYMENT_RESOURCES/\
-\n{{ toYaml .Values.resources | indent 12 }}\
-\n    {{- with .Values.nodeSelector }}\
-\n      nodeSelector:\
-\n{{ toYaml . | indent 8 }}\
-\n    {{- end }}\
-\n    {{- with .Values.affinity }}\
+sed -i -E "s/HELMSUBST_DEPLOYMENT_CONTAINER_RESOURCES/\
+\n{{ toYaml .Values.resources | indent 10 }}/" templates/gatekeeper.yaml
+sed -i -E "s/HELMSUBST_DEPLOYMENT_POD_SCHEDULING/\
+\n{{ toYaml .Values.nodeSelector | indent 8 }}\
 \n      affinity:\
-\n{{ toYaml . | indent 8 }}\
-\n    {{- end }}\
-\n    {{- with .Values.tolerations }}\
+\n{{ toYaml .Values.affinity | indent 8 }}\
 \n      tolerations:\
-\n{{ toYaml . | indent 8 }}\
-\n    {{- end }}/" templates/gatekeeper.yaml
-sed -i "s/HELMSUBST_VALUES_REPLICAS_PLACEHOLDER/{{ .Values.replicas }}/g" templates/gatekeeper.yaml
+\n{{ toYaml .Values.tolerations | indent 8 }}/" templates/gatekeeper.yaml
+sed -i "s/HELMSUBST_DEPLOYMENT_REPLICAS/{{ .Values.replicas }}/g" templates/gatekeeper.yaml
 rm ./helm-modifications/_temp.yaml
 echo "Helm template created under 'chart/gatekeeper-operator/templates'"

--- a/chart/gatekeeper-operator/helm-modifications/helm-modifications.yaml
+++ b/chart/gatekeeper-operator/helm-modifications/helm-modifications.yaml
@@ -39,20 +39,21 @@ metadata:
   name: gatekeeper-controller-manager
   namespace: gatekeeper-system
 spec:
-  replicas: HELMSUBST_VALUES_REPLICAS_PLACEHOLDER
+  replicas: HELMSUBST_DEPLOYMENT_REPLICAS
   selector:
     matchLabels:
       app: gatekeeper-operator
       release: RELEASE_NAME
-  resources: HELMSUBST_DEPLOYMENT_RESOURCES
   template:
     spec:
       containers:
-      -  name: manager
-         args:
-         - --auditInterval={{ .Values.auditInterval }}
-         - --port=8443
-         - --logtostderr
-         - --constraintViolationsLimit={{ .Values.constraintViolationsLimit }}
-         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
-         image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
+        - name: manager
+          args:
+            - --auditInterval={{ .Values.auditInterval }}
+            - --port=8443
+            - --logtostderr
+            - --constraintViolationsLimit={{ .Values.constraintViolationsLimit }}
+          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.release }}"
+          resources: HELMSUBST_DEPLOYMENT_CONTAINER_RESOURCES
+      nodeSelector: HELMSUBST_DEPLOYMENT_POD_SCHEDULING

--- a/chart/gatekeeper-operator/templates/gatekeeper.yaml
+++ b/chart/gatekeeper-operator/templates/gatekeeper.yaml
@@ -13,7 +13,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.2
+    controller-gen.kubebuilder.io/version: v0.2.4
     helm.sh/hook: crd-install
     helm.sh/hook-delete-policy: before-hook-creation
   creationTimestamp: null
@@ -430,20 +430,6 @@ metadata:
   namespace: gatekeeper-system
 spec:
   replicas: {{ .Values.replicas }}
-  resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
   selector:
     matchLabels:
       app: '{{ template "gatekeeper-operator.name" . }}'
@@ -489,12 +475,7 @@ spec:
           name: metrics
           protocol: TCP
         resources:
-          limits:
-            cpu: 1000m
-            memory: 512Mi
-          requests:
-            cpu: 100m
-            memory: 256Mi
+{{ toYaml .Values.resources | indent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           runAsGroup: 999
@@ -504,6 +485,12 @@ spec:
         - mountPath: /certs
           name: cert
           readOnly: true
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       terminationGracePeriodSeconds: 60
       volumes:
       - name: cert

--- a/chart/gatekeeper-operator/values.yaml
+++ b/chart/gatekeeper-operator/values.yaml
@@ -7,3 +7,10 @@ image:
   pullPolicy: IfNotPresent
 nodeSelector: {}
 tolerations: []
+resources:
+  limits:
+    cpu: 1000m
+    memory: 512Mi
+  requests:
+    cpu: 100m
+    memory: 256Mi


### PR DESCRIPTION
The resources were incorrectly applied to the deployment rather than the
containers. This moves the resources to the containers and allows users
to change the values from the values.yaml file.