### PR TITLE
docs: Update README with security release process pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,3 +565,12 @@ If Gatekeeper is not running:
   * The container had a panic
 
 Finalizers can be removed manually via `kubectl edit` or `kubectl patch`
+
+# Security
+
+Please report vulnerabilities by email to [open-policy-agent-security](mailto:open-policy-agent-security@googlegroups.com).
+We will send a confirmation message to acknowledge that we have received the
+report and then we will send additional messages to follow up once the issue
+has been investigated.
+
+For details on the security release process please refer to the [open-policy-agent/opa/SECURITY.md](https://github.com/open-policy-agent/opa/blob/master/SECURITY.md) file.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,1 @@
+See [https://github.com/open-policy-agent/opa/blob/master/SECURITY.md](https://github.com/open-policy-agent/opa/blob/master/SECURITY.md)


### PR DESCRIPTION
This follows the convention in OPA (and other CNCF projects) around security release processes.

Signed-off-by: Torin Sandall <torinsandall@gmail.com>