### PR TITLE
Ensure cluster scoped resources always match namespace filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,12 +247,13 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/
 Note the `match` field, which defines the scope of objects to which a given constraint will be applied. It supports the following matchers:
 
    * `kinds` accepts a list of objects with `apiGroups` and `kinds` fields that list the groups/kinds of objects to which the constraint will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+   * `scope` accepts `*`, `Cluster`, or `Namespaced` which determines if cluster-scoped and/or namesapced-scoped resources are selected. (defaults to `*`)
    * `namespaces` is a list of namespace names. If defined, a constraint will only apply to resources in a listed namespace.
    * `excludedNamespaces` is a list of namespace names. If defined, a constraint will only apply to resources not in a listed namespace.
    * `labelSelector` is a standard Kubernetes label selector.
    * `namespaceSelector` is a standard Kubernetes namespace selector. If defined, make sure to add `Namespaces` to your `configs.config.gatekeeper.sh` object to ensure namespaces are synced into OPA. Refer to the [Replicating Data section](#replicating-data) for more details.
 
-Note that if multiple matchers are specified, a resource must satisfy each top-level matcher (`kinds`, `namespaces`, etc.) to be in scope. Each top-level matcher has its own semantics for what qualifies as a match. An empty matcher is deemed to be inclusive (matches everything).
+Note that if multiple matchers are specified, a resource must satisfy each top-level matcher (`kinds`, `namespaces`, etc.) to be in scope. Each top-level matcher has its own semantics for what qualifies as a match. An empty matcher is deemed to be inclusive (matches everything). Also understand `namespaces`, `excludedNamespaces`, and `namespaceSelector` will match on cluster scoped resources which are not namespaced. To avoid this adjust the `scope` to `Namespaced`.
 
 ### Replicating Data
 

--- a/pkg/target/regolib/namespace_selector_test.rego
+++ b/pkg/target/regolib/namespace_selector_test.rego
@@ -27,28 +27,30 @@ test_name_no_match_is_ns {
 test_sideload_match {
   matches_nsselector({"namespaceSelector": {"matchLabels": {"hi": "there"}}})
     with input.review.kind as pod_kind
+    with input.review.namespace as "my_namespace"
     with input.review._unstable.namespace as {"metadata": {"labels": {"hi": "there"}}}
 }
 
 test_sideload_no_match {
   not matches_nsselector({"namespaceSelector": {"matchLabels": {"hi": "there"}}})
     with input.review.kind as pod_kind
+    with input.review.namespace as "my_namespace"
     with input.review._unstable.namespace as {"metadata": {"labels": {"bye": "there"}}}
 }
 
 
 test_cache_match {
   matches_nsselector({"namespaceSelector": {"matchLabels": {"hi": "there"}}})
-  	with data["{{.DataRoot}}"].cluster["v1"]["Namespace"]["my_namespace"] as {"metadata": {"labels": {"hi": "there"}}}
-  	with input.review.kind as pod_kind
-	  with input.review.namespace as "my_namespace"
+    with data["{{.DataRoot}}"].cluster["v1"]["Namespace"]["my_namespace"] as {"metadata": {"labels": {"hi": "there"}}}
+    with input.review.kind as pod_kind
+    with input.review.namespace as "my_namespace"
 }
 
 test_cache_no_match {
   not matches_nsselector({"namespaceSelector": {"matchLabels": {"bye": "there"}}})
-  	with data["{{.DataRoot}}"].cluster["v1"]["Namespace"]["my_namespace"] as {"metadata": {"labels": {"hi": "there"}}}
-  	with input.review.kind as pod_kind
-	  with input.review.namespace as "my_namespace"
+    with data["{{.DataRoot}}"].cluster["v1"]["Namespace"]["my_namespace"] as {"metadata": {"labels": {"hi": "there"}}}
+    with input.review.kind as pod_kind
+    with input.review.namespace as "my_namespace"
 }
 
 pod_kind = {
@@ -81,24 +83,65 @@ ns_no_match_obj = {
 
 test_direct_negative_match {
   matches_nsselector({"namespaceSelector": {"matchExpressions": [{"key": "match", "operator": "NotIn", "values": ["no"]}]}})
-  	with input.review.kind as ns_kind
-  	with input.review.object as ns_match_obj
+    with input.review.kind as ns_kind
+    with input.review.object as ns_match_obj
 }
 
 test_direct_no_negative_match {
   not matches_nsselector({"namespaceSelector": {"matchExpressions": [{"key": "match", "operator": "NotIn", "values": ["no"]}]}})
-  	with input.review.kind as ns_kind
-  	with input.review.object as ns_no_match_obj
+    with input.review.kind as ns_kind
+    with input.review.object as ns_no_match_obj
 }
 
 test_direct_negative_match_oldobject {
   matches_nsselector({"namespaceSelector": {"matchExpressions": [{"key": "match", "operator": "NotIn", "values": ["no"]}]}})
-  	with input.review.kind as ns_kind
-  	with input.review.oldObject as ns_match_obj
+    with input.review.kind as ns_kind
+    with input.review.oldObject as ns_match_obj
 }
 
 test_direct_no_negative_match_oldobject {
   not matches_nsselector({"namespaceSelector": {"matchExpressions": [{"key": "match", "operator": "NotIn", "values": ["no"]}]}})
-  	with input.review.kind as ns_kind
-  	with input.review.oldObject as ns_no_match_obj
+    with input.review.kind as ns_kind
+    with input.review.oldObject as ns_no_match_obj
+}
+
+test_exclude_not_provided {
+  does_not_match_excludednamespaces({})
+    with input.review.kind as pod_kind
+    with input.review.namespace as "baz"
+}
+
+test_exclude_cluster_scoped {
+  does_not_match_excludednamespaces({"excludedNamespaces": ["foo", "bar"]})
+    with input.review.kind as pod_kind
+}
+
+test_exclude_namespaced_no_match {
+  does_not_match_excludednamespaces({"excludedNamespaces": ["foo", "bar"]})
+    with input.review.kind as pod_kind
+    with input.review.namespace as "baz"
+}
+
+test_exclude_namespaced_match {
+  not does_not_match_excludednamespaces({"excludedNamespaces": ["foo", "bar"]})
+    with input.review.kind as pod_kind
+    with input.review.namespace as "bar"
+}
+
+test_exclude_not_provided_ns {
+  does_not_match_excludednamespaces({})
+    with input.review.kind as ns_kind
+    with input.review.object.metadata.name as "match"
+}
+
+test_exclude_namespaced_match_ns {
+  not does_not_match_excludednamespaces({"excludedNamespaces": ["foo", "bar"]})
+    with input.review.kind as ns_kind
+    with input.review.object.metadata.name as "foo"
+}
+
+test_exclude_namespaced_no_match_ns {
+  does_not_match_excludednamespaces({"excludedNamespaces": ["foo", "bar"]})
+    with input.review.kind as ns_kind
+    with input.review.object.metadata.name as "no-match"
 }

--- a/pkg/target/regolib/scope_selector_test.rego
+++ b/pkg/target/regolib/scope_selector_test.rego
@@ -1,0 +1,33 @@
+package target
+
+test_match_empty_with_namespaced {
+  matches_scope({})  with input.review as {"namespace": "foo"}
+}
+
+test_match_empty_with_cluster_scoped {
+  matches_scope({})  with input.review as {}
+}
+
+test_match_any_with_namespaced {
+  matches_scope({"scope": "*"}) with input.review as {"namespace": "foo"}
+}
+
+test_match_any_with_cluster_scoped {
+  matches_scope({"scope": "*"})  with input.review as {}
+}
+
+test_match_namespaced_with_namespaced {
+  matches_scope({"scope": "Namespaced"}) with input.review as {"namespace": "foo"}
+}
+
+test_match_namespaced_with_cluster_scoped {
+  not matches_scope({"scope": "Namespaced"}) with input.review as {}
+}
+
+test_match_cluster_with_namespaced {
+  not matches_scope({"scope": "Cluster"}) with input.review as {"namespace": "foo"}
+}
+
+test_match_cluster_with_cluster_scoped {
+  matches_scope({"scope": "Cluster"}) with input.review as {}
+}

--- a/pkg/target/regolib/src.rego
+++ b/pkg/target/regolib/src.rego
@@ -32,6 +32,8 @@ matching_constraints[constraint] {
 
   matches_nsselector(match)
 
+  matches_scope(match)
+
   label_selector := get_default(match, "labelSelector", {})
   any_labelselector_match(label_selector)
 }
@@ -146,6 +148,28 @@ kind_matches(ks) {
 
 kind_matches(ks) {
   ks.kinds[_] == input.review.kind.kind
+}
+
+########################
+# Scope Selector Logic #
+########################
+
+matches_scope(match) {
+  not has_field(match, "scope")
+}
+
+matches_scope(match) {
+  match.scope == "*"
+}
+
+matches_scope(match) {
+  match.scope == "Namespaced"
+  has_field(input.review, "namespace")
+}
+
+matches_scope(match) {
+  match.scope == "Cluster"
+  not has_field(input.review, "namespace")
 }
 
 ########################
@@ -283,6 +307,12 @@ matches_namespaces(match) {
   not has_field(match, "namespaces")
 }
 
+# Always match cluster scoped resources, unless resource is namespace
+matches_namespaces(match) {
+  not is_ns(input.review.kind)
+  not has_field(input.review, "namespace")
+}
+
 matches_namespaces(match) {
   has_field(match, "namespaces")
   get_ns_name[ns]
@@ -294,6 +324,12 @@ does_not_match_excludednamespaces(match) {
   not has_field(match, "excludedNamespaces")
 }
 
+# Always match cluster scoped resources, unless resource is namespace
+does_not_match_excludednamespaces(match) {
+  not is_ns(input.review.kind)
+  not has_field(input.review, "namespace")
+}
+
 does_not_match_excludednamespaces(match) {
   has_field(match, "excludedNamespaces")
   get_ns_name[ns]
@@ -303,6 +339,12 @@ does_not_match_excludednamespaces(match) {
 
 matches_nsselector(match) {
   not has_field(match, "namespaceSelector")
+}
+
+# Always match cluster scoped resources, unless resource is namespace
+matches_nsselector(match) {
+  not is_ns(input.review.kind)
+  not has_field(input.review, "namespace")
 }
 
 matches_nsselector(match) {

--- a/pkg/target/regolib/src.rego
+++ b/pkg/target/regolib/src.rego
@@ -309,6 +309,7 @@ matches_namespaces(match) {
 
 # Always match cluster scoped resources, unless resource is namespace
 matches_namespaces(match) {
+  has_field(match, "namespaces")
   not is_ns(input.review.kind)
   not has_field(input.review, "namespace")
 }
@@ -326,6 +327,7 @@ does_not_match_excludednamespaces(match) {
 
 # Always match cluster scoped resources, unless resource is namespace
 does_not_match_excludednamespaces(match) {
+  has_field(match, "excludedNamespaces")
   not is_ns(input.review.kind)
   not has_field(input.review, "namespace")
 }
@@ -343,6 +345,7 @@ matches_nsselector(match) {
 
 # Always match cluster scoped resources, unless resource is namespace
 matches_nsselector(match) {
+  has_field(match, "namespaceSelector")
   not is_ns(input.review.kind)
   not has_field(input.review, "namespace")
 }

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -305,6 +305,14 @@ func (h *K8sValidationTarget) MatchSchema() apiextensions.JSONSchemaProps {
 					Schema: &apiextensions.JSONSchemaProps{Type: "string"}}},
 			"labelSelector":     labelSelectorSchema,
 			"namespaceSelector": labelSelectorSchema,
+			"scope": apiextensions.JSONSchemaProps{
+				Type: "string",
+				Enum: []apiextensions.JSON{
+					"*",
+					"Cluster",
+					"Namespaced",
+				},
+			},
 		},
 	}
 }

--- a/pkg/target/target_template_source.go
+++ b/pkg/target/target_template_source.go
@@ -169,12 +169,12 @@ matches_scope(match) {
 
 matches_scope(match) {
   match.scope == "Namespaced"
-  has_field(input.review, "namespace")
+  get_default(input.review, "namespace", "") != ""
 }
 
 matches_scope(match) {
   match.scope == "Cluster"
-  not has_field(input.review, "namespace")
+  get_default(input.review, "namespace", "") == ""
 }
 
 ########################
@@ -308,18 +308,24 @@ get_ns_name[out] {
   out := input.review.namespace
 }
 
+always_match_ns_selectors(match) {
+  not is_ns(input.review.kind)
+  get_default(input.review, "namespace", "") == ""
+}
+
 matches_namespaces(match) {
   not has_field(match, "namespaces")
 }
 
 # Always match cluster scoped resources, unless resource is namespace
 matches_namespaces(match) {
-  not is_ns(input.review.kind)
-  not has_field(input.review, "namespace")
+  has_field(match, "namespaces")
+  always_match_ns_selectors(match)
 }
 
 matches_namespaces(match) {
   has_field(match, "namespaces")
+  not always_match_ns_selectors(match)
   get_ns_name[ns]
   nss := {n | n = match.namespaces[_]}
   count({ns} - nss) == 0
@@ -331,12 +337,13 @@ does_not_match_excludednamespaces(match) {
 
 # Always match cluster scoped resources, unless resource is namespace
 does_not_match_excludednamespaces(match) {
-  not is_ns(input.review.kind)
-  not has_field(input.review, "namespace")
+  has_field(match, "excludedNamespaces")
+  always_match_ns_selectors(match)
 }
 
 does_not_match_excludednamespaces(match) {
   has_field(match, "excludedNamespaces")
+  not always_match_ns_selectors(match)
   get_ns_name[ns]
   nss := {n | n = match.excludedNamespaces[_]}
   count({ns} - nss) != 0
@@ -348,12 +355,13 @@ matches_nsselector(match) {
 
 # Always match cluster scoped resources, unless resource is namespace
 matches_nsselector(match) {
-  not is_ns(input.review.kind)
-  not has_field(input.review, "namespace")
+  has_field(match, "namespaceSelector")
+  always_match_ns_selectors(match)
 }
 
 matches_nsselector(match) {
   not is_ns(input.review.kind)
+  not always_match_ns_selectors(match)
   has_field(match, "namespaceSelector")
   get_ns[ns]
   matches_namespace_selector(match, ns)
@@ -362,6 +370,7 @@ matches_nsselector(match) {
 # if we are matching against a namespace, match against either the old or new object
 matches_nsselector(match) {
   is_ns(input.review.kind)
+  not always_match_ns_selectors(match)
   has_field(match, "namespaceSelector")
   any_labelselector_match(get_default(match, "namespaceSelector", {}))
 }

--- a/pkg/target/target_template_source.go
+++ b/pkg/target/target_template_source.go
@@ -37,6 +37,8 @@ matching_constraints[constraint] {
 
   matches_nsselector(match)
 
+  matches_scope(match)
+
   label_selector := get_default(match, "labelSelector", {})
   any_labelselector_match(label_selector)
 }
@@ -151,6 +153,28 @@ kind_matches(ks) {
 
 kind_matches(ks) {
   ks.kinds[_] == input.review.kind.kind
+}
+
+########################
+# Scope Selector Logic #
+########################
+
+matches_scope(match) {
+  not has_field(match, "scope")
+}
+
+matches_scope(match) {
+  match.scope == "*"
+}
+
+matches_scope(match) {
+  match.scope == "Namespaced"
+  has_field(input.review, "namespace")
+}
+
+matches_scope(match) {
+  match.scope == "Cluster"
+  not has_field(input.review, "namespace")
 }
 
 ########################
@@ -288,6 +312,12 @@ matches_namespaces(match) {
   not has_field(match, "namespaces")
 }
 
+# Always match cluster scoped resources, unless resource is namespace
+matches_namespaces(match) {
+  not is_ns(input.review.kind)
+  not has_field(input.review, "namespace")
+}
+
 matches_namespaces(match) {
   has_field(match, "namespaces")
   get_ns_name[ns]
@@ -299,6 +329,12 @@ does_not_match_excludednamespaces(match) {
   not has_field(match, "excludedNamespaces")
 }
 
+# Always match cluster scoped resources, unless resource is namespace
+does_not_match_excludednamespaces(match) {
+  not is_ns(input.review.kind)
+  not has_field(input.review, "namespace")
+}
+
 does_not_match_excludednamespaces(match) {
   has_field(match, "excludedNamespaces")
   get_ns_name[ns]
@@ -308,6 +344,12 @@ does_not_match_excludednamespaces(match) {
 
 matches_nsselector(match) {
   not has_field(match, "namespaceSelector")
+}
+
+# Always match cluster scoped resources, unless resource is namespace
+matches_nsselector(match) {
+  not is_ns(input.review.kind)
+  not has_field(input.review, "namespace")
 }
 
 matches_nsselector(match) {

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -39,19 +39,19 @@ func TestValidateConstraint(t *testing.T) {
 	"apiVersion": "constraints.gatekeeper.sh/v1beta1",
 	"kind": "K8sRequiredLabel",
 	"metadata": {
-  	"name": "ns-must-have-gk"
+		"name": "ns-must-have-gk"
 	},
 	"spec": {
-  	"match": {
-    	"kinds": [
-      	{
+		"match": {
+			"kinds": [
+				{
 					"apiGroups": [""],
-        	"kinds": ["Namespace"]
+					"kinds": ["Namespace"]
 				}
 			]
 		},
-  	"parameters": {
-    	"labels": ["gatekeeper"]
+		"parameters": {
+			"labels": ["gatekeeper"]
 		}
 	}
 }
@@ -65,14 +65,14 @@ func TestValidateConstraint(t *testing.T) {
 	"apiVersion": "constraints.gatekeeper.sh/v1beta1",
 	"kind": "K8sRequiredLabel",
 	"metadata": {
-  	"name": "ns-must-have-gk"
+		"name": "ns-must-have-gk"
 	},
 	"spec": {
-  	"match": {
-    	"kinds": [
-      	{
+		"match": {
+			"kinds": [
+				{
 					"apiGroups": [""],
-        	"kinds": ["Namespace"]
+					"kinds": ["Namespace"]
 				}
 			],
 			"labelSelector": {
@@ -83,8 +83,8 @@ func TestValidateConstraint(t *testing.T) {
 				}]
 			}
 		},
-  	"parameters": {
-    	"labels": ["gatekeeper"]
+		"parameters": {
+			"labels": ["gatekeeper"]
 		}
 	}
 }
@@ -98,14 +98,14 @@ func TestValidateConstraint(t *testing.T) {
 	"apiVersion": "constraints.gatekeeper.sh/v1beta1",
 	"kind": "K8sRequiredLabel",
 	"metadata": {
-  	"name": "ns-must-have-gk"
+		"name": "ns-must-have-gk"
 	},
 	"spec": {
-  	"match": {
-    	"kinds": [
-      	{
+		"match": {
+			"kinds": [
+				{
 					"apiGroups": [""],
-        	"kinds": ["Namespace"]
+					"kinds": ["Namespace"]
 				}
 			],
 			"labelSelector": {
@@ -116,8 +116,8 @@ func TestValidateConstraint(t *testing.T) {
 				}]
 			}
 		},
-  	"parameters": {
-    	"labels": ["gatekeeper"]
+		"parameters": {
+			"labels": ["gatekeeper"]
 		}
 	}
 }
@@ -131,25 +131,26 @@ func TestValidateConstraint(t *testing.T) {
 	"apiVersion": "constraints.gatekeeper.sh/v1beta1",
 	"kind": "K8sAllowedRepos",
 	"metadata": {
-  	"name": "prod-nslabels-is-openpolicyagent"
+		"name": "prod-nslabels-is-openpolicyagent"
 	},
 	"spec": {
-  	"match": {
-    	"kinds": [
-      	{
-			"apiGroups": [""],
-        	"kinds": ["Pod"]
-		}],
-		"labelSelector": {
-			"matchExpressions": [{
-	     		"key": "someKey",
-				"operator": "In",
-				"values": ["some value"]
-			}]
-		}
-	},
-  	"parameters": {
-    	"repos": ["openpolicyagent"]
+		"match": {
+			"kinds": [
+				{
+					"apiGroups": [""],
+					"kinds": ["Pod"]
+				}
+			],
+			"labelSelector": {
+				"matchExpressions": [{
+					"key": "someKey",
+					"operator": "In",
+					"values": ["some value"]
+				}]
+			}
+		},
+		"parameters": {
+			"repos": ["openpolicyagent"]
 		}
 	}
 }
@@ -163,25 +164,26 @@ func TestValidateConstraint(t *testing.T) {
 	"apiVersion": "constraints.gatekeeper.sh/v1beta1",
 	"kind": "K8sAllowedRepos",
 	"metadata": {
-  	"name": "prod-nslabels-is-openpolicyagent"
+		"name": "prod-nslabels-is-openpolicyagent"
 	},
 	"spec": {
-  	"match": {
-    	"kinds": [
-      	{
-			"apiGroups": [""],
-        	"kinds": ["Pod"]
-		}],
-		"namespaceSelector": {
-			"matchExpressions": [{
-	     		"key": "someKey",
-				"operator": "In",
-				"values": ["some value"]
-			}]
-		}
-	},
-  	"parameters": {
-    	"repos": ["openpolicyagent"]
+		"match": {
+			"kinds": [
+				{
+					"apiGroups": [""],
+					"kinds": ["Pod"]
+				}
+			],
+			"namespaceSelector": {
+				"matchExpressions": [{
+					"key": "someKey",
+					"operator": "In",
+					"values": ["some value"]
+				}]
+			}
+		},
+		"parameters": {
+			"repos": ["openpolicyagent"]
 		}
 	}
 }
@@ -195,25 +197,26 @@ func TestValidateConstraint(t *testing.T) {
 	"apiVersion": "constraints.gatekeeper.sh/v1beta1",
 	"kind": "K8sAllowedRepos",
 	"metadata": {
-  	"name": "prod-nslabels-is-openpolicyagent"
+		"name": "prod-nslabels-is-openpolicyagent"
 	},
 	"spec": {
-  	"match": {
-    	"kinds": [
-      	{
-			"apiGroups": [""],
-        	"kinds": ["Pod"]
-		}],
-		"namespaceSelector": {
-			"matchExpressions": [{
-	     		"key": "someKey",
-				"operator": "Blah",
-				"values": ["some value"]
-			}]
-		}
-	},
-  	"parameters": {
-    	"repos": ["openpolicyagent"]
+		"match": {
+			"kinds": [
+				{
+					"apiGroups": [""],
+					"kinds": ["Pod"]
+				}
+			],
+			"namespaceSelector": {
+				"matchExpressions": [{
+				 		"key": "someKey",
+					"operator": "Blah",
+					"values": ["some value"]
+				}]
+			}
+		},
+		"parameters": {
+			"repos": ["openpolicyagent"]
 		}
 	}
 }
@@ -227,19 +230,20 @@ func TestValidateConstraint(t *testing.T) {
 	"apiVersion": "constraints.gatekeeper.sh/v1beta1",
 	"kind": "K8sAllowedRepos",
 	"metadata": {
-  	"name": "prod-nslabels-is-openpolicyagent"
+		"name": "prod-nslabels-is-openpolicyagent"
 	},
 	"spec": {
-	"enforcementAction": "dryrun",
-  	"match": {
-    	"kinds": [
-      	{
-			"apiGroups": [""],
-        	"kinds": ["Pod"]
-		}]
-	},
-  	"parameters": {
-    	"repos": ["openpolicyagent"]
+		"enforcementAction": "dryrun",
+		"match": {
+			"kinds": [
+				{
+					"apiGroups": [""],
+					"kinds": ["Pod"]
+				}
+			]
+		},
+		"parameters": {
+			"repos": ["openpolicyagent"]
 		}
 	}
 }
@@ -284,7 +288,7 @@ func TestHandleViolation(t *testing.T) {
 	},
 	"name": "somename",
 	"operation": "CREATE",
-  "object": {
+	"object": {
 		"metadata": {"name": "somename"},
 		"spec": {"value": "yep"}
 	}
@@ -310,7 +314,7 @@ func TestHandleViolation(t *testing.T) {
 	},
 	"name": "somename",
 	"operation": "CREATE",
-  "object": {
+	"object": {
 		"metadata": {"name": "somename"},
 		"spec": {"value": "yep"}
 	}


### PR DESCRIPTION
Signed-off-by: Robert Sheehy <rob.sheehy@workiva.com>

**What this PR does / why we need it**:
This change helps ensure gatekeeper includes cluster scoped resources when using any of the namespace filtering (since this is closer to how Kubernetes handles matching).

For example this is how Kubernetes handles the `namespaceSelector` on Webhooks.

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#mutatingwebhook-v1beta1-admissionregistration-k8s-io

> NamespaceSelector decides whether to run the webhook on an object based on whether the namespace for that object matches the selector. If the object itself is a namespace, the matching is performed on object.metadata.labels. If the object is another cluster scoped resource, it never skips the webhook.

#### Change List
* Add `scope` to the constraint configuration which accepts `Cluster`, `Namespaced`, or `*`
* Update behavior to adhere to the `scope` specified on the constraint.
* Alway select cluster scoped resources regardless of `namespaceSelector`, `namespaces`, and `excludedNamespaces` (if people don't like this they can modify the `scope`)

**Which issue(s) this PR fixes**
Fixes #615

**Special notes for your reviewer**:
I don't have a preference when it comes to tabs or spaces, but there were some spots I stumbled across which had mixtures of both.  So I adjusted to using one or the other depending on the context.