### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ If there is an error in the Rego in the ConstraintTemplate, there are cases wher
 
 When applying the constraint using `kubectl apply -f constraint.yaml` with a ConstraintTemplate that contains incorrect Rego, and error will occur: `error: unable to recognize "[CONSTRAINT_FILENAME].yaml": no matches for kind "[NAME_OF_CONSTRAINT]" in version "constraints.gatekeeper.sh/v1beta1"`.
 
-To find the error, run `kubectl get -f [CONSTRAINT_FILENAME].yaml -oyaml`. Build errors are shown in the `status` field.
+To find the error, run `kubectl get -f [CONSTRAINT_TEMPLATE_FILENAME].yaml -oyaml`. Build errors are shown in the `status` field.
 
 ### Customizing Admission Behavior
 


### PR DESCRIPTION
In line number 502, to find the error, we should get the status of the template file, not the constraint. The template file is the one containing the Rego errors in the status while the constraint file was not accepted to the API yes. Running `kubectl apply -f` against the constraint file will result in the same error message `error: unable to recognize..."

**What this PR does / why we need it**:
Fixes a typo in the README.md file
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: