### PR TITLE
Refactor cert.go for easy reuse

### DIFF
--- a/pkg/webhook/certs.go
+++ b/pkg/webhook/certs.go
@@ -14,7 +14,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/open-policy-agent/gatekeeper/pkg/util"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,8 +32,6 @@ import (
 )
 
 const (
-	caName                 = "gatekeeper-ca"
-	service                = "gatekeeper-webhook-service"
 	certName               = "tls.crt"
 	keyName                = "tls.key"
 	caCertName             = "ca.crt"
@@ -45,43 +42,42 @@ const (
 
 var crLog = logf.Log.WithName("cert-rotation")
 
-var (
-	secretKey = types.NamespacedName{
-		Namespace: util.GetNamespace(),
-		Name:      "gatekeeper-webhook-server-cert",
-	}
-	// DNSName is <service name>.<namespace>.svc
-	DNSName = fmt.Sprintf("%s.%s.svc", service, util.GetNamespace())
-	vwhGVK  = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"}
-	vwhKey  = types.NamespacedName{Name: "gatekeeper-validating-webhook-configuration"}
-)
+var vwhGVK = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1beta1", Kind: "ValidatingWebhookConfiguration"}
 
 var _ manager.Runnable = &certRotator{}
 
-func AddRotator(mgr manager.Manager) error {
+func AddRotator(mgr manager.Manager, cr *certRotator, vwhName string) error {
 	// Use a new client so we are unaffected by the cache sync kill signal
 	cli, err := client.New(mgr.GetConfig(), client.Options{Scheme: mgr.GetScheme(), Mapper: mgr.GetRESTMapper()})
 	if err != nil {
 		return err
 	}
-	rotator := &certRotator{client: cli}
-	if err = mgr.Add(rotator); err != nil {
+
+	cr.client = cli
+	if err = mgr.Add(cr); err != nil {
 		return err
 	}
 
+	vwhKey := types.NamespacedName{Name: vwhName}
 	reconciler := &ReconcileVWH{
-		client: mgr.GetClient(),
-		scheme: mgr.GetScheme(),
-		ctx:    context.Background(),
+		client:    mgr.GetClient(),
+		scheme:    mgr.GetScheme(),
+		ctx:       context.Background(),
+		secretKey: cr.secretKey,
+		vwhKey:    vwhKey,
 	}
-	if err := addController(mgr, reconciler); err != nil {
+	if err := addController(mgr, reconciler, cr.secretKey, vwhKey); err != nil {
 		return err
 	}
 	return nil
 }
 
 type certRotator struct {
-	client client.Client
+	client         client.Client
+	secretKey      types.NamespacedName
+	caName         string
+	caOrganization string
+	dnsName        string
 }
 
 func (cr *certRotator) Start(stop <-chan (struct{})) error {
@@ -120,15 +116,15 @@ tickerLoop:
 // refreshCertIfNeeded returns whether the cert was refreshed and any errors
 func (cr *certRotator) refreshCertIfNeeded() (bool, error) {
 	secret := &corev1.Secret{}
-	if err := cr.client.Get(context.Background(), secretKey, secret); err != nil {
+	if err := cr.client.Get(context.Background(), cr.secretKey, secret); err != nil {
 		return false, errors.Wrap(err, "acquiring secret to update certificates")
 	}
-	if secret.Data == nil || !validCACert(secret.Data[caCertName], secret.Data[caKeyName]) {
+	if secret.Data == nil || !cr.validCACert(secret.Data[caCertName], secret.Data[caKeyName]) {
 		crLog.Info("refreshing CA and server certs")
 		return cr.refreshCerts(true, secret)
 	}
 	// make sure our reconciler is initialized on startup (either this or the above refreshCerts() will call this)
-	if !validServerCert(secret.Data[caCertName], secret.Data[certName], secret.Data[keyName]) {
+	if !cr.validServerCert(secret.Data[caCertName], secret.Data[certName], secret.Data[keyName]) {
 		crLog.Info("refreshing server certs")
 		return cr.refreshCerts(false, secret)
 	}
@@ -140,7 +136,7 @@ func (cr *certRotator) refreshCerts(refreshCA bool, secret *corev1.Secret) (bool
 	var caArtifacts *KeyPairArtifacts
 	if refreshCA {
 		var err error
-		caArtifacts, err = createCACert()
+		caArtifacts, err = cr.createCACert()
 		if err != nil {
 			return false, err
 		}
@@ -151,7 +147,7 @@ func (cr *certRotator) refreshCerts(refreshCA bool, secret *corev1.Secret) (bool
 			return false, err
 		}
 	}
-	cert, key, err := createCertPEM(caArtifacts)
+	cert, key, err := cr.createCertPEM(caArtifacts)
 	if err != nil {
 		return false, err
 	}
@@ -254,7 +250,7 @@ func buildArtifactsFromSecret(secret *corev1.Secret) (*KeyPairArtifacts, error) 
 
 // createCACert creates the self-signed CA cert and private key that will
 // be used to sign the server certificate
-func createCACert() (*KeyPairArtifacts, error) {
+func (cr *certRotator) createCACert() (*KeyPairArtifacts, error) {
 	now := time.Now()
 	begin := now.Add(-1 * time.Hour)
 	end := now.Add(certValidityDuration)
@@ -262,7 +258,7 @@ func createCACert() (*KeyPairArtifacts, error) {
 		SerialNumber: big.NewInt(0),
 		Subject: pkix.Name{
 			CommonName:   caName,
-			Organization: []string{"gatekeeper"},
+			Organization: []string{cr.caOrganization},
 		},
 		NotBefore:             begin,
 		NotAfter:              end,
@@ -292,14 +288,14 @@ func createCACert() (*KeyPairArtifacts, error) {
 
 // createCertPEM takes the results of createCACert and uses it to create the
 // PEM-encoded public certificate and private key, respectively
-func createCertPEM(ca *KeyPairArtifacts) ([]byte, []byte, error) {
+func (cr *certRotator) createCertPEM(ca *KeyPairArtifacts) ([]byte, []byte, error) {
 	now := time.Now()
 	begin := now.Add(-1 * time.Hour)
 	end := now.Add(certValidityDuration)
 	templ := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
 		Subject: pkix.Name{
-			CommonName: DNSName,
+			CommonName: cr.dnsName,
 		},
 		NotBefore:             begin,
 		NotAfter:              end,
@@ -339,16 +335,16 @@ func lookaheadTime() time.Time {
 	return time.Now().Add(90 * 24 * time.Hour)
 }
 
-func validServerCert(caCert, cert, key []byte) bool {
-	valid, err := validCert(caCert, cert, key, DNSName, lookaheadTime())
+func (cr *certRotator) validServerCert(caCert, cert, key []byte) bool {
+	valid, err := validCert(caCert, cert, key, cr.dnsName, lookaheadTime())
 	if err != nil {
 		return false
 	}
 	return valid
 }
 
-func validCACert(cert, key []byte) bool {
-	valid, err := validCert(cert, cert, key, caName, lookaheadTime())
+func (cr *certRotator) validCACert(cert, key []byte) bool {
+	valid, err := validCert(cert, cert, key, cr.caName, lookaheadTime())
 	if err != nil {
 		return false
 	}
@@ -401,20 +397,23 @@ func validCert(caCert, cert, key []byte, dnsName string, at time.Time) (bool, er
 
 var _ handler.Mapper = &mapper{}
 
-type mapper struct{}
+type mapper struct {
+	secretKey types.NamespacedName
+	vwhKey    types.NamespacedName
+}
 
 func (m *mapper) Map(object handler.MapObject) []reconcile.Request {
-	if object.Meta.GetNamespace() != vwhKey.Namespace {
+	if object.Meta.GetNamespace() != m.vwhKey.Namespace {
 		return nil
 	}
-	if object.Meta.GetName() != vwhKey.Name {
+	if object.Meta.GetName() != m.vwhKey.Name {
 		return nil
 	}
-	return []reconcile.Request{{NamespacedName: secretKey}}
+	return []reconcile.Request{{NamespacedName: m.secretKey}}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func addController(mgr manager.Manager, r reconcile.Reconciler) error {
+func addController(mgr manager.Manager, r reconcile.Reconciler, secretKey, vwhKey types.NamespacedName) error {
 	// Create a new controller
 	c, err := controller.New(("validating-webhook-controller"), mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -429,7 +428,10 @@ func addController(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	vwh := &unstructured.Unstructured{}
 	vwh.SetGroupVersionKind(vwhGVK)
-	mapper := &handler.EnqueueRequestsFromMapFunc{ToRequests: &mapper{}}
+	mapper := &handler.EnqueueRequestsFromMapFunc{ToRequests: &mapper{
+		secretKey: secretKey,
+		vwhKey:    vwhKey,
+	}}
 	if err := c.Watch(&source.Kind{Type: vwh}, mapper); err != nil {
 		return err
 	}
@@ -442,15 +444,17 @@ var _ reconcile.Reconciler = &ReconcileVWH{}
 // ReconcileVWH reconciles a validatingwebhookconfiguration, making sure it
 // has the appropriate CA cert
 type ReconcileVWH struct {
-	client client.Client
-	scheme *runtime.Scheme
-	ctx    context.Context
+	client    client.Client
+	scheme    *runtime.Scheme
+	ctx       context.Context
+	secretKey types.NamespacedName
+	vwhKey    types.NamespacedName
 }
 
 // Reconcile reads that state of the cluster for a validatingwebhookconfiguration
 // object and makes sure the most recent CA cert is included
 func (r *ReconcileVWH) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	if request.NamespacedName != secretKey {
+	if request.NamespacedName != r.secretKey {
 		return reconcile.Result{}, nil
 	}
 	secret := &corev1.Secret{}
@@ -466,7 +470,7 @@ func (r *ReconcileVWH) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 	vwh := &unstructured.Unstructured{}
 	vwh.SetGroupVersionKind(vwhGVK)
-	if err := r.client.Get(r.ctx, vwhKey, vwh); err != nil {
+	if err := r.client.Get(r.ctx, r.vwhKey, vwh); err != nil {
 		if k8sErrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.

--- a/pkg/webhook/certs_test.go
+++ b/pkg/webhook/certs_test.go
@@ -8,37 +8,47 @@ import (
 )
 
 func TestCertSigning(t *testing.T) {
-	caArtifacts, err := createCACert()
+	cr := &certRotator{
+		caName:         caName,
+		caOrganization: caOrganization,
+		dnsName:        dnsName,
+	}
+	caArtifacts, err := cr.createCACert()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cert, key, err := createCertPEM(caArtifacts)
+	cert, key, err := cr.createCertPEM(caArtifacts)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !validServerCert(caArtifacts.CertPEM, cert, key) {
+	if !cr.validServerCert(caArtifacts.CertPEM, cert, key) {
 		t.Error("Generated cert is not valid")
 	}
 }
 
 func TestCertExpiry(t *testing.T) {
-	caArtifacts, err := createCACert()
+	cr := &certRotator{
+		caName:         caName,
+		caOrganization: caOrganization,
+		dnsName:        dnsName,
+	}
+	caArtifacts, err := cr.createCACert()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cert, key, err := createCertPEM(caArtifacts)
+	cert, key, err := cr.createCertPEM(caArtifacts)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !validServerCert(caArtifacts.CertPEM, cert, key) {
+	if !cr.validServerCert(caArtifacts.CertPEM, cert, key) {
 		t.Error("Generated cert is not valid")
 	}
 
-	valid, err := validCert(caArtifacts.CertPEM, cert, key, DNSName, time.Now().Add(11*365*24*time.Hour))
+	valid, err := validCert(caArtifacts.CertPEM, cert, key, cr.dnsName, time.Now().Add(11*365*24*time.Hour))
 	if err == nil {
 		t.Error("Generated cert has not expired when it should have")
 	}
@@ -48,48 +58,63 @@ func TestCertExpiry(t *testing.T) {
 }
 
 func TestBadCA(t *testing.T) {
-	caArtifacts, err := createCACert()
+	cr := &certRotator{
+		caName:         caName,
+		caOrganization: caOrganization,
+		dnsName:        dnsName,
+	}
+	caArtifacts, err := cr.createCACert()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cert, key, err := createCertPEM(caArtifacts)
+	cert, key, err := cr.createCertPEM(caArtifacts)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	badCAArtifacts, err := createCACert()
+	badCAArtifacts, err := cr.createCACert()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if validServerCert(badCAArtifacts.CertPEM, cert, key) {
+	if cr.validServerCert(badCAArtifacts.CertPEM, cert, key) {
 		t.Error("Generated cert is valid when it should not be")
 	}
 }
 
 func TestSelfSignedCA(t *testing.T) {
-	caArtifacts, err := createCACert()
+	cr := &certRotator{
+		caName:         caName,
+		caOrganization: caOrganization,
+		dnsName:        dnsName,
+	}
+	caArtifacts, err := cr.createCACert()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !validCACert(caArtifacts.CertPEM, caArtifacts.KeyPEM) {
+	if !cr.validCACert(caArtifacts.CertPEM, caArtifacts.KeyPEM) {
 		t.Error("Generated cert is not valid")
 	}
 }
 
 func TestCAExpiry(t *testing.T) {
-	caArtifacts, err := createCACert()
+	cr := &certRotator{
+		caName:         caName,
+		caOrganization: caOrganization,
+		dnsName:        dnsName,
+	}
+	caArtifacts, err := cr.createCACert()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !validCACert(caArtifacts.CertPEM, caArtifacts.KeyPEM) {
+	if !cr.validCACert(caArtifacts.CertPEM, caArtifacts.KeyPEM) {
 		t.Error("Generated cert is not valid")
 	}
 
-	valid, err := validCert(caArtifacts.CertPEM, caArtifacts.CertPEM, caArtifacts.KeyPEM, DNSName, time.Now().Add(11*365*24*time.Hour))
+	valid, err := validCert(caArtifacts.CertPEM, caArtifacts.CertPEM, caArtifacts.KeyPEM, cr.caName, time.Now().Add(11*365*24*time.Hour))
 	if err == nil {
 		t.Error("Generated cert has not expired when it should have")
 	}
@@ -99,17 +124,22 @@ func TestCAExpiry(t *testing.T) {
 }
 
 func TestSecretRoundTrip(t *testing.T) {
-	caArtifacts, err := createCACert()
+	cr := &certRotator{
+		caName:         caName,
+		caOrganization: caOrganization,
+		dnsName:        dnsName,
+	}
+	caArtifacts, err := cr.createCACert()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cert, key, err := createCertPEM(caArtifacts)
+	cert, key, err := cr.createCertPEM(caArtifacts)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !validServerCert(caArtifacts.CertPEM, cert, key) {
+	if !cr.validServerCert(caArtifacts.CertPEM, cert, key) {
 		t.Fatal("Generated cert is not valid")
 	}
 
@@ -120,25 +150,30 @@ func TestSecretRoundTrip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !validServerCert(art2.CertPEM, cert, key) {
+	if !cr.validServerCert(art2.CertPEM, cert, key) {
 		t.Fatal("Recovered cert is not valid")
 	}
 
-	cert2, key2, err := createCertPEM(art2)
+	cert2, key2, err := cr.createCertPEM(art2)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if !validServerCert(caArtifacts.CertPEM, cert2, key2) {
+	if !cr.validServerCert(caArtifacts.CertPEM, cert2, key2) {
 		t.Fatal("Second generated cert is not valid")
 	}
 }
 
 func TestEmptyIsInvalid(t *testing.T) {
-	if validServerCert([]byte{}, []byte{}, []byte{}) {
+	cr := &certRotator{
+		caName:         caName,
+		caOrganization: caOrganization,
+		dnsName:        dnsName,
+	}
+	if cr.validServerCert([]byte{}, []byte{}, []byte{}) {
 		t.Fatal("empty cert is valid")
 	}
-	if validCACert([]byte{}, []byte{}) {
+	if cr.validCACert([]byte{}, []byte{}) {
 		t.Fatal("empty CA cert is valid")
 	}
 }


### PR DESCRIPTION
Add new fields in CertRotator and ReconcileVWH structs to store previous
"Gatekeeper" constants and get rid of referencing global constants in the
code.

Refactor AddRotator() to take CertRotator and vwhName as parameters.
Pass all "Gatekeeper" constants from the caller instead.

Tested on a GKE cluster with "make test-e2e".