### PR TITLE
Ensure terminated are ignored for readiness

### DIFF
--- a/pkg/readiness/object_tracker.go
+++ b/pkg/readiness/object_tracker.go
@@ -72,6 +72,16 @@ func (t *objectTracker) Expect(o runtime.Object) {
 		return
 	}
 
+	accessor, err := meta.Accessor(o)
+	if err != nil {
+		return
+	}
+
+	// Don't expect resources which are being terminated.
+	if !accessor.GetDeletionTimestamp().IsZero() {
+		return
+	}
+
 	k, err := objKeyFromObject(o)
 	if err != nil {
 		log.Error(err, "skipping")

--- a/pkg/readiness/object_tracker_test.go
+++ b/pkg/readiness/object_tracker_test.go
@@ -90,6 +90,18 @@ func Test_ObjectTracker_Seen_Before_Expect(t *testing.T) {
 	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should have been satisfied")
 }
 
+// Verify that terminated resources are ignored when calling Expect.
+func Test_ObjectTracker_Termintated_Expect(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ot := newObjTracker(schema.GroupVersionKind{})
+	ct := makeCT("test-ct")
+	now := metav1.Now()
+	ct.ObjectMeta.DeletionTimestamp = &now
+	ot.Expect(ct)
+	ot.ExpectationsDone()
+	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+}
+
 // Verify that that expectations can be cancelled.
 func Test_ObjectTracker_Cancelled_Expectations(t *testing.T) {
 	g := gomega.NewWithT(t)


### PR DESCRIPTION
## What
Resources which are being terminated on startup (which gatekeeper is trying to sync/reconcile) cause gatekeeper to fail its readiness check indefinitely.

To help with this let's not look for resources marked for termination in the readiness check.

Fixes #660

## Notes
The readiness check still seems a little shaky though. As @maxsmythe pointed out in the issue, there's still the possibility that a resource can be deleted between when the `ready_tracker` discovers the resource, and when the controllers start reconciling.