### PR TITLE
Fix certRotator early return bug

### DIFF
--- a/pkg/webhook/certs.go
+++ b/pkg/webhook/certs.go
@@ -89,12 +89,11 @@ func (cr *certRotator) Start(stop <-chan (struct{})) error {
 	// can be bootstrapped, otherwise manager exits before a cert can be written
 	crLog.Info("starting cert rotator controller")
 	defer crLog.Info("stopping cert rotator controller")
-	if restart, err := cr.refreshCertIfNeeded(); err != nil {
+	if refreshed, err := cr.refreshCertIfNeeded(); err != nil {
 		crLog.Error(err, "could not refresh cert on startup")
 		return errors.Wrap(err, "could not refresh cert on startup")
-	} else if restart {
-		crLog.Info("certs refreshed, restarting server")
-		return nil
+	} else if refreshed {
+		crLog.Info("certs refreshed on startup")
 	}
 	ticker := time.NewTicker(rotationCheckFrequency)
 
@@ -102,11 +101,10 @@ tickerLoop:
 	for {
 		select {
 		case <-ticker.C:
-			if restart, err := cr.refreshCertIfNeeded(); err != nil {
+			if refreshed, err := cr.refreshCertIfNeeded(); err != nil {
 				crLog.Error(err, "error rotating certs")
-			} else if restart {
-				crLog.Info("certs refreshed, restarting server")
-				break tickerLoop
+			} else if refreshed {
+				crLog.Info("certs refreshed")
 			}
 		case <-stop:
 			break tickerLoop


### PR DESCRIPTION
Since the controller manager will no longer restart when certRotator
returns, the return after a cert rotation in certRotator.Start() makes
certRotator stop working after first cert rotation is done before the
stop channel closes.

This commit keeps the certRotator blocked and rotating certs
periodically until the stop channel is closed. There's no need to
trigger a restart for webhooks to pick up the new certs because
CertWatcher can renew the webhook certs on the fly.

Tested on a GKE cluster:
I set rotationCheckFrequency to 1 minute, certValidityDuration to 10
minutes and lookaheadTime() to 6 minutes to test the behaviour of a cert
rotation and how webhooks react.

There would always be 1 manager restart as expected since the webhook
couldn't find the cert files in the first start.

I also observed a lag for about 20s before CertWatcher updates the
webhook certs after each cert rotation. In this 20s, there will be bad
certificate TLS handshake errors. After CertWatcher updates the webhook
certs, the webhook works fine in the rest of the 4 minutes.

Considering the actual certValidityDuration is 10 years, it's probably
okay for a 20-second down time for webhooks only after a cert rotation.

Fixes #462 