### PR TITLE
docs: add firewall rules prerequisite to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ For either installation method, make sure you have cluster admin permissions:
     --user <YOUR USER NAME>
 ```
 
+##### Firewall Rules
+
+TCP port 8443 must be allowed from the Kubernetes API server to the node which Gatekeeper runs on in order for the validation webhooks to be accessible. This is blocked in the default configuration for some managed Kubernetes services and will result in a timeout. 
+
 #### Deploying a Release using Prebuilt Image
 
 If you want to deploy a released version of Gatekeeper in your cluster with a prebuilt image, then you can run the following command:


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a note to the prerequisites section about port 8443 needing to be accessible from the Kubernetes API server.

**Which issue(s) this PR fixes**:

Adds documentation for #262 

