### PR TITLE
push dev tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ REGISTRY ?= quay.io
 REPOSITORY ?= $(REGISTRY)/open-policy-agent/gatekeeper
 
 IMG := $(REPOSITORY):latest
+# DEV_TAG will be replaced with short Git SHA on pre-release stage in CI
 DEV_TAG ?= dev
 
 VERSION := v3.1.0-beta.9

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ docker-tag-release:
 # Push for Dev
 docker-push-dev:  docker-tag-dev
 	@docker push $(REPOSITORY):$(DEV_TAG)
+	@docker push $(REPOSITORY):dev
 
 # Push for Release
 docker-push-release:  docker-tag-release


### PR DESCRIPTION
**What this PR does / why we need it**:
we were not pushing latest dev tag (only the commit sha tags)
