### PR TITLE
NodeSelector for Linux

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -155,3 +155,5 @@ spec:
           runAsUser: 1000
       serviceAccountName: gatekeeper-admin
       terminationGracePeriodSeconds: 60
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -7,7 +7,9 @@ image:
   repository: quay.io/open-policy-agent/gatekeeper
   release: v3.1.0-beta.8
   pullPolicy: IfNotPresent
-nodeSelector: {}
+nodeSelector: {
+  kubernetes.io/os: linux
+}
 tolerations: []
 podAnnotations: {
   container.seccomp.security.alpha.kubernetes.io/manager: runtime/default

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -470,6 +470,8 @@ spec:
           runAsUser: 1000
       serviceAccountName: gatekeeper-admin
       terminationGracePeriodSeconds: 60
+      nodeSelector:
+        kubernetes.io/os: linux
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -561,6 +563,8 @@ spec:
         secret:
           defaultMode: 420
           secretName: gatekeeper-webhook-server-cert
+      nodeSelector:
+        kubernetes.io/os: linux
 ---
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
**What this PR does / why we need it**:
Since we are only supporting Linux OS right now, adding a nodeSelector to assign deploments to Linux agents
