### PR TITLE
change 'data will be added' from Info to Debug to be less spammy

### DIFF
--- a/pkg/controller/sync/sync_controller.go
+++ b/pkg/controller/sync/sync_controller.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
+	"github.com/open-policy-agent/gatekeeper/pkg/logging"
 	"github.com/open-policy-agent/gatekeeper/pkg/watch"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -131,7 +132,7 @@ func (r *ReconcileSync) Reconcile(request reconcile.Request) (reconcile.Result, 
 		return reconcile.Result{}, nil
 	}
 
-	r.log.Info("data will be added", "data", instance)
+	r.log.V(logging.DebugLevel).Info("data will be added", "data", instance)
 	if _, err := r.opa.AddData(context.Background(), instance); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -15,4 +15,5 @@ const (
 	ResourceKind         = "resource_kind"
 	ResourceNamespace    = "resource_namespace"
 	ResourceName         = "resource_name"
+	DebugLevel           = 2 // r.log.Debug(foo) == r.log.V(logging.DebugLevel).Info(foo)
 )


### PR DESCRIPTION
syncing happens a lot, especially when watching many resources and the constant "data will be added"
spam is only needed when "debugging" sync issues, so change to debug

fixes https://github.com/open-policy-agent/gatekeeper/issues/399
@maxsmythe 