### PR TITLE
update readme with buildx instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,3 @@
-# Enable Docker CLI experimental features
-DOCKER_CLI_EXPERIMENTAL=enabled
-
 # Image URL to use all building/pushing image targets
 REGISTRY ?= quay.io
 REPOSITORY ?= $(REGISTRY)/open-policy-agent/gatekeeper
@@ -183,35 +180,31 @@ docker-push-release:  docker-tag-release
 	@docker push $(REPOSITORY):$(VERSION)
 	@docker push $(REPOSITORY):latest
 
-# Build the docker image
-docker-build: test
-	docker build --pull . -t ${IMG}
-
 # Build docker image with buildx
 # Experimental docker feature to build cross platform multi-architecture docker images
 # https://docs.docker.com/buildx/working-with-buildx/
 docker-buildx: test
-	@if ! docker buildx ls | grep -q container-builder; then\
-		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\
+	if ! DOCKER_CLI_EXPERIMENTAL=enabled docker buildx ls | grep -q container-builder; then\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name container-builder --use;\
 	fi
-	docker buildx build --platform "linux/amd64" \
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform "linux/amd64" \
 		-t $(IMG) \
 		. --load
 
 docker-buildx-dev: test
-	@if ! docker buildx ls | grep -q container-builder; then\
-		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\
+	@if ! DOCKER_CLI_EXPERIMENTAL=enabled docker buildx ls | grep -q container-builder; then\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name container-builder --use;\
 	fi
-	docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" \
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" \
 		-t $(REPOSITORY):$(DEV_TAG) \
 		-t $(REPOSITORY):dev \
 		. --push
 
 docker-buildx-release: test
-	@if ! docker buildx ls | grep -q container-builder; then\
-		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\
+	@if ! DOCKER_CLI_EXPERIMENTAL=enabled docker buildx ls | grep -q container-builder; then\
+		DOCKER_CLI_EXPERIMENTAL=enabled docker buildx create --name container-builder --use;\
 	fi
-	docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" \
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform "linux/amd64,linux/arm64,linux/arm/v7" \
 		-t $(REPOSITORY):$(VERSION) \
 		-t $(REPOSITORY):latest \
 		. --push

--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,13 @@ docker-push-release:  docker-tag-release
 	@docker push $(REPOSITORY):$(VERSION)
 	@docker push $(REPOSITORY):latest
 
+# Build the docker image
+docker-build: test
+	docker build --pull . -t ${IMG}
+
+# Build docker image with buildx
+# Experimental docker feature to build cross platform multi-architecture docker images
+# https://docs.docker.com/buildx/working-with-buildx/
 docker-buildx: test
 	@if ! docker buildx ls | grep -q container-builder; then\
 		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\
@@ -191,9 +198,6 @@ docker-buildx: test
 		-t $(IMG) \
 		. --load
 
-# Build docker image with buildx
-# Experimental docker feature to build cross platform multi-architecture docker images
-# https://docs.docker.com/buildx/working-with-buildx/
 docker-buildx-dev: test
 	@if ! docker buildx ls | grep -q container-builder; then\
 		docker buildx create --platform "linux/amd64,linux/arm64,linux/arm/v7" --name container-builder --use;\

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/
 Currently the most reliable way of installing Gatekeeper is to build and install from HEAD:
 
    * Make sure that:
+       * You have Docker version 19.03 or later installed.
        * [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#getting-started) and [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) are installed.
        * Your kubectl context is set to the desired installation cluster.
        * You have a container registry you can write to that is readable by the target cluster.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Currently the most reliable way of installing Gatekeeper is to build and install
       ```
    * Build and push your Docker image:
       ```sh
-      make docker-build REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
+      make docker-buildx REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
       make docker-push-release REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
       ```
    * Finally, deploy:


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
- update readme with `make docker-buildx` instructions
- setting or exporting `DOCKER_CLI_EXPERIMENTAL` at the top doesn't work

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #666

**Special notes for your reviewer**: