### PR TITLE
Disable default Kubebuilder metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ var (
 
 var (
 	logLevel    = flag.String("log-level", "INFO", "Minimum log level. For example, DEBUG, INFO, WARNING, ERROR. Defaulted to INFO if unspecified.")
-	metricsAddr = flag.String("metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	metricsAddr = flag.String("metrics-addr", "0", "The address the metric endpoint binds to.")
 	port        = flag.Int("port", 443, "port for the server. defaulted to 443 if unspecified ")
 	certDir     = flag.String("cert-dir", "/certs", "The directory where certs are stored, defaults to /certs")
 )


### PR DESCRIPTION
Disable kubebuilder metrics by default as they don't
play well with the watch manager. Currently it's possible
for stale metrics to persist after restart. In addition, because
metric names correlate with template names, this means
that the installed constraint templates would be visible
if these metrics were enabled.

Default metrics can still be enabled by setting:

`--metrics-addr=":8080"`

Signed-off-by: Max Smythe <smythe@google.com>