### PR TITLE
update README-  GKE private node webhook exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,22 +498,25 @@ Two ways of working around this:
   - https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
 - make the pod to run on privileged port 443 (need to run pod as root)
   - update Gatekeeper deployment manifest spec:
-  ```yaml
-  containers:
-  - args:
-    - --port=443
-    ports:
-    - containerPort: 443
-      name: webhook-server
-      protocol: TCP
-  ```
+    - remove `securityContext` settings that force the pods not to run as root
+    - update port from `8443` to `443`
+    ```yaml
+    containers:
+    - args:
+      - --port=443
+      ports:
+      - containerPort: 443
+        name: webhook-server
+        protocol: TCP
+    ```
+
   - update Gatekeeper service manifest spec:
-  ```yaml
-  ports:
-  - port: 443
-    targetPort: 443
-  ```
-  - remove `securityContext` settings that force the pods not to run as root
+    - update `targetPort` from `8443` to `443`
+    ```yaml
+    ports:
+    - port: 443
+      targetPort: 443
+    ```
 
 ## Kick The Tires
 

--- a/README.md
+++ b/README.md
@@ -514,9 +514,6 @@ Two ways of working around this:
   ```
   - remove `securityContext` settings that force the pods not to run as root
 
-
-
-
 ## Kick The Tires
 
 The [demo/basic](https://github.com/open-policy-agent/gatekeeper/tree/master/demo/basic) directory contains the above examples of simple constraints, templates and configs to play with. The [demo/agilebank](https://github.com/open-policy-agent/gatekeeper/tree/master/demo/agilebank) directory contains more complex examples based on a slightly more realistic scenario. Both folders have a handy demo script to step you through the demos.

--- a/README.md
+++ b/README.md
@@ -490,11 +490,11 @@ Redeploying the webhook configuration will re-enable Gatekeeper.
 
 ### Running on private GKE Cluster nodes
 
-By default, firewall rules restrict the cluster master communication to nodes only on ports 443 (HTTPS) and 10250 (kubelet). Although Gatekeeper exposes its service on port 443, GKE by default enables `--enable-aggregator-routing` option, which makes the master to bypass the service and communicate straigth to the POD on port 8443.
+By default, firewall rules restrict the cluster master communication to nodes only on ports 443 (HTTPS) and 10250 (kubelet). Although Gatekeeper exposes its service on port 443, GKE by default enables `--enable-aggregator-routing` option, which makes the master to bypass the service and communicate straigt to the POD on port 8443.
 
 Two ways of working around this:
 
-- new firewall rule from master to private nodes to open port `8443` (or any other custom port)
+- create a new firewall rule from master to private nodes to open port `8443` (or any other custom port)
   - https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
 - make the pod to run on privileged port 443 (need to run pod as root)
   - update Gatekeeper deployment manifest spec:

--- a/README.md
+++ b/README.md
@@ -488,9 +488,39 @@ the default webhook name has been used this can be achieved by running:
 
 Redeploying the webhook configuration will re-enable Gatekeeper.
 
+### Running on private GKE Cluster nodes
+
+By default, firewall rules restrict the cluster master communication to nodes only on ports 443 (HTTPS) and 10250 (kubelet). Although Gatekeeper exposes its service on port 443, GKE by default enables `--enable-aggregator-routing` option, which makes the master to bypass the service and communicate straigth to the POD on port 8443.
+
+Two ways of working around this:
+
+- new firewall rule from master to private nodes to open port `8443` (or any other custom port)
+- make the pod to run on privileged port 443 (need to run pod as root)
+  - update Gatekeeper deployment manifest spec:
+  ```yaml
+  containers:
+  - args:
+    - --port=443
+    ports:
+    - containerPort: 443
+      name: webhook-server
+      protocol: TCP
+  ```
+  - update Gatekeeper service manifest spec:
+  ```yaml
+  ports:
+  - port: 443
+    targetPort: 443
+  ```
+  - remove `securityContext` settings that force the pods not to run as root
+
+
+
+
 ## Kick The Tires
 
 The [demo/basic](https://github.com/open-policy-agent/gatekeeper/tree/master/demo/basic) directory contains the above examples of simple constraints, templates and configs to play with. The [demo/agilebank](https://github.com/open-policy-agent/gatekeeper/tree/master/demo/agilebank) directory contains more complex examples based on a slightly more realistic scenario. Both folders have a handy demo script to step you through the demos.
+
 
 # FAQ
 

--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ By default, firewall rules restrict the cluster master communication to nodes on
 Two ways of working around this:
 
 - new firewall rule from master to private nodes to open port `8443` (or any other custom port)
+  - https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
 - make the pod to run on privileged port 443 (need to run pod as root)
   - update Gatekeeper deployment manifest spec:
   ```yaml

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ Redeploying the webhook configuration will re-enable Gatekeeper.
 
 ### Running on private GKE Cluster nodes
 
-By default, firewall rules restrict the cluster master communication to nodes only on ports 443 (HTTPS) and 10250 (kubelet). Although Gatekeeper exposes its service on port 443, GKE by default enables `--enable-aggregator-routing` option, which makes the master to bypass the service and communicate straigt to the POD on port 8443.
+By default, firewall rules restrict the cluster master communication to nodes only on ports 443 (HTTPS) and 10250 (kubelet). Although Gatekeeper exposes its service on port 443, GKE by default enables `--enable-aggregator-routing` option, which makes the master to bypass the service and communicate straight to the POD on port 8443.
 
 Two ways of working around this:
 


### PR DESCRIPTION
Adding troubleshoot information refer to running Gatekeeper on GKE private nodes due to known issue of master plane only able to communicate with webhook on port 443.

Fix #498 .