### PR TITLE
Fix patch-image overwrite issue + more installation readme cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,11 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/
 
 Currently the most reliable way of installing Gatekeeper is to build and install from HEAD:
 
-   * Make sure [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#getting-started) and [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) are installed.
+   * Make sure [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#getting-started) and [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) are installed, your kubectl context is set to the desired installation cluster, and you have a container registry you can write to that is readable by the target cluster.
    * Clone the Gatekeeper repository to your local system:
      ```sh
      git clone https://github.com/open-policy-agent/gatekeeper.git
      ```
-   * Make sure you have a container registry you can write to that is readable by the target cluster.
    * `cd` to the repository directory.
    * Define your destination Docker image location:
       ```sh
@@ -85,10 +84,11 @@ Currently the most reliable way of installing Gatekeeper is to build and install
       ```sh
       make docker-build REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
       make docker-push-release REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
-      make patch-image REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
       ```
-   * Make sure your kubectl context is set to the desired installation cluster.
-   * Run `make deploy`
+   * Finally, deploy: 
+     ```sh
+     make deploy REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
+     ```
 
 #### Deploying via Helm ####
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/
 
 Currently the most reliable way of installing Gatekeeper is to build and install from HEAD:
 
-   * Make sure [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#getting-started) and [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) are installed, your kubectl context is set to the desired installation cluster, and you have a container registry you can write to that is readable by the target cluster.
+   * Make sure that:
+       * [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#getting-started) and [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) are installed.
+       * Your kubectl context is set to the desired installation cluster.
+       * You have a container registry you can write to that is readable by the target cluster.
    * Clone the Gatekeeper repository to your local system:
      ```sh
      git clone https://github.com/open-policy-agent/gatekeeper.git


### PR DESCRIPTION
`make deploy` has `make patch-image` as a dependency so the deploy without a repository value was overwriting the image value in `manager_image_patch.yaml` with the default. 

Fixing this by removing the standalone `make patch-image` and specifying a repository in `make deploy`.

Plus, more README cleanup

Signed-off-by: Craig Tabita <ctab@google.com>