### PR TITLE
Update Seccomp PSP to respect container level flag

### DIFF
--- a/library/pod-security-policy/seccomp/src.rego
+++ b/library/pod-security-policy/seccomp/src.rego
@@ -1,4 +1,4 @@
-package k8sazureallowedseccomp
+package k8spspseccomp
 
 violation[{"msg": msg, "details": {}}] {
     metadata := input.review.object.metadata

--- a/library/pod-security-policy/seccomp/src.rego
+++ b/library/pod-security-policy/seccomp/src.rego
@@ -1,24 +1,33 @@
-package k8spspseccomp
+package k8sazureallowedseccomp
 
 violation[{"msg": msg, "details": {}}] {
     metadata := input.review.object.metadata
-    not input_seccomp_allowed(metadata)
-    msg := sprintf("Seccomp profile is not allowed, pod: %v. Allowed profiles: %v", [input.review.object.metadata.name, input.parameters.allowedProfiles])
+    not input_wildcard_allowed(metadata)
+    container := input_containers[_]
+    not input_container_allowed(metadata, container)
+    msg := sprintf("Seccomp profile is not allowed, pod: %v, container: %v, Allowed profiles: %v", [metadata.name, container.name, input.parameters.allowedProfiles])
 }
 
-input_seccomp_allowed(metadata) {
+input_wildcard_allowed(metadata) {
     input.parameters.allowedProfiles[_] == "*"
 }
 
-input_seccomp_allowed(metadata) {
+input_container_allowed(metadata, container) {
+    not get_container_profile(metadata, container)
     metadata.annotations["seccomp.security.alpha.kubernetes.io/pod"] == input.parameters.allowedProfiles[_]
 }
 
-input_seccomp_allowed(metadata) {
-    metadata.annotations[key] == input.parameters.allowedProfiles[_]
+input_container_allowed(metadata, container) {
+	profile := get_container_profile(metadata, container)
+	profile == input.parameters.allowedProfiles[_]
+}
+
+get_container_profile(metadata, container) = profile {
+	value := metadata.annotations[key]
     startswith(key, "container.seccomp.security.alpha.kubernetes.io/")
     [prefix, name] := split(key, "/")
-    name == input_containers[_].name
+    name == container.name
+    profile = value
 }
 
 input_containers[c] {

--- a/library/pod-security-policy/seccomp/src_test.rego
+++ b/library/pod-security-policy/seccomp/src_test.rego
@@ -1,33 +1,62 @@
-package k8spspseccomp
+package k8sazureallowedseccomp
 
 test_input_seccomp_allowed_empty {
-    input := { "review": input_review, "parameters": input_parameters_empty}
+    input := { "review": input_review_pod_single, "parameters": input_parameters_empty}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 1
 }
 
 test_input_seccomp_allowed_all {
-    input := { "review": input_review, "parameters": input_parameters_wildcard}
+    input := { "review": input_review_pod_single, "parameters": input_parameters_wildcard}
     results := violation with input as input
     count(results) == 0
 }
 
 test_input_seccomp_allowed_in_list {
-    input := { "review": input_review, "parameters": input_parameters_in_list}
+    input := { "review": input_review_pod_single, "parameters": input_parameter_in_list}
     results := violation with input as input
     count(results) == 0
 }
 
 test_input_seccomp_not_allowed_not_in_list {
-    input := { "review": input_review, "parameters": input_parameters_not_in_list}
+    input := { "review": input_review_pod_single, "parameters": input_parameters_not_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 1
+}
+test_input_seccomp_pod_multiple_allowed_empty {
+    input := { "review": input_review_pod_multiple, "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_input_seccomp_pod_multiple_allowed_all {
+    input := { "review": input_review_pod_multiple, "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_seccomp_pod_multiple_allowed_in_list {
+    input := { "review": input_review_pod_multiple, "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_seccomp_pod_multiple_not_allowed_not_in_list {
+    input := { "review": input_review_pod_multiple, "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_seccomp_not_allowed_no_annotation {
-    input := { "review": input_review_no_annotation, "parameters": input_parameters_in_list}
+    input := { "review": input_review_no_annotation, "parameters": input_parameter_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 1
+}
+
+test_input_seccomp_not_allowed_multiple_no_annotation {
+    input := { "review": input_review_containers_no_annotation, "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 2
 }
 
 test_input_seccomp_container_allowed_all {
@@ -37,7 +66,7 @@ test_input_seccomp_container_allowed_all {
 }
 
 test_input_seccomp_container_allowed_in_list {
-    input := { "review": input_review_container, "parameters": input_parameters_in_list}
+    input := { "review": input_review_container, "parameters": input_parameter_in_list}
     results := violation with input as input
     count(results) == 0
 }
@@ -45,11 +74,11 @@ test_input_seccomp_container_allowed_in_list {
 test_input_seccomp_container_not_allowed_not_in_list {
     input := { "review": input_review_container, "parameters": input_parameters_not_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 1
 }
 
 test_input_seccomp_containers_allowed_in_list {
-    input := { "review": input_review_containers, "parameters": input_parameters_in_list}
+    input := { "review": input_review_containers, "parameters": input_parameter_in_list}
     results := violation with input as input
     count(results) == 0
 }
@@ -57,10 +86,95 @@ test_input_seccomp_containers_allowed_in_list {
 test_input_seccomp_containers_not_allowed_not_in_list {
     input := { "review": input_review_containers, "parameters": input_parameters_not_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 2
 }
 
-input_review = {
+test_input_seccomp_containers_mixed {
+    input := { "review": input_review_containers_mixed, "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_seccomp_containers_mixed_missing_annotation {
+    input := { "review": input_review_containers_missing, "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_seccomp_containers_allowed_in_list_multiple {
+    input := { "review": input_review_containers_mixed, "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_seccomp_pod_container_annotation {
+    input := { "review": input_review_pod_container, "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_seccomp_pod_container_annotation_not_allowed {
+    input := { "review": input_review_pod_container, "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_input_seccomp_pod_container_annotation_both_allowed {
+    input := { "review": input_review_pod_container_mixed, "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_seccomp_pod_container_annotation_mixed_allowed {
+    input := { "review": input_review_pod_container_mixed, "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_seccomp_pod_container_annotation_mixed_not_allowed {
+    input := { "review": input_review_pod_container_mixed, "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_input_seccomp_pod_container_annotation_both_allowed_reversed {
+    input := { "review": input_review_pod_container_mixed_reversed, "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_seccomp_pod_container_annotation_mixed_allowed_reversed {
+    input := { "review": input_review_pod_container_mixed_reversed, "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_seccomp_pod_container_annotation_mixed_not_allowed_reversed {
+    input := { "review": input_review_pod_container_mixed_reversed, "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
+}
+
+#Init Containers
+test_input_init_seccomp_pod_container_annotation_both_allowed {
+    input := { "review": input_review_init_pod_container_mixed, "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_init_seccomp_pod_container_annotation_mixed_allowed {
+    input := { "review": input_review_init_pod_container_mixed, "parameters": input_parameter_in_list}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_init_seccomp_pod_container_annotation_mixed_not_allowed {
+    input := { "review": input_review_init_pod_container_mixed, "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 2
+}
+
+input_review_pod_single = {
     "object": {
         "metadata": {
             "name": "nginx",
@@ -69,10 +183,21 @@ input_review = {
             }
         },
         "spec": {
-            "containers": [{
-                "name": "nginx",
-                "image": "nginx"
-            }]
+            "containers": single_container
+        }
+    }
+}
+
+input_review_pod_multiple = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default"
+            }
+        },
+        "spec": {
+            "containers": multiple_containers
         }
     }
 }
@@ -86,10 +211,7 @@ input_review_container = {
             }
         },
         "spec": {
-            "containers": [{
-                "name": "nginx",
-                "image": "nginx"
-            }]
+            "containers": single_container
         }
     }
 }
@@ -99,17 +221,101 @@ input_review_containers = {
         "metadata": {
             "name": "nginx",
             "annotations": {
+                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
                 "container.seccomp.security.alpha.kubernetes.io/nginx2": "runtime/default"
             }
         },
         "spec": {
-            "containers": [{
-                "name": "nginx",
-                "image": "nginx"
-            },{
-                "name": "nginx2",
-                "image": "nginx"
-            }]
+            "containers": multiple_containers
+        }
+    }
+}
+
+input_review_containers_mixed = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default",
+                "container.seccomp.security.alpha.kubernetes.io/nginx2": "docker/default"
+            }
+        },
+        "spec": {
+            "containers": multiple_containers
+        }
+    }
+}
+
+input_review_containers_missing = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"
+            }
+        },
+        "spec": {
+            "containers": multiple_containers
+        }
+    }
+}
+
+input_review_pod_container = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"
+            }
+        },
+        "spec": {
+            "containers": multiple_containers
+        }
+    }
+}
+
+input_review_pod_container_mixed = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+                "container.seccomp.security.alpha.kubernetes.io/nginx": "docker/default"
+            }
+        },
+        "spec": {
+            "containers": multiple_containers
+        }
+    }
+}
+
+input_review_pod_container_mixed_reversed = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "seccomp.security.alpha.kubernetes.io/pod": "docker/default",
+                "container.seccomp.security.alpha.kubernetes.io/nginx": "runtime/default"
+            }
+        },
+        "spec": {
+            "containers": multiple_containers
+        }
+    }
+}
+
+input_review_init_pod_container_mixed = {
+    "object": {
+        "metadata": {
+            "name": "nginx",
+            "annotations": {
+                "seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+                "container.seccomp.security.alpha.kubernetes.io/nginx": "docker/default"
+            }
+        },
+        "spec": {
+            "initContainers": multiple_containers
         }
     }
 }
@@ -121,13 +327,35 @@ input_review_no_annotation = {
             "name": "nginx"
         },
         "spec": {
-            "containers": [{
-                "name": "nginx",
-                "image": "nginx"
-            }]
+            "containers": single_container
         }
     }
 }
+
+
+input_review_containers_no_annotation = {
+    "object": {
+        "metadata": {
+            "name": "nginx"
+        },
+        "spec": {
+            "containers": multiple_containers
+        }
+    }
+}
+
+single_container = [{
+    "name": "nginx",
+    "image": "nginx"
+}]
+
+multiple_containers = [{
+    "name": "nginx",
+    "image": "nginx"
+}, {
+    "name": "nginx2",
+    "image": "nginx"
+}]
 
 input_parameters_empty = {
     "allowedProfiles": []
@@ -136,6 +364,12 @@ input_parameters_empty = {
 input_parameters_wildcard = {
     "allowedProfiles": [
         "*"
+    ]
+}
+
+input_parameter_in_list = {
+    "allowedProfiles": [
+        "runtime/default"
     ]
 }
 

--- a/library/pod-security-policy/seccomp/src_test.rego
+++ b/library/pod-security-policy/seccomp/src_test.rego
@@ -1,6 +1,6 @@
 package k8spspseccomp
 
-test_input_seccomp_allowed_empty {
+test_input_seccomp_empty_parameters {
     input := { "review": input_review_pod_single, "parameters": input_parameters_empty}
     results := violation with input as input
     count(results) == 1
@@ -23,7 +23,8 @@ test_input_seccomp_not_allowed_not_in_list {
     results := violation with input as input
     count(results) == 1
 }
-test_input_seccomp_pod_multiple_allowed_empty {
+
+test_input_seccomp_pod_multiple_empty_parameters {
     input := { "review": input_review_pod_multiple, "parameters": input_parameters_empty}
     results := violation with input as input
     count(results) == 2

--- a/library/pod-security-policy/seccomp/src_test.rego
+++ b/library/pod-security-policy/seccomp/src_test.rego
@@ -1,4 +1,4 @@
-package k8sazureallowedseccomp
+package k8spspseccomp
 
 test_input_seccomp_allowed_empty {
     input := { "review": input_review_pod_single, "parameters": input_parameters_empty}

--- a/library/pod-security-policy/seccomp/template.yaml
+++ b/library/pod-security-policy/seccomp/template.yaml
@@ -22,23 +22,32 @@ spec:
 
         violation[{"msg": msg, "details": {}}] {
             metadata := input.review.object.metadata
-            not input_seccomp_allowed(metadata)
-            msg := sprintf("Seccomp profile is not allowed, pod: %v. Allowed profiles: %v", [input.review.object.metadata.name, input.parameters.allowedProfiles])
+            not input_wildcard_allowed(metadata)
+            container := input_containers[_]
+            not input_container_allowed(metadata, container)
+            msg := sprintf("Seccomp profile is not allowed, pod: %v, container: %v, Allowed profiles: %v", [metadata.name, container.name, input.parameters.allowedProfiles])
         }
 
-        input_seccomp_allowed(metadata) {
+        input_wildcard_allowed(metadata) {
             input.parameters.allowedProfiles[_] == "*"
         }
 
-        input_seccomp_allowed(metadata) {
+        input_container_allowed(metadata, container) {
+            not get_container_profile(metadata, container)
             metadata.annotations["seccomp.security.alpha.kubernetes.io/pod"] == input.parameters.allowedProfiles[_]
         }
 
-        input_seccomp_allowed(metadata) {
-            metadata.annotations[key] == input.parameters.allowedProfiles[_]
+        input_container_allowed(metadata, container) {
+          profile := get_container_profile(metadata, container)
+          profile == input.parameters.allowedProfiles[_]
+        }
+
+        get_container_profile(metadata, container) = profile {
+          value := metadata.annotations[key]
             startswith(key, "container.seccomp.security.alpha.kubernetes.io/")
             [prefix, name] := split(key, "/")
-            name == input_containers[_].name
+            name == container.name
+            profile = value
         }
 
         input_containers[c] {


### PR DESCRIPTION
Signed-off-by: Emma McMillan <emma.mcmillan@microsoft.com>

**What this PR does / why we need it**:
This fix updates the seccomp pod-security-policy to respect the container-level seccomp flag, and to raise a violation per container in error.

The existing rego will match all containers as passing if at least one container is valid. It also respects the pod-level flag over the container-level flag. As k8s will give the container-level flag precedence, this change ensures the rego matches that, and ensures each container in violation is flagged.
