### PR TITLE
Run audit in a deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ patch-image:
 	@test -s ./config/overlays/dev/manager_image_patch.yaml || bash -c 'echo -e ${MANAGER_IMAGE_PATCH} > ./config/overlays/dev/manager_image_patch.yaml'
 ifeq ($(USE_LOCAL_IMG),true)
 	@sed -i '/^        name: manager/a \ \ \ \ \ \ \ \ imagePullPolicy: IfNotPresent' ./config/overlays/dev/manager_image_patch.yaml
-	@sed -i '/^    name: auditcontainer/a \ \ \ \ imagePullPolicy: IfNotPresent' ./config/overlays/dev/manager_image_patch.yaml
+	@sed -i '/^        name: auditcontainer/a \ \ \ \ \ \ \ \ imagePullPolicy: IfNotPresent' ./config/overlays/dev/manager_image_patch.yaml
 endif
 	@sed -i'' -e 's@image: .*@image: '"${IMG}"'@' ./config/overlays/dev/manager_image_patch.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -33,14 +33,16 @@ MANAGER_IMAGE_PATCH := "apiVersion: apps/v1\
 \n        name: manager\
 \n---\
 \napiVersion: v1\
-\nkind: Pod\
+\nkind: Deployment\
 \nmetadata:\
 \n  name: audit\
 \n  namespace: system\
 \nspec:\
-\n  containers:\
-\n  - image: <your image file>\
-\n    name: auditcontainer"
+\n  template:\
+\n    spec:
+\n      containers:\
+\n      - image: <your image file>\
+\n        name: auditcontainer"
 
 
 FRAMEWORK_PACKAGE := github.com/open-policy-agent/frameworks/constraint

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ MANAGER_IMAGE_PATCH := "apiVersion: apps/v1\
 \n      - image: <your image file>\
 \n        name: manager\
 \n---\
-\napiVersion: v1\
+\napiVersion: apps/v1\
 \nkind: Deployment\
 \nmetadata:\
 \n  name: audit\

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ MANAGER_IMAGE_PATCH := "apiVersion: apps/v1\
 \n  namespace: system\
 \nspec:\
 \n  template:\
-\n    spec:
+\n    spec:\
 \n      containers:\
 \n      - image: <your image file>\
 \n        name: auditcontainer"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -82,64 +82,75 @@ spec:
               - all
       terminationGracePeriodSeconds: 60
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  labels:
-    control-plane: controller-manager
   name: audit
   namespace: system
-  annotations:
-    container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+  labels:
+    control-plane: controller-manager
+    gatekeeper.sh/operation: audit
 spec:
-  containers:
-  - args:
-    - --operation=audit
-    - --logtostderr
-    command:
-    - /manager
-    env:
-    - name: POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.namespace
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
-    image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.8
-    imagePullPolicy: Always
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: 9090
-    name: auditcontainer
-    ports:
-    - containerPort: 8888
-      name: metrics
-      protocol: TCP
-    - containerPort: 9090
-      name: healthz
-      protocol: TCP
-    readinessProbe:
-      httpGet:
-        path: /readyz
-        port: 9090
-    resources:
-      limits:
-        cpu: 1000m
-        memory: 512Mi
-      requests:
-        cpu: 100m
-        memory: 256Mi
-    securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - all
-      runAsGroup: 999
-      runAsNonRoot: true
-      runAsUser: 1000
-  serviceAccountName: gatekeeper-admin
-  terminationGracePeriodSeconds: 60
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      gatekeeper.sh/operation: audit
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+      annotations:
+        container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+    spec:
+      containers:
+      - args:
+        - --operation=audit
+        - --logtostderr
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.8
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+        name: auditcontainer
+        ports:
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        - containerPort: 9090
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9090
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          runAsGroup: 999
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: gatekeeper-admin
+      terminationGracePeriodSeconds: 60

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -93,13 +93,14 @@ metadata:
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: audit-controller
       gatekeeper.sh/operation: audit
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
+        control-plane: audit-controller
+        gatekeeper.sh/operation: audit
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
     spec:

--- a/manifest_staging/chart/gatekeeper-operator/generate_helm_template.sh
+++ b/manifest_staging/chart/gatekeeper-operator/generate_helm_template.sh
@@ -3,26 +3,21 @@ scriptdir="$(dirname "$0")"
 cd "$scriptdir"
 cp ./../../deploy/gatekeeper.yaml ${PWD}/helm-modifications/_temp.yaml
 kustomize build helm-modifications -o templates/gatekeeper.yaml
+
 sed -i -E "s/HELMSUBST_DEPLOYMENT_CONTAINER_RESOURCES/\
 \n{{ toYaml .Values.resources | indent 10 }}/" templates/gatekeeper.yaml
-sed -i -E "s/HELMSUBST_POD_CONTAINER_RESOURCES/\
-\n{{ toYaml .Values.resources | indent 6 }}/" templates/gatekeeper.yaml
+
 sed -i -E "s/HELMSUBST_DEPLOYMENT_POD_SCHEDULING/\
 \n{{ toYaml .Values.nodeSelector | indent 8 }}\
 \n      affinity:\
 \n{{ toYaml .Values.affinity | indent 8 }}\
 \n      tolerations:\
 \n{{ toYaml .Values.tolerations | indent 8 }}/" templates/gatekeeper.yaml
-sed -i -E "s/HELMSUBST_POD_SCHEDULING/\
-\n{{ toYaml .Values.nodeSelector | indent 4 }}\
-\n  affinity:\
-\n{{ toYaml .Values.affinity | indent 4 }}\
-\n  tolerations:\
-\n{{ toYaml .Values.tolerations | indent 4 }}/" templates/gatekeeper.yaml
+
 sed -i "s/HELMSUBST_DEPLOYMENT_REPLICAS/{{ .Values.replicas }}/g" templates/gatekeeper.yaml
+
 sed -i -E "s/HELMSUBST_ANNOTATIONS/\
 \n{{- toYaml .Values.podAnnotations | trim | nindent 8 }}/" templates/gatekeeper.yaml
-sed -i -E "s/HELMSUBST_POD_ANNOTATIONS/\
-\n{{- toYaml .Values.podAnnotations | trim | nindent 4 }}/" templates/gatekeeper.yaml
+
 rm ./helm-modifications/_temp.yaml
 echo "Helm template created under '$PWD/templates'"

--- a/manifest_staging/chart/gatekeeper-operator/helm-modifications/helm-modifications.yaml
+++ b/manifest_staging/chart/gatekeeper-operator/helm-modifications/helm-modifications.yaml
@@ -61,23 +61,30 @@ spec:
           resources: HELMSUBST_DEPLOYMENT_CONTAINER_RESOURCES
       nodeSelector: HELMSUBST_DEPLOYMENT_POD_SCHEDULING
 ---
-kind: Pod
-apiVersion: v1
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  annotations: HELMSUBST_POD_ANNOTATIONS
   name: gatekeeper-audit
   namespace: gatekeeper-system
 spec:
-  containers:
-  - args:
-    - --audit-interval={{ .Values.auditInterval }}
-    - --log-level={{ .Values.logLevel }}
-    - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
-    - --audit-from-cache={{ .Values.auditFromCache }}
-    - --operation=audit
-    - --logtostderr
-    name: auditcontainer
-    imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-    image: "{{ .Values.image.repository }}:{{ .Values.image.release }}"
-    resources: HELMSUBST_POD_CONTAINER_RESOURCES
-  nodeSelector: HELMSUBST_POD_SCHEDULING
+  selector:
+    matchLabels:
+      app: gatekeeper-operator
+      release: RELEASE_NAME
+  template:
+    metadata:
+      annotations: HELMSUBST_ANNOTATIONS
+    spec:
+      containers:
+      - name: auditcontainer
+        args:
+        - --audit-interval={{ .Values.auditInterval }}
+        - --log-level={{ .Values.logLevel }}
+        - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
+        - --audit-from-cache={{ .Values.auditFromCache }}
+        - --operation=audit
+        - --logtostderr
+        imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.release }}"
+        resources: HELMSUBST_DEPLOYMENT_CONTAINER_RESOURCES
+      nodeSelector: HELMSUBST_DEPLOYMENT_POD_SCHEDULING

--- a/manifest_staging/chart/gatekeeper-operator/templates/gatekeeper.yaml
+++ b/manifest_staging/chart/gatekeeper-operator/templates/gatekeeper.yaml
@@ -453,7 +453,7 @@ spec:
     matchLabels:
       app: '{{ template "gatekeeper-operator.name" . }}'
       chart: '{{ template "gatekeeper-operator.name" . }}'
-      control-plane: controller-manager
+      control-plane: audit-controller
       gatekeeper.sh/operation: audit
       gatekeeper.sh/system: "yes"
       heritage: '{{ .Release.Service }}'
@@ -465,7 +465,8 @@ spec:
       labels:
         app: '{{ template "gatekeeper-operator.name" . }}'
         chart: '{{ template "gatekeeper-operator.name" . }}'
-        control-plane: controller-manager
+        control-plane: audit-controller
+        gatekeeper.sh/operation: audit
         gatekeeper.sh/system: "yes"
         heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'

--- a/manifest_staging/chart/gatekeeper-operator/templates/gatekeeper.yaml
+++ b/manifest_staging/chart/gatekeeper-operator/templates/gatekeeper.yaml
@@ -441,6 +441,99 @@ metadata:
     app: '{{ template "gatekeeper-operator.name" . }}'
     chart: '{{ template "gatekeeper-operator.name" . }}'
     control-plane: controller-manager
+    gatekeeper.sh/operation: audit
+    gatekeeper.sh/system: "yes"
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
+  name: gatekeeper-audit
+  namespace: gatekeeper-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: '{{ template "gatekeeper-operator.name" . }}'
+      chart: '{{ template "gatekeeper-operator.name" . }}'
+      control-plane: controller-manager
+      gatekeeper.sh/operation: audit
+      gatekeeper.sh/system: "yes"
+      heritage: '{{ .Release.Service }}'
+      release: '{{ .Release.Name }}'
+  template:
+    metadata:
+      annotations: 
+{{- toYaml .Values.podAnnotations | trim | nindent 8 }}
+      labels:
+        app: '{{ template "gatekeeper-operator.name" . }}'
+        chart: '{{ template "gatekeeper-operator.name" . }}'
+        control-plane: controller-manager
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
+        release: '{{ .Release.Name }}'
+    spec:
+      containers:
+      - args:
+        - --audit-interval={{ .Values.auditInterval }}
+        - --log-level={{ .Values.logLevel }}
+        - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
+        - --audit-from-cache={{ .Values.auditFromCache }}
+        - --operation=audit
+        - --logtostderr
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
+        imagePullPolicy: '{{ .Values.image.pullPolicy }}'
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+        name: auditcontainer
+        ports:
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        - containerPort: 9090
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9090
+        resources: 
+{{ toYaml .Values.resources | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          runAsGroup: 999
+          runAsNonRoot: true
+          runAsUser: 1000
+      nodeSelector: 
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      serviceAccountName: gatekeeper-admin
+      terminationGracePeriodSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: '{{ template "gatekeeper-operator.name" . }}'
+    chart: '{{ template "gatekeeper-operator.name" . }}'
+    control-plane: controller-manager
     gatekeeper.sh/operation: webhook
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
@@ -538,78 +631,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
----
-apiVersion: v1
-kind: Pod
-metadata:
-  annotations: 
-{{- toYaml .Values.podAnnotations | trim | nindent 4 }}
-  labels:
-    app: '{{ template "gatekeeper-operator.name" . }}'
-    chart: '{{ template "gatekeeper-operator.name" . }}'
-    control-plane: controller-manager
-    gatekeeper.sh/system: "yes"
-    heritage: '{{ .Release.Service }}'
-    release: '{{ .Release.Name }}'
-  name: gatekeeper-audit
-  namespace: gatekeeper-system
-spec:
-  containers:
-  - args:
-    - --audit-interval={{ .Values.auditInterval }}
-    - --log-level={{ .Values.logLevel }}
-    - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
-    - --audit-from-cache={{ .Values.auditFromCache }}
-    - --operation=audit
-    - --logtostderr
-    command:
-    - /manager
-    env:
-    - name: POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.namespace
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
-    image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
-    imagePullPolicy: '{{ .Values.image.pullPolicy }}'
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: 9090
-    name: auditcontainer
-    ports:
-    - containerPort: 8888
-      name: metrics
-      protocol: TCP
-    - containerPort: 9090
-      name: healthz
-      protocol: TCP
-    readinessProbe:
-      httpGet:
-        path: /readyz
-        port: 9090
-    resources: 
-{{ toYaml .Values.resources | indent 6 }}
-    securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - all
-      runAsGroup: 999
-      runAsNonRoot: true
-      runAsUser: 1000
-  nodeSelector: 
-{{ toYaml .Values.nodeSelector | indent 4 }}
-  affinity:
-{{ toYaml .Values.affinity | indent 4 }}
-  tolerations:
-{{ toYaml .Values.tolerations | indent 4 }}
-  serviceAccountName: gatekeeper-admin
-  terminationGracePeriodSeconds: 60
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -290,6 +290,82 @@ kind: Deployment
 metadata:
   labels:
     control-plane: controller-manager
+    gatekeeper.sh/operation: audit
+    gatekeeper.sh/system: "yes"
+  name: gatekeeper-audit
+  namespace: gatekeeper-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      gatekeeper.sh/operation: audit
+      gatekeeper.sh/system: "yes"
+  template:
+    metadata:
+      annotations:
+        container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+      labels:
+        control-plane: controller-manager
+        gatekeeper.sh/system: "yes"
+    spec:
+      containers:
+      - args:
+        - --operation=audit
+        - --logtostderr
+        command:
+        - /manager
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.8
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 9090
+        name: auditcontainer
+        ports:
+        - containerPort: 8888
+          name: metrics
+          protocol: TCP
+        - containerPort: 9090
+          name: healthz
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 9090
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - all
+          runAsGroup: 999
+          runAsNonRoot: true
+          runAsUser: 1000
+      serviceAccountName: gatekeeper-admin
+      terminationGracePeriodSeconds: 60
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    control-plane: controller-manager
     gatekeeper.sh/operation: webhook
     gatekeeper.sh/system: "yes"
   name: gatekeeper-controller-manager
@@ -375,69 +451,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
----
-apiVersion: v1
-kind: Pod
-metadata:
-  annotations:
-    container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
-  labels:
-    control-plane: controller-manager
-    gatekeeper.sh/system: "yes"
-  name: gatekeeper-audit
-  namespace: gatekeeper-system
-spec:
-  containers:
-  - args:
-    - --operation=audit
-    - --logtostderr
-    command:
-    - /manager
-    env:
-    - name: POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.namespace
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
-    image: quay.io/open-policy-agent/gatekeeper:v3.1.0-beta.8
-    imagePullPolicy: Always
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: 9090
-    name: auditcontainer
-    ports:
-    - containerPort: 8888
-      name: metrics
-      protocol: TCP
-    - containerPort: 9090
-      name: healthz
-      protocol: TCP
-    readinessProbe:
-      httpGet:
-        path: /readyz
-        port: 9090
-    resources:
-      limits:
-        cpu: 1000m
-        memory: 512Mi
-      requests:
-        cpu: 100m
-        memory: 256Mi
-    securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - all
-      runAsGroup: 999
-      runAsNonRoot: true
-      runAsUser: 1000
-  serviceAccountName: gatekeeper-admin
-  terminationGracePeriodSeconds: 60
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -298,7 +298,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: audit-controller
       gatekeeper.sh/operation: audit
       gatekeeper.sh/system: "yes"
   template:
@@ -306,7 +306,8 @@ spec:
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
       labels:
-        control-plane: controller-manager
+        control-plane: audit-controller
+        gatekeeper.sh/operation: audit
         gatekeeper.sh/system: "yes"
     spec:
       containers:


### PR DESCRIPTION
Audit should still be run as a deployment so that we can control update behavior if necessary and get whatever other app management features come with deployments in the future.