### PR TITLE
Fix empty resource name for logDenies

### DIFF
--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -172,17 +172,20 @@ func (h *validationHandler) Handle(ctx context.Context, req admission.Request) a
 
 func (h *validationHandler) getDenyMessages(res []*rtypes.Result, req admission.Request) []string {
 	var msgs []string
+	var resourceName string
+	if len(res) > 0 && *logDenies {
+		resourceName = req.AdmissionRequest.Name
+		if len(resourceName) == 0 && req.AdmissionRequest.Object.Raw != nil {
+			// On a CREATE operation, the client may omit name and
+			// rely on the server to generate the name.
+			obj := &unstructured.Unstructured{}
+			if _, _, err := deserializer.Decode(req.AdmissionRequest.Object.Raw, nil, obj); err == nil {
+				resourceName = obj.GetName()
+			}
+		}
+	}
 	for _, r := range res {
 		if r.EnforcementAction == "deny" || r.EnforcementAction == "dryrun" {
-			resourceName := req.AdmissionRequest.Name
-			if len(resourceName) == 0 && req.AdmissionRequest.Object.Raw != nil {
-				// On a CREATE operation, the client may omit name and
-				// rely on the server to generate the name.
-				obj := &unstructured.Unstructured{}
-				if _, _, err := deserializer.Decode(req.AdmissionRequest.Object.Raw, nil, obj); err == nil {
-					resourceName = obj.GetName()
-				}
-			}
 			if *logDenies {
 				log.WithValues(
 					"process", "admission",


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

**What this PR does / why we need it**:
On a CREATE operation, the client may omit name and rely on the server to generate the name. For this case, we get the resource name from the object metadata.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #617

**Special notes for your reviewer**:
Was able to repro the issue on k8s v1.15.4. Verified the fix works there and v1.16.1.