### PR TITLE
Sync cert generation before tearing down the manager

### DIFF
--- a/main.go
+++ b/main.go
@@ -241,12 +241,18 @@ func main() {
 	templatesCleaned := make(chan struct{})
 	go constrainttemplate.TearDownState(cli, templatesCleaned)
 
+	// Make sure certs are generated and valid.
+	certsValid := make(chan struct{})
+	go webhook.EnsureValidCerts(cli, certsValid)
+
 	<-syncCleaned
 	<-templatesCleaned
 	setupLog.Info("state cleaned")
+
+	<-certsValid
+	setupLog.Info("valid certs created")
+
 	if hadError {
-		/// give the cert manager time to generate the cert
-		time.Sleep(5 * time.Second)
 		os.Exit(1)
 	}
 }

--- a/pkg/webhook/certs.go
+++ b/pkg/webhook/certs.go
@@ -492,3 +492,30 @@ func (r *ReconcileVWH) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 	return reconcile.Result{}, nil
 }
+
+// EnsureValidCerts ensure the certs are created and valid.
+func EnsureValidCerts(c client.Client, valid chan struct{}) {
+	defer close(valid)
+	checkFn := func() (bool, error) {
+		secret := &corev1.Secret{}
+		if err := c.Get(context.Background(), secretKey, secret); err != nil {
+			crLog.Error(err, "while retrieving secret")
+			return false, nil
+		}
+		if secret.Data == nil {
+			return false, nil
+		}
+		if validCACert(secret.Data[caCertName], secret.Data[caKeyName]) && validServerCert(secret.Data[caCertName], secret.Data[certName], secret.Data[keyName]) {
+			return true, nil
+		}
+		return false, nil
+	}
+	if err := wait.ExponentialBackoff(wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   2,
+		Jitter:   1,
+		Steps:    10,
+	}, checkFn); err != nil {
+		log.Error(err, "max retries for checking certs validity")
+	}
+}


### PR DESCRIPTION
Add a goroutine to check cert generation and validity to block the
teardown of the manager until certs are valid. This replaces the
current 5s-sleep before tearing down the manager.

Tested on a GKE cluster with "make test-e2e"

Fixes #465 