### PR TITLE
Add kubebuilder RBAC marker for ConstraintTemplate

### DIFF
--- a/config/crd/bases/config.gatekeeper.sh_configs.yaml
+++ b/config/crd/bases/config.gatekeeper.sh_configs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: configs.config.gatekeeper.sh
 spec:

--- a/config/crd/bases/status.gatekeeper.sh_constraintpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_constraintpodstatuses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: constraintpodstatuses.status.gatekeeper.sh
 spec:

--- a/config/crd/bases/status.gatekeeper.sh_constrainttemplatepodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_constrainttemplatepodstatuses.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: constrainttemplatepodstatuses.status.gatekeeper.sh
 spec:
@@ -53,8 +53,7 @@ spec:
                 type: object
               type: array
             id:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
+              description: 'Important: Run "make" to regenerate code after modifying
                 this file'
               type: string
             observedGeneration:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -91,6 +91,15 @@ rules:
 - apiGroups:
   - templates.gatekeeper.sh
   resources:
+  - constrainttemplates/finalizers
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
   - constrainttemplates/status
   verbs:
   - get

--- a/manifest_staging/charts/gatekeeper/templates/config-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/config-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
     helm.sh/hook: crd-install
     helm.sh/hook-delete-policy: before-hook-creation
   creationTimestamp: null

--- a/manifest_staging/charts/gatekeeper/templates/constraintpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/constraintpodstatus-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   labels:
     app: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   labels:
     app: '{{ template "gatekeeper.name" . }}'
@@ -57,8 +57,7 @@ spec:
                 type: object
               type: array
             id:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
+              description: 'Important: Run "make" to regenerate code after modifying
                 this file'
               type: string
             observedGeneration:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
@@ -95,6 +95,15 @@ rules:
 - apiGroups:
   - templates.gatekeeper.sh
   resources:
+  - constrainttemplates/finalizers
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
   - constrainttemplates/status
   verbs:
   - get

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -11,7 +11,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   labels:
     gatekeeper.sh/system: "yes"
@@ -109,7 +109,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   labels:
     gatekeeper.sh/system: "yes"
@@ -192,7 +192,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.4
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   labels:
     gatekeeper.sh/system: "yes"
@@ -243,8 +243,7 @@ spec:
                 type: object
               type: array
             id:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
+              description: 'Important: Run "make" to regenerate code after modifying
                 this file'
               type: string
             observedGeneration:
@@ -503,6 +502,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - templates.gatekeeper.sh
+  resources:
+  - constrainttemplates/finalizers
+  verbs:
+  - delete
+  - get
+  - patch
+  - update
 - apiGroups:
   - templates.gatekeeper.sh
   resources:

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -233,6 +233,7 @@ type ReconcileConstraintTemplate struct {
 
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=templates.gatekeeper.sh,resources=constrainttemplates,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=templates.gatekeeper.sh,resources=constrainttemplates/finalizers,verbs=get;update;patch;delete
 // +kubebuilder:rbac:groups=templates.gatekeeper.sh,resources=constrainttemplates/status,verbs=get;update;patch
 
 // Reconcile reads that state of the cluster for a ConstraintTemplate object and makes changes based on the state read


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a kubebuilder marker for ConstraintTemplates to generate the
necessary RBAC permissions for the gatekeeper-manager-role ClusterRole
to access the ConstraintTemplate finalizer subresource. This is needed
in order to set an owner reference on the CRD being created by the
ConstraintTemplate.


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #603

**Special notes for your reviewer**: