### PR TITLE
Fix cold cache problem by making a request to api-server

### DIFF
--- a/test/client/noop_client.go
+++ b/test/client/noop_client.go
@@ -1,0 +1,57 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clients
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type NoopClient struct{}
+
+func (f *NoopClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	return nil
+}
+
+func (f *NoopClient) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	return nil
+}
+
+func (f *NoopClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+	return nil
+}
+
+func (f *NoopClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+	return nil
+}
+
+func (f *NoopClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+	return nil
+}
+
+func (f *NoopClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
+}
+
+func (f *NoopClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
+	return nil
+}
+
+func (f *NoopClient) Status() client.StatusWriter {
+	return f
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a problem where the created namespace is not found by cached client when a admission request is being reviewed. This can happen if admission request is made immediately after the namespace is created.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #558 

**Special notes for your reviewer**: