### PR TITLE
Fixes crashloop caused by cert gen

### DIFF
--- a/main.go
+++ b/main.go
@@ -194,6 +194,8 @@ func main() {
 	<-templatesCleaned
 	setupLog.Info("state cleaned")
 	if hadError {
+		/// give the cert manager time to generate the cert
+		time.Sleep(5 * time.Second)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Fixes #452 

Seems by removing the sleep in main.go in #418 the pod to exit before it has a chance to generate the cert. 

Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>
