### PR TITLE
Sync cert generation before tearing down the manager

### DIFF
--- a/main.go
+++ b/main.go
@@ -241,12 +241,18 @@ func main() {
 	templatesCleaned := make(chan struct{})
 	go constrainttemplate.TearDownState(cli, templatesCleaned)
 
+	// Make sure certs are generated and valid.
+	certsValid := make(chan struct{})
+	go webhook.EnsureValidCerts(cli, certsValid)
+
 	<-syncCleaned
 	<-templatesCleaned
 	setupLog.Info("state cleaned")
+
+	<-certsValid
+	setupLog.Info("valid certs created")
+
 	if hadError {
-		/// give the cert manager time to generate the cert
-		time.Sleep(5 * time.Second)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Add a goroutine to check cert generation and validity to block the
teardown of the manager until certs are valid. This replaces the
current 5s-sleep before tearing down the manager.

Tested on a GKE cluster with "make test-e2e"

Fixes #465 