### PR TITLE
cleanup readme installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,14 +71,24 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/
 Currently the most reliable way of installing Gatekeeper is to build and install from HEAD:
 
    * Make sure [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#getting-started) and [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) are installed.
-   * Clone the Gatekeeper repo to your local system
-   * Make sure you have a container registry you can write to that is readable by the target cluster
-   * cd to the repository directory
-   * run `make docker-build REPOSITORY=<YOUR DESIRED DESTINATION DOCKER IMAGE>`
-   * run `make docker-push-release REPOSITORY=<YOUR DESIRED DESTINATION DOCKER IMAGE>`
-   * run `make patch-image REPOSITORY=<YOUR DESIRED DESTINATION DOCKER IMAGE>`
-   * make sure your kubectl context is set to the desired installation cluster
-   * run `make deploy`
+   * Clone the Gatekeeper repository to your local system:
+     ```sh
+     git clone https://github.com/open-policy-agent/gatekeeper.git
+     ```
+   * Make sure you have a container registry you can write to that is readable by the target cluster.
+   * `cd` to the repository directory.
+   * Define your destination Docker image location:
+      ```sh
+      export DESTINATION_GATEKEEPER_DOCKER_IMAGE=<YOUR DESIRED DESTINATION DOCKER IMAGE> 
+      ```
+   * Build and push your Docker image: 
+      ```sh
+      make docker-build REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
+      make docker-push-release REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
+      make patch-image REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
+      ```
+   * Make sure your kubectl context is set to the desired installation cluster.
+   * Run `make deploy`
 
 #### Deploying via Helm ####
 


### PR DESCRIPTION
Cleaning up the installation instructions. Mainly, making it so you only have to enter the docker image location once.

Signed-off-by: Craig Tabita <ctab@google.com>