### PR TITLE
Allow for 'm' memory unit in examples

### DIFF
--- a/demo/agilebank/templates/k8scontainterlimits_template.yaml
+++ b/demo/agilebank/templates/k8scontainterlimits_template.yaml
@@ -64,6 +64,9 @@ spec:
         # 10 ** 3
         mem_multiple("K") = 1000 { true }
 
+        # 10 ** -3
+        mem_multiple("m") = 0.001 { true }
+
         # 10 ** 0
         mem_multiple("") = 1 { true }
 

--- a/demo/agilebank/templates/k8scontainterlimits_template.yaml
+++ b/demo/agilebank/templates/k8scontainterlimits_template.yaml
@@ -132,7 +132,7 @@ spec:
 
         canonify_mem(orig) = new {
           is_number(orig)
-          new := orig
+          new := orig * 1000
         }
 
         canonify_mem(orig) = new {

--- a/demo/agilebank/templates/k8scontainterlimits_template.yaml
+++ b/demo/agilebank/templates/k8scontainterlimits_template.yaml
@@ -46,47 +46,49 @@ spec:
           new := to_number(orig) * 1000
         }
 
+        # 10 ** 21
+        mem_multiple("E") = 1000000000000000000000 { true }
+
         # 10 ** 18
-        mem_multiple("E") = 1000000000000000000 { true }
+        mem_multiple("P") = 1000000000000000000 { true }
 
         # 10 ** 15
-        mem_multiple("P") = 1000000000000000 { true }
+        mem_multiple("T") = 1000000000000000 { true }
 
         # 10 ** 12
-        mem_multiple("T") = 1000000000000 { true }
+        mem_multiple("G") = 1000000000000 { true }
 
         # 10 ** 9
-        mem_multiple("G") = 1000000000 { true }
+        mem_multiple("M") = 1000000000 { true }
 
         # 10 ** 6
-        mem_multiple("M") = 1000000 { true }
+        mem_multiple("K") = 1000000 { true }
 
         # 10 ** 3
-        mem_multiple("K") = 1000 { true }
+        mem_multiple("") = 1000 { true }
 
-        # 10 ** -3
-        mem_multiple("m") = 0.001 { true }
-
+        # Kubernetes accepts millibyte precision when it probably shouldn't.
+        # https://github.com/kubernetes/kubernetes/issues/28741
         # 10 ** 0
-        mem_multiple("") = 1 { true }
+        mem_multiple("m") = 1 { true }
 
-        # 2 ** 10
-        mem_multiple("Ki") = 1024 { true }
+        # 1000 * 2 ** 10
+        mem_multiple("Ki") = 1024000 { true }
 
-        # 2 ** 20
-        mem_multiple("Mi") = 1048576 { true }
+        # 1000 * 2 ** 20
+        mem_multiple("Mi") = 1048576000 { true }
 
-        # 2 ** 30
-        mem_multiple("Gi") = 1073741824 { true }
+        # 1000 * 2 ** 30
+        mem_multiple("Gi") = 1073741824000 { true }
 
-        # 2 ** 40
-        mem_multiple("Ti") = 1099511627776 { true }
+        # 1000 * 2 ** 40
+        mem_multiple("Ti") = 1099511627776000 { true }
 
-        # 2 ** 50
-        mem_multiple("Pi") = 1125899906842624 { true }
+        # 1000 * 2 ** 50
+        mem_multiple("Pi") = 1125899906842624000 { true }
 
-        # 2 ** 60
-        mem_multiple("Ei") = 1152921504606846976 { true }
+        # 1000 * 2 ** 60
+        mem_multiple("Ei") = 1152921504606846976000 { true }
 
         get_suffix(mem) = suffix {
           not is_string(mem)

--- a/library/general/containerlimits/src.rego
+++ b/library/general/containerlimits/src.rego
@@ -112,7 +112,7 @@ get_suffix(mem) = suffix {
 
 canonify_mem(orig) = new {
   is_number(orig)
-  new := orig
+  new := orig * 1000
 }
 
 canonify_mem(orig) = new {

--- a/library/general/containerlimits/src.rego
+++ b/library/general/containerlimits/src.rego
@@ -44,6 +44,9 @@ mem_multiple("M") = 1000000 { true }
 # 10 ** 3
 mem_multiple("K") = 1000 { true }
 
+# 10 ** -3
+mem_multiple("m") = 0.001 { true }
+
 # 10 ** 0
 mem_multiple("") = 1 { true }
 

--- a/library/general/containerlimits/src.rego
+++ b/library/general/containerlimits/src.rego
@@ -26,47 +26,49 @@ canonify_cpu(orig) = new {
   new := to_number(orig) * 1000
 }
 
+# 10 ** 21
+mem_multiple("E") = 1000000000000000000000 { true }
+
 # 10 ** 18
-mem_multiple("E") = 1000000000000000000 { true }
+mem_multiple("P") = 1000000000000000000 { true }
 
 # 10 ** 15
-mem_multiple("P") = 1000000000000000 { true }
+mem_multiple("T") = 1000000000000000 { true }
 
 # 10 ** 12
-mem_multiple("T") = 1000000000000 { true }
+mem_multiple("G") = 1000000000000 { true }
 
 # 10 ** 9
-mem_multiple("G") = 1000000000 { true }
+mem_multiple("M") = 1000000000 { true }
 
 # 10 ** 6
-mem_multiple("M") = 1000000 { true }
+mem_multiple("K") = 1000000 { true }
 
 # 10 ** 3
-mem_multiple("K") = 1000 { true }
+mem_multiple("") = 1000 { true }
 
-# 10 ** -3
-mem_multiple("m") = 0.001 { true }
-
+# Kubernetes accepts millibyte precision when it probably shouldn't.
+# https://github.com/kubernetes/kubernetes/issues/28741
 # 10 ** 0
-mem_multiple("") = 1 { true }
+mem_multiple("m") = 1 { true }
 
-# 2 ** 10
-mem_multiple("Ki") = 1024 { true }
+# 1000 * 2 ** 10
+mem_multiple("Ki") = 1024000 { true }
 
-# 2 ** 20
-mem_multiple("Mi") = 1048576 { true }
+# 1000 * 2 ** 20
+mem_multiple("Mi") = 1048576000 { true }
 
-# 2 ** 30
-mem_multiple("Gi") = 1073741824 { true }
+# 1000 * 2 ** 30
+mem_multiple("Gi") = 1073741824000 { true }
 
-# 2 ** 40
-mem_multiple("Ti") = 1099511627776 { true }
+# 1000 * 2 ** 40
+mem_multiple("Ti") = 1099511627776000 { true }
 
-# 2 ** 50
-mem_multiple("Pi") = 1125899906842624 { true }
+# 1000 * 2 ** 50
+mem_multiple("Pi") = 1125899906842624000 { true }
 
-# 2 ** 60
-mem_multiple("Ei") = 1152921504606846976 { true }
+# 1000 * 2 ** 60
+mem_multiple("Ei") = 1152921504606846976000 { true }
 
 get_suffix(mem) = suffix {
   not is_string(mem)

--- a/library/general/containerlimits/src_test.rego
+++ b/library/general/containerlimits/src_test.rego
@@ -102,13 +102,13 @@ test_input_no_violations_mem_K {
     results := violation with input as input
     count(results) == 0
 }
-test_input_violations_mem_K {
-    input := {"review": review([ctr("a", "1K", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
+test_input_violations_mem_m {
+    input := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "1m", "cpu": "4"}}
     results := violation with input as input
     count(results) == 1
 }
-test_input_violations_mem_m {
-    input := {"review": review([ctr("a", "1000000m", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
+test_input_violations_mem_K {
+    input := {"review": review([ctr("a", "1K", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
     results := violation with input as input
     count(results) == 1
 }

--- a/library/general/containerlimits/src_test.rego
+++ b/library/general/containerlimits/src_test.rego
@@ -107,6 +107,11 @@ test_input_violations_mem_K {
     results := violation with input as input
     count(results) == 1
 }
+test_input_violations_mem_m {
+    input := {"review": review([ctr("a", "1000000m", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
+    results := violation with input as input
+    count(results) == 1
+}
 test_input_violations_mem_M {
     input := {"review": review([ctr("a", "1M", "2")]), "parameters": {"memory": "1K", "cpu": "4"}}
     results := violation with input as input

--- a/library/general/containerlimits/src_test.rego
+++ b/library/general/containerlimits/src_test.rego
@@ -25,6 +25,13 @@ test_input_violations_int {
     results := violation with input as input
     count(results) == 2
 }
+
+test_input_violations_mem_int_v_str {
+    input := {"review": review([ctr("a", 10, "4")]), "parameters": {"memory": "1000m", "cpu": "4"}}
+    results := violation with input as input
+    count(results) == 1
+}
+
 test_input_violations_str {
     input := {"review": review([ctr("a", "10", "20")]), "parameters": {"memory": "5", "cpu": "10"}}
     results := violation with input as input

--- a/library/general/containerlimits/template.yaml
+++ b/library/general/containerlimits/template.yaml
@@ -64,6 +64,9 @@ spec:
         # 10 ** 3
         mem_multiple("K") = 1000 { true }
 
+        # 10 ** -3
+        mem_multiple("m") = 0.001 { true }
+
         # 10 ** 0
         mem_multiple("") = 1 { true }
 

--- a/library/general/containerlimits/template.yaml
+++ b/library/general/containerlimits/template.yaml
@@ -132,7 +132,7 @@ spec:
 
         canonify_mem(orig) = new {
           is_number(orig)
-          new := orig
+          new := orig * 1000
         }
 
         canonify_mem(orig) = new {

--- a/library/general/containerlimits/template.yaml
+++ b/library/general/containerlimits/template.yaml
@@ -46,47 +46,49 @@ spec:
           new := to_number(orig) * 1000
         }
 
+        # 10 ** 21
+        mem_multiple("E") = 1000000000000000000000 { true }
+
         # 10 ** 18
-        mem_multiple("E") = 1000000000000000000 { true }
+        mem_multiple("P") = 1000000000000000000 { true }
 
         # 10 ** 15
-        mem_multiple("P") = 1000000000000000 { true }
+        mem_multiple("T") = 1000000000000000 { true }
 
         # 10 ** 12
-        mem_multiple("T") = 1000000000000 { true }
+        mem_multiple("G") = 1000000000000 { true }
 
         # 10 ** 9
-        mem_multiple("G") = 1000000000 { true }
+        mem_multiple("M") = 1000000000 { true }
 
         # 10 ** 6
-        mem_multiple("M") = 1000000 { true }
+        mem_multiple("K") = 1000000 { true }
 
         # 10 ** 3
-        mem_multiple("K") = 1000 { true }
+        mem_multiple("") = 1000 { true }
 
-        # 10 ** -3
-        mem_multiple("m") = 0.001 { true }
-
+        # Kubernetes accepts millibyte precision when it probably shouldn't.
+        # https://github.com/kubernetes/kubernetes/issues/28741
         # 10 ** 0
-        mem_multiple("") = 1 { true }
+        mem_multiple("m") = 1 { true }
 
-        # 2 ** 10
-        mem_multiple("Ki") = 1024 { true }
+        # 1000 * 2 ** 10
+        mem_multiple("Ki") = 1024000 { true }
 
-        # 2 ** 20
-        mem_multiple("Mi") = 1048576 { true }
+        # 1000 * 2 ** 20
+        mem_multiple("Mi") = 1048576000 { true }
 
-        # 2 ** 30
-        mem_multiple("Gi") = 1073741824 { true }
+        # 1000 * 2 ** 30
+        mem_multiple("Gi") = 1073741824000 { true }
 
-        # 2 ** 40
-        mem_multiple("Ti") = 1099511627776 { true }
+        # 1000 * 2 ** 40
+        mem_multiple("Ti") = 1099511627776000 { true }
 
-        # 2 ** 50
-        mem_multiple("Pi") = 1125899906842624 { true }
+        # 1000 * 2 ** 50
+        mem_multiple("Pi") = 1125899906842624000 { true }
 
-        # 2 ** 60
-        mem_multiple("Ei") = 1152921504606846976 { true }
+        # 1000 * 2 ** 60
+        mem_multiple("Ei") = 1152921504606846976000 { true }
 
         get_suffix(mem) = suffix {
           not is_string(mem)

--- a/library/general/containerresourceratios/src.rego
+++ b/library/general/containerresourceratios/src.rego
@@ -119,7 +119,7 @@ get_suffix(mem) = suffix {
 
 canonify_mem(orig) = new {
   is_number(orig)
-  new := orig
+  new := orig * 1000
 }
 
 canonify_mem(orig) = new {

--- a/library/general/containerresourceratios/src.rego
+++ b/library/general/containerresourceratios/src.rego
@@ -51,6 +51,9 @@ mem_multiple("M") = 1000000 { true }
 # 10 ** 3
 mem_multiple("K") = 1000 { true }
 
+# 10 ** -3
+mem_multiple("m") = 0.001 { true }
+
 # 10 ** 0
 mem_multiple("") = 1 { true }
 
@@ -210,7 +213,7 @@ general_violation[{"msg": msg, "field": field}] {
   cpu_requests_orig := container.resources.requests.cpu
   cpu_requests := canonify_cpu(cpu_requests_orig)
   cpu_ratio := input.parameters.ratio
-  to_number(cpu_limits) > to_number(cpu_ratio) * to_number(cpu_requests)  
+  to_number(cpu_limits) > to_number(cpu_ratio) * to_number(cpu_requests)
   msg := sprintf("container <%v> cpu limit <%v> is higher than the maximum allowed ratio of <%v>", [container.name, cpu_limits_orig, cpu_ratio])
 }
 

--- a/library/general/containerresourceratios/src.rego
+++ b/library/general/containerresourceratios/src.rego
@@ -33,47 +33,49 @@ canonify_cpu(orig) = new {
   new := to_number(orig) * 1000
 }
 
+# 10 ** 21
+mem_multiple("E") = 1000000000000000000000 { true }
+
 # 10 ** 18
-mem_multiple("E") = 1000000000000000000 { true }
+mem_multiple("P") = 1000000000000000000 { true }
 
 # 10 ** 15
-mem_multiple("P") = 1000000000000000 { true }
+mem_multiple("T") = 1000000000000000 { true }
 
 # 10 ** 12
-mem_multiple("T") = 1000000000000 { true }
+mem_multiple("G") = 1000000000000 { true }
 
 # 10 ** 9
-mem_multiple("G") = 1000000000 { true }
+mem_multiple("M") = 1000000000 { true }
 
 # 10 ** 6
-mem_multiple("M") = 1000000 { true }
+mem_multiple("K") = 1000000 { true }
 
 # 10 ** 3
-mem_multiple("K") = 1000 { true }
+mem_multiple("") = 1000 { true }
 
-# 10 ** -3
-mem_multiple("m") = 0.001 { true }
-
+# Kubernetes accepts millibyte precision when it probably shouldn't.
+# https://github.com/kubernetes/kubernetes/issues/28741
 # 10 ** 0
-mem_multiple("") = 1 { true }
+mem_multiple("m") = 1 { true }
 
-# 2 ** 10
-mem_multiple("Ki") = 1024 { true }
+# 1000 * 2 ** 10
+mem_multiple("Ki") = 1024000 { true }
 
-# 2 ** 20
-mem_multiple("Mi") = 1048576 { true }
+# 1000 * 2 ** 20
+mem_multiple("Mi") = 1048576000 { true }
 
-# 2 ** 30
-mem_multiple("Gi") = 1073741824 { true }
+# 1000 * 2 ** 30
+mem_multiple("Gi") = 1073741824000 { true }
 
-# 2 ** 40
-mem_multiple("Ti") = 1099511627776 { true }
+# 1000 * 2 ** 40
+mem_multiple("Ti") = 1099511627776000 { true }
 
-# 2 ** 50
-mem_multiple("Pi") = 1125899906842624 { true }
+# 1000 * 2 ** 50
+mem_multiple("Pi") = 1125899906842624000 { true }
 
-# 2 ** 60
-mem_multiple("Ei") = 1152921504606846976 { true }
+# 1000 * 2 ** 60
+mem_multiple("Ei") = 1152921504606846976000 { true }
 
 get_suffix(mem) = suffix {
   not is_string(mem)

--- a/library/general/containerresourceratios/src_test.rego
+++ b/library/general/containerresourceratios/src_test.rego
@@ -36,6 +36,12 @@ test_input_violations_int {
     trace(sprintf("results - <%v>", [results]))
     count(results) == 2
 }
+test_input_violations_mem_int_v_str {
+    input := {"review": review([ctr("a", 1, "3", "1m", "1.5")]), "parameters": {"ratio": "2"}}
+    results := violation with input as input
+    trace(sprintf("results - <%v>", [results]))
+    count(results) == 1
+}
 test_input_violations_str {
     input := {"review": review([ctr("a", "10", "20", "2", "4")]), "parameters": {"ratio": "2"}}
     results := violation with input as input

--- a/library/general/containerresourceratios/src_test.rego
+++ b/library/general/containerresourceratios/src_test.rego
@@ -158,6 +158,11 @@ test_input_violations_mem_K {
     results := violation with input as input
     count(results) == 1
 }
+test_input_violations_mem_m {
+    input := {"review": review([ctr("a", "1000000m", "2", "1", "2")]), "parameters": {"ratio": "4"}}
+    results := violation with input as input
+    count(results) == 1
+}
 test_input_violations_mem_M {
     input := {"review": review([ctr("a", "1M", "2", "1K", "2")]), "parameters": {"ratio": "4"}}
     results := violation with input as input

--- a/library/general/containerresourceratios/src_test.rego
+++ b/library/general/containerresourceratios/src_test.rego
@@ -159,7 +159,7 @@ test_input_violations_mem_K {
     count(results) == 1
 }
 test_input_violations_mem_m {
-    input := {"review": review([ctr("a", "1000000m", "2", "1", "2")]), "parameters": {"ratio": "4"}}
+    input := {"review": review([ctr("a", "1", "2", "1m", "2")]), "parameters": {"ratio": "4"}}
     results := violation with input as input
     count(results) == 1
 }

--- a/library/general/containerresourceratios/template.yaml
+++ b/library/general/containerresourceratios/template.yaml
@@ -135,7 +135,7 @@ spec:
         
         canonify_mem(orig) = new {
           is_number(orig)
-          new := orig
+          new := orig * 1000
         }
         
         canonify_mem(orig) = new {

--- a/library/general/containerresourceratios/template.yaml
+++ b/library/general/containerresourceratios/template.yaml
@@ -67,6 +67,9 @@ spec:
         # 10 ** 3
         mem_multiple("K") = 1000 { true }
         
+        # 10 ** -3
+        mem_multiple("m") = 0.001 { true }
+        
         # 10 ** 0
         mem_multiple("") = 1 { true }
         

--- a/library/general/containerresourceratios/template.yaml
+++ b/library/general/containerresourceratios/template.yaml
@@ -49,47 +49,49 @@ spec:
           new := to_number(orig) * 1000
         }
         
+        # 10 ** 21
+        mem_multiple("E") = 1000000000000000000000 { true }
+        
         # 10 ** 18
-        mem_multiple("E") = 1000000000000000000 { true }
+        mem_multiple("P") = 1000000000000000000 { true }
         
         # 10 ** 15
-        mem_multiple("P") = 1000000000000000 { true }
+        mem_multiple("T") = 1000000000000000 { true }
         
         # 10 ** 12
-        mem_multiple("T") = 1000000000000 { true }
+        mem_multiple("G") = 1000000000000 { true }
         
         # 10 ** 9
-        mem_multiple("G") = 1000000000 { true }
+        mem_multiple("M") = 1000000000 { true }
         
         # 10 ** 6
-        mem_multiple("M") = 1000000 { true }
+        mem_multiple("K") = 1000000 { true }
         
         # 10 ** 3
-        mem_multiple("K") = 1000 { true }
+        mem_multiple("") = 1000 { true }
         
-        # 10 ** -3
-        mem_multiple("m") = 0.001 { true }
-        
+        # Kubernetes accepts millibyte precision when it probably shouldn't.
+        # https://github.com/kubernetes/kubernetes/issues/28741
         # 10 ** 0
-        mem_multiple("") = 1 { true }
+        mem_multiple("m") = 1 { true }
         
-        # 2 ** 10
-        mem_multiple("Ki") = 1024 { true }
+        # 1000 * 2 ** 10
+        mem_multiple("Ki") = 1024000 { true }
         
-        # 2 ** 20
-        mem_multiple("Mi") = 1048576 { true }
+        # 1000 * 2 ** 20
+        mem_multiple("Mi") = 1048576000 { true }
         
-        # 2 ** 30
-        mem_multiple("Gi") = 1073741824 { true }
+        # 1000 * 2 ** 30
+        mem_multiple("Gi") = 1073741824000 { true }
         
-        # 2 ** 40
-        mem_multiple("Ti") = 1099511627776 { true }
+        # 1000 * 2 ** 40
+        mem_multiple("Ti") = 1099511627776000 { true }
         
-        # 2 ** 50
-        mem_multiple("Pi") = 1125899906842624 { true }
+        # 1000 * 2 ** 50
+        mem_multiple("Pi") = 1125899906842624000 { true }
         
-        # 2 ** 60
-        mem_multiple("Ei") = 1152921504606846976 { true }
+        # 1000 * 2 ** 60
+        mem_multiple("Ei") = 1152921504606846976000 { true }
         
         get_suffix(mem) = suffix {
           not is_string(mem)

--- a/test/bats/tests/templates/k8scontainterlimits_template.yaml
+++ b/test/bats/tests/templates/k8scontainterlimits_template.yaml
@@ -117,7 +117,7 @@ spec:
 
           canonify_mem(orig) = new {
             is_number(orig)
-            new := orig
+            new := orig * 1000
           }
 
           canonify_mem(orig) = new {

--- a/test/bats/tests/templates/k8scontainterlimits_template.yaml
+++ b/test/bats/tests/templates/k8scontainterlimits_template.yaml
@@ -47,47 +47,49 @@ spec:
             new := to_number(orig) * 1000
           }
 
+          # 10 ** 21
+          mem_multiple("E") = 1000000000000000000000 { true }
+
           # 10 ** 18
-          mem_multiple("E") = 1000000000000000000 { true }
+          mem_multiple("P") = 1000000000000000000 { true }
 
           # 10 ** 15
-          mem_multiple("P") = 1000000000000000 { true }
+          mem_multiple("T") = 1000000000000000 { true }
 
           # 10 ** 12
-          mem_multiple("T") = 1000000000000 { true }
+          mem_multiple("G") = 1000000000000 { true }
 
           # 10 ** 9
-          mem_multiple("G") = 1000000000 { true }
+          mem_multiple("M") = 1000000000 { true }
 
           # 10 ** 6
-          mem_multiple("M") = 1000000 { true }
+          mem_multiple("K") = 1000000 { true }
 
           # 10 ** 3
-          mem_multiple("K") = 1000 { true }
+          mem_multiple("") = 1000 { true }
 
-          # 10 ** -3
-          mem_multiple("m") = 0.001 { true }
-
+          # Kubernetes accepts millibyte precision when it probably shouldn't.
+          # https://github.com/kubernetes/kubernetes/issues/28741
           # 10 ** 0
-          mem_multiple("") = 1 { true }
+          mem_multiple("m") = 1 { true }
 
-          # 2 ** 10
-          mem_multiple("Ki") = 1024 { true }
+          # 1000 * 2 ** 10
+          mem_multiple("Ki") = 1024000 { true }
 
-          # 2 ** 20
-          mem_multiple("Mi") = 1048576 { true }
+          # 1000 * 2 ** 20
+          mem_multiple("Mi") = 1048576000 { true }
 
-          # 2 ** 30
-          mem_multiple("Gi") = 1073741824 { true }
+          # 1000 * 2 ** 30
+          mem_multiple("Gi") = 1073741824000 { true }
 
-          # 2 ** 40
-          mem_multiple("Ti") = 1099511627776 { true }
+          # 1000 * 2 ** 40
+          mem_multiple("Ti") = 1099511627776000 { true }
 
-          # 2 ** 50
-          mem_multiple("Pi") = 1125899906842624 { true }
+          # 1000 * 2 ** 50
+          mem_multiple("Pi") = 1125899906842624000 { true }
 
-          # 2 ** 60
-          mem_multiple("Ei") = 1152921504606846976 { true }
+          # 1000 * 2 ** 60
+          mem_multiple("Ei") = 1152921504606846976000 { true }
 
           get_suffix(mem) = suffix {
             not is_string(mem)

--- a/test/bats/tests/templates/k8scontainterlimits_template.yaml
+++ b/test/bats/tests/templates/k8scontainterlimits_template.yaml
@@ -65,6 +65,9 @@ spec:
           # 10 ** 3
           mem_multiple("K") = 1000 { true }
 
+          # 10 ** -3
+          mem_multiple("m") = 0.001 { true }
+
           # 10 ** 0
           mem_multiple("") = 1 { true }
 


### PR DESCRIPTION
## What
It's possible for memory resources to be represented with the `m` unit. This causes problems for the examples listed in this repo which parse memory, since they are unaware of how to convert from this unit.

For example creating the following deployment results in pods with a resource limit and request of `1288490188800m`.

```YAML
apiVersion: apps/v1
kind: Deployment
metadata:
  name: foobar
  labels:
    app: nginx
spec:
  replicas: 3
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:1.14.2
        ports:
        - containerPort: 80
        resources:
          limits:
            cpu: "1"
            memory: 1.2Gi
          requests:
            cpu: "10m"
            memory: 1.2Gi
```