### PR TITLE
Fix golangci-lint memory usage

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,8 +13,7 @@ linters:
     - ineffassign
     - golint
     - goconst
-    - goimports
-    - unused
+    - goimports #- unused, https://github.com/golangci/golangci-lint/issues/337#issuecomment-536721714
     - varcheck
     - deadcode
     - misspell


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

Removing  `unused` for now until we move off travis. Ref: https://github.com/golangci/golangci-lint/issues/337#issuecomment-536721714