### PR TITLE
Ensure AppArmor rego throws violations as expected

### DIFF
--- a/library/pod-security-policy/apparmor/src.rego
+++ b/library/pod-security-policy/apparmor/src.rego
@@ -2,15 +2,14 @@ package k8spspapparmor
 
 violation[{"msg": msg, "details": {}}] {
     metadata := input.review.object.metadata
-    not input_apparmor_allowed(metadata)
-    msg := sprintf("AppArmor profile is not allowed, pod: %v. Allowed profiles: %v", [input.review.object.metadata.name, input.parameters.allowedProfiles])
+    container := input_containers[_]
+    not input_apparmor_allowed(container, metadata)
+    msg := sprintf("AppArmor profile is not allowed, pod: %v, container: %v. Allowed profiles: %v", [input.review.object.metadata.name, container.name, input.parameters.allowedProfiles])
 }
 
-input_apparmor_allowed(metadata) {
+input_apparmor_allowed(container, metadata) {
     metadata.annotations[key] == input.parameters.allowedProfiles[_]
-    startswith(key, "container.apparmor.security.beta.kubernetes.io/")
-    [prefix, name] := split(key, "/")
-    name == input_containers[_].name
+    key == sprintf("container.apparmor.security.beta.kubernetes.io/%v", [container.name])
 }
 
 input_containers[c] {

--- a/library/pod-security-policy/apparmor/src_test.rego
+++ b/library/pod-security-policy/apparmor/src_test.rego
@@ -3,13 +3,19 @@ package k8spspapparmor
 test_input_apparmor_allowed_empty {
     input := { "review": input_review_container, "parameters": input_parameters_empty}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 1
+}
+
+test_input_apparmor_not_allowed_no_annotation_empty {
+    input := { "review": input_review_no_annotation, "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 1
 }
 
 test_input_apparmor_not_allowed_no_annotation {
     input := { "review": input_review_no_annotation, "parameters": input_parameters_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 1
 }
 
 test_input_apparmor_container_allowed_in_list {
@@ -21,7 +27,7 @@ test_input_apparmor_container_allowed_in_list {
 test_input_apparmor_container_not_allowed_not_in_list {
     input := { "review": input_review_container, "parameters": input_parameters_not_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 1
 }
 
 test_input_apparmor_containers_allowed_in_list {
@@ -33,7 +39,25 @@ test_input_apparmor_containers_allowed_in_list {
 test_input_apparmor_containers_not_allowed_not_in_list {
     input := { "review": input_review_containers, "parameters": input_parameters_not_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 2
+}
+
+test_input_apparmor_containers_allowed_in_list_mixed_no_annotation {
+    input := { "review": input_review_containers_missing_annotation, "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_apparmor_containers_not_allowed_not_in_list_mixed_no_annotation {
+    input := { "review": input_review_containers_missing_annotation, "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_input_apparmor_containers_not_allowed_not_in_list_mixed {
+    input := { "review": input_review_containers_mixed, "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 1
 }
 
 input_review_container = {
@@ -47,26 +71,6 @@ input_review_container = {
         "spec": {
             "containers": [{
                 "name": "nginx",
-                "image": "nginx"
-            }]
-        }
-    }
-}
-
-input_review_containers = {
-    "object": {
-        "metadata": {
-            "name": "nginx",
-            "annotations": {
-                "container.apparmor.security.beta.kubernetes.io/nginx2": "runtime/default"
-            }
-        },
-        "spec": {
-            "containers": [{
-                "name": "nginx",
-                "image": "nginx"
-            },{
-                "name": "nginx2",
                 "image": "nginx"
             }]
         }
@@ -88,14 +92,60 @@ input_review_no_annotation = {
     }
 }
 
-input_parameters_empty = {
-    "allowedProfiles": []
+input_review_containers = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "container.apparmor.security.beta.kubernetes.io/nginx": "runtime/default",
+                "container.apparmor.security.beta.kubernetes.io/nginx2": "runtime/default"
+            }
+        },
+        "spec": {
+            "containers": two_containers
+        }
+    }
 }
 
-input_parameters_wildcard = {
-    "allowedProfiles": [
-        "*"
-    ]
+input_review_containers_missing_annotation = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "container.apparmor.security.beta.kubernetes.io/nginx": "runtime/default"
+            }
+        },
+        "spec": {
+            "containers": two_containers
+        }
+    }
+}
+
+input_review_containers_mixed = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "container.apparmor.security.beta.kubernetes.io/nginx": "runtime/default",
+                "container.apparmor.security.beta.kubernetes.io/nginx2": "unconfined"
+            }
+        },
+        "spec": {
+            "containers": two_containers
+        }
+    }
+}
+
+two_containers = [{
+    "name": "nginx",
+    "image": "nginx"
+},{
+    "name": "nginx2",
+    "image": "nginx"
+}]
+
+input_parameters_empty = {
+    "allowedProfiles": []
 }
 
 input_parameters_in_list = {

--- a/library/pod-security-policy/apparmor/template.yaml
+++ b/library/pod-security-policy/apparmor/template.yaml
@@ -22,15 +22,14 @@ spec:
 
         violation[{"msg": msg, "details": {}}] {
             metadata := input.review.object.metadata
-            not input_apparmor_allowed(metadata)
-            msg := sprintf("AppArmor profile is not allowed, pod: %v. Allowed profiles: %v", [input.review.object.metadata.name, input.parameters.allowedProfiles])
+            container := input_containers[_]
+            not input_apparmor_allowed(container, metadata)
+            msg := sprintf("AppArmor profile is not allowed, container: %v. Allowed profiles: %v", [input.review.object.metadata.name, container.name, input.parameters.allowedProfiles])
         }
 
-        input_apparmor_allowed(metadata) {
+        input_apparmor_allowed(container, metadata) {
             metadata.annotations[key] == input.parameters.allowedProfiles[_]
-            startswith(key, "container.apparmor.security.beta.kubernetes.io/")
-            [prefix, name] := split(key, "/")
-            name == input_containers[_].name
+            key == sprintf("container.apparmor.security.beta.kubernetes.io/%v", [container.name])
         }
 
         input_containers[c] {

--- a/library/pod-security-policy/apparmor/template.yaml
+++ b/library/pod-security-policy/apparmor/template.yaml
@@ -24,7 +24,7 @@ spec:
             metadata := input.review.object.metadata
             container := input_containers[_]
             not input_apparmor_allowed(container, metadata)
-            msg := sprintf("AppArmor profile is not allowed, container: %v. Allowed profiles: %v", [input.review.object.metadata.name, container.name, input.parameters.allowedProfiles])
+            msg := sprintf("AppArmor profile is not allowed, pod: %v, container: %v. Allowed profiles: %v", [input.review.object.metadata.name, container.name, input.parameters.allowedProfiles])
         }
 
         input_apparmor_allowed(container, metadata) {


### PR DESCRIPTION
Fixes an issue with the AppArmor rego.

A pod was considered valid if only one container had a valid AppArmor profile and other containers did not. Now each container is considered separately.