### PR TITLE
Decrease verbosity of ReconcileSync logging

### DIFF
--- a/pkg/controller/sync/sync_controller.go
+++ b/pkg/controller/sync/sync_controller.go
@@ -123,7 +123,14 @@ func (r *ReconcileSync) Reconcile(request reconcile.Request) (reconcile.Result, 
 		return reconcile.Result{}, nil
 	}
 
-	r.log.V(logging.DebugLevel).Info("data will be added", "data", instance)
+	r.log.V(logging.DebugLevel).Info(
+		"data will be added",
+		logging.ResourceAPIVersion, instance.GetAPIVersion(),
+		logging.ResourceKind, instance.GetKind(),
+		logging.ResourceNamespace, instance.GetNamespace(),
+		logging.ResourceName, instance.GetName(),
+	)
+
 	if _, err := r.opa.AddData(context.Background(), instance); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -13,6 +13,7 @@ const (
 	AuditID              = "audit_id"
 	ConstraintViolations = "constraint_violations"
 	ResourceKind         = "resource_kind"
+	ResourceAPIVersion   = "resource_api_version"
 	ResourceNamespace    = "resource_namespace"
 	ResourceName         = "resource_name"
 	DebugLevel           = 2 // r.log.Debug(foo) == r.log.V(logging.DebugLevel).Info(foo)


### PR DESCRIPTION
## What
Lower the verbosity of the ReconcileSync logging (to avoid logging sensitive information).

https://github.com/open-policy-agent/gatekeeper/issues/574