### PR TITLE
fix max retries error

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -553,7 +553,7 @@ func (ucloop *updateConstraintLoop) update() {
 					}
 				}
 				if !failure {
-					delete(ucloop.uc, latestItem.GetSelfLink())
+					delete(ucloop.uc, item.GetSelfLink())
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #476

When we changed to status client, it also changed `GetSelfLink()` to return with `/status` suffix (which is status subresource's selflink value), it didn't match with the existing `ucloop.uc` key value