### PR TITLE
Add annotation for prometheus scraping

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,8 @@ spec:
     metadata:
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
       labels:
         control-plane: controller-manager
         gatekeeper.sh/operation: webhook
@@ -103,6 +105,8 @@ spec:
         gatekeeper.sh/operation: audit
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
     spec:
       containers:
       - args:

--- a/manifest_staging/chart/gatekeeper-operator/templates/gatekeeper.yaml
+++ b/manifest_staging/chart/gatekeeper-operator/templates/gatekeeper.yaml
@@ -461,7 +461,7 @@ spec:
       release: '{{ .Release.Name }}'
   template:
     metadata:
-      annotations: 
+      annotations:
 {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
         app: '{{ template "gatekeeper-operator.name" . }}'
@@ -510,7 +510,7 @@ spec:
           httpGet:
             path: /readyz
             port: 9090
-        resources: 
+        resources:
 {{ toYaml .Values.resources | indent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -520,7 +520,7 @@ spec:
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000
-      nodeSelector: 
+      nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
@@ -555,7 +555,7 @@ spec:
       release: '{{ .Release.Name }}'
   template:
     metadata:
-      annotations: 
+      annotations:
 {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
         app: '{{ template "gatekeeper-operator.name" . }}'
@@ -606,7 +606,7 @@ spec:
           httpGet:
             path: /readyz
             port: 9090
-        resources: 
+        resources:
 {{ toYaml .Values.resources | indent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -620,7 +620,7 @@ spec:
         - mountPath: /certs
           name: cert
           readOnly: true
-      nodeSelector: 
+      nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}

--- a/manifest_staging/chart/gatekeeper-operator/values.yaml
+++ b/manifest_staging/chart/gatekeeper-operator/values.yaml
@@ -9,9 +9,12 @@ image:
   pullPolicy: IfNotPresent
 nodeSelector: {}
 tolerations: []
-podAnnotations: {
-  container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
-}
+podAnnotations:
+  {
+    container.seccomp.security.alpha.kubernetes.io/manager: runtime/default,
+    prometheus.io/port: "8888",
+    prometheus.io/scrape: "true",
+  }
 resources:
   limits:
     cpu: 1000m

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -414,6 +414,8 @@ spec:
     metadata:
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
       labels:
         control-plane: audit-controller
         gatekeeper.sh/operation: audit
@@ -491,6 +493,8 @@ spec:
     metadata:
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
+        prometheus.io/port: "8888"
+        prometheus.io/scrape: "true"
       labels:
         control-plane: controller-manager
         gatekeeper.sh/operation: webhook


### PR DESCRIPTION
When this annotation is specified, Prometheus will scrape both audit and controller-manager pods.

https://www.weave.works/docs/cloud/latest/tasks/monitor/configuration-k8s/#per-pod-prometheus-annotations