### PR TITLE
say that the status is changed, not the contraint itself

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -290,7 +290,7 @@ func (am *Manager) writeAuditResults(ctx context.Context, resourceList *metav1.A
 
 func (ucloop *updateConstraintLoop) updateConstraintStatus(ctx context.Context, instance *unstructured.Unstructured, auditResults []auditResult, timestamp string, totalViolations int64) error {
 	constraintName := instance.GetName()
-	log.Info("updating constraint", "constraintName", constraintName)
+	log.Info("updating constraint status", "constraintName", constraintName)
 	// create constraint status violations
 	var statusViolations []interface{}
 	for _, ar := range auditResults {


### PR DESCRIPTION
I saw a ton of `"logger":"controller","msg":"updating constraint"` in our logs an was worried that something is constantly changing the constraints ... turns out it is just the status update, so say that it is only changing the status.