### PR TITLE
Fix PSP sysctls rego

### DIFF
--- a/library/pod-security-policy/forbidden-sysctls/src.rego
+++ b/library/pod-security-policy/forbidden-sysctls/src.rego
@@ -2,6 +2,7 @@ package k8spspforbiddensysctls
 
 violation[{"msg": msg, "details": {}}] {
     sysctls := {x | x = input.review.object.spec.securityContext.sysctls[_][name]}
+    count(sysctls) > 0
     input_sysctls(sysctls)
     msg := sprintf("One of the sysctls %v is not allowed, pod: %v. Forbidden sysctls: %v", [sysctls, input.review.object.metadata.name, input.parameters.forbiddenSysctls])
 }

--- a/library/pod-security-policy/forbidden-sysctls/src_test.rego
+++ b/library/pod-security-policy/forbidden-sysctls/src_test.rego
@@ -36,6 +36,12 @@ test_input_sysctls_empty_allowed {
     count(results) == 0
 }
 
+test_input_no_sysctls_wildcard_allowed {
+    input := { "review": input_review_empty, "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
+}
+
 input_review = {
     "object": {
         "metadata": {
@@ -57,6 +63,22 @@ input_review = {
                         "value": "1024"
                     }
                 ]
+            }
+        }
+    }
+}
+
+input_review_empty = {
+    "object": {
+        "metadata": {
+            "name": "nginx"
+        },
+        "spec": {
+            "containers": {
+                "name": "nginx",
+                "image": "nginx",
+            },
+            "securityContext": {
             }
         }
     }

--- a/library/pod-security-policy/forbidden-sysctls/template.yaml
+++ b/library/pod-security-policy/forbidden-sysctls/template.yaml
@@ -22,6 +22,7 @@ spec:
 
         violation[{"msg": msg, "details": {}}] {
             sysctls := {x | x = input.review.object.spec.securityContext.sysctls[_][name]}
+            count(sysctls) > 0
             input_sysctls(sysctls)
             msg := sprintf("One of the sysctls %v is not allowed, pod: %v. Forbidden sysctls: %v", [sysctls, input.review.object.metadata.name, input.parameters.forbiddenSysctls])
         }


### PR DESCRIPTION
The Pod will be blocked if `forbiddenSysctls` is a wildcard and the sysctls list in the Pod is empty. The change adds quick check to see if any sysctls are set to the Pod.