### PR TITLE
make tracing dump case insensitive

### DIFF
--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -289,7 +289,7 @@ func (h *validationHandler) reviewRequest(ctx context.Context, req admission.Req
 		}
 		if gvk == trace.Kind {
 			traceEnabled = true
-			if trace.Dump == "All" {
+			if strings.EqualFold(trace.Dump, "All") {
 				dump = true
 			}
 		}


### PR DESCRIPTION
It's a simple change to allow the Config > validation > traces > user [] > dump to be case insensitive.

I was writing the config file without copying/pasting from examples and mistakenly used "all". Ended spending quite some time to figure it out the issue.

I would even suggest changing the variable to bool instead of string. Happy to amend the PR if you prefer.