### PR TITLE
Use "k" instead of "K" for mem parsing

### DIFF
--- a/demo/agilebank/templates/k8scontainterlimits_template.yaml
+++ b/demo/agilebank/templates/k8scontainterlimits_template.yaml
@@ -62,7 +62,7 @@ spec:
         mem_multiple("M") = 1000000000 { true }
 
         # 10 ** 6
-        mem_multiple("K") = 1000000 { true }
+        mem_multiple("k") = 1000000 { true }
 
         # 10 ** 3
         mem_multiple("") = 1000 { true }

--- a/library/general/containerlimits/src.rego
+++ b/library/general/containerlimits/src.rego
@@ -42,7 +42,7 @@ mem_multiple("G") = 1000000000000 { true }
 mem_multiple("M") = 1000000000 { true }
 
 # 10 ** 6
-mem_multiple("K") = 1000000 { true }
+mem_multiple("k") = 1000000 { true }
 
 # 10 ** 3
 mem_multiple("") = 1000 { true }

--- a/library/general/containerlimits/src_test.rego
+++ b/library/general/containerlimits/src_test.rego
@@ -105,7 +105,7 @@ test_init_containers_checked {
 
 # MEM SCALE TESTS
 test_input_no_violations_mem_K {
-    input := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "1K", "cpu": "4"}}
+    input := {"review": review([ctr("a", "1", "2")]), "parameters": {"memory": "1k", "cpu": "4"}}
     results := violation with input as input
     count(results) == 0
 }
@@ -115,12 +115,12 @@ test_input_violations_mem_m {
     count(results) == 1
 }
 test_input_violations_mem_K {
-    input := {"review": review([ctr("a", "1K", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
+    input := {"review": review([ctr("a", "1k", "2")]), "parameters": {"memory": "1", "cpu": "4"}}
     results := violation with input as input
     count(results) == 1
 }
 test_input_violations_mem_M {
-    input := {"review": review([ctr("a", "1M", "2")]), "parameters": {"memory": "1K", "cpu": "4"}}
+    input := {"review": review([ctr("a", "1M", "2")]), "parameters": {"memory": "1k", "cpu": "4"}}
     results := violation with input as input
     count(results) == 1
 }

--- a/library/general/containerlimits/template.yaml
+++ b/library/general/containerlimits/template.yaml
@@ -62,7 +62,7 @@ spec:
         mem_multiple("M") = 1000000000 { true }
 
         # 10 ** 6
-        mem_multiple("K") = 1000000 { true }
+        mem_multiple("k") = 1000000 { true }
 
         # 10 ** 3
         mem_multiple("") = 1000 { true }

--- a/library/general/containerresourceratios/src.rego
+++ b/library/general/containerresourceratios/src.rego
@@ -49,7 +49,7 @@ mem_multiple("G") = 1000000000000 { true }
 mem_multiple("M") = 1000000000 { true }
 
 # 10 ** 6
-mem_multiple("K") = 1000000 { true }
+mem_multiple("k") = 1000000 { true }
 
 # 10 ** 3
 mem_multiple("") = 1000 { true }

--- a/library/general/containerresourceratios/src_test.rego
+++ b/library/general/containerresourceratios/src_test.rego
@@ -155,12 +155,12 @@ test_init_containers_checked {
 }
 # MEM SCALE TESTS
 test_input_no_violations_mem_K {
-    input := {"review": review([ctr("a", "1K", "2", "1K", "2")]), "parameters": {"ratio": "4"}}
+    input := {"review": review([ctr("a", "1k", "2", "1k", "2")]), "parameters": {"ratio": "4"}}
     results := violation with input as input
     count(results) == 0
 }
 test_input_violations_mem_K {
-    input := {"review": review([ctr("a", "4K", "2", "1K", "2")]), "parameters": {"ratio": "2"}}
+    input := {"review": review([ctr("a", "4k", "2", "1k", "2")]), "parameters": {"ratio": "2"}}
     results := violation with input as input
     count(results) == 1
 }
@@ -170,7 +170,7 @@ test_input_violations_mem_m {
     count(results) == 1
 }
 test_input_violations_mem_M {
-    input := {"review": review([ctr("a", "1M", "2", "1K", "2")]), "parameters": {"ratio": "4"}}
+    input := {"review": review([ctr("a", "1M", "2", "1k", "2")]), "parameters": {"ratio": "4"}}
     results := violation with input as input
     count(results) == 1
 }

--- a/library/general/containerresourceratios/template.yaml
+++ b/library/general/containerresourceratios/template.yaml
@@ -65,7 +65,7 @@ spec:
         mem_multiple("M") = 1000000000 { true }
         
         # 10 ** 6
-        mem_multiple("K") = 1000000 { true }
+        mem_multiple("k") = 1000000 { true }
         
         # 10 ** 3
         mem_multiple("") = 1000 { true }

--- a/test/bats/tests/templates/k8scontainterlimits_template.yaml
+++ b/test/bats/tests/templates/k8scontainterlimits_template.yaml
@@ -63,7 +63,7 @@ spec:
           mem_multiple("M") = 1000000000 { true }
 
           # 10 ** 6
-          mem_multiple("K") = 1000000 { true }
+          mem_multiple("k") = 1000000 { true }
 
           # 10 ** 3
           mem_multiple("") = 1000 { true }


### PR DESCRIPTION
## What
Lowercase k should be the unit of memory used in the examples instead of uppercase.

https://github.com/kubernetes/apimachinery/blob/37516730658b375821d581544103caaca05ada05/pkg/api/resource/quantity.go#L46

https://github.com/open-policy-agent/gatekeeper/issues/583