### PR TITLE
Add Support for Prometheus ServiceMonitor to the Helm chart

### DIFF
--- a/cmd/build/helmify/static/README.md
+++ b/cmd/build/helmify/static/README.md
@@ -3,21 +3,25 @@
 ## Parameters
 
 | Parameter                 | Description                                                 | Default                                                                   |
-| :------------------------ | :---------------------------------------------------------- | :------------------------------------------------------------------------ |
-| auditInterval             | The frequency with which audit is run                       | `60`                                                                      |
-| constraintViolationsLimit | The maximum # of audit violations reported on a constraint  | `20`                                                                      |
-| auditFromCache            | Take the roster of resources to audit from the OPA cache    | `false`                                                                   |
-| disableValidatingWebhook  | Disable ValidatingWebhook                                   | `false`                                                                   |
-| logLevel                  | Minimum log level                                           | `INFO`                                                                    |
-| image.pullPolicy          | The image pull policy                                       | `IfNotPresent`                                                            |
-| image.repository          | The Docker image repository                                 | `openpolicyagent/gatekeeper`                                              |
-| image.release             | The image release tag to use                                | Current release version: `v3.1.0-beta.9`                                  |
-| resources                 | The resource request/limits for the container image         | limits: 1 CPU, 512Mi, requests: 100mCPU, 256Mi                            |
-| nodeSelector              | The node selector to use for pod scheduling                 | `kubernetes.io/os: linux`                                                 |
-| affinity                  | The node affinity to use for pod scheduling                 | `{}`                                                                      |
-| tolerations               | The tolerations to use for pod scheduling                   | `[]`                                                                      |
-| replicas                  | The number of Gatekeeper replicas to deploy for the webhook | `1`                                                                       |
-| podAnnotations            | The annotations to add to the Gatekeeper pods               | `container.seccomp.security.alpha.kubernetes.io/manager: runtime/default` |
+| :------------------------------------ | :---------------------------------------------------------- | :------------------------------------------------------------------------ |
+| auditInterval                         | The frequency with which audit is run                       | `60`                                                                      |
+| constraintViolationsLimit             | The maximum # of audit violations reported on a constraint  | `20`                                                                      |
+| auditFromCache                        | Take the roster of resources to audit from the OPA cache    | `false`                                                                   |
+| disableValidatingWebhook              | Disable ValidatingWebhook                                   | `false`                                                                   |
+| logLevel                              | Minimum log level                                           | `INFO`                                                                    |
+| image.pullPolicy                      | The image pull policy                                       | `IfNotPresent`                                                            |
+| image.repository                      | The Docker image repository                                 | `openpolicyagent/gatekeeper`                                              |
+| image.release                         | The image release tag to use                                | Current release version: `v3.1.0-beta.9`                                                       |
+| resources                             | The resource request/limits for the container image         | limits: 1 CPU, 512Mi, requests: 100mCPU, 256Mi                                                    |
+| metricsAudit.enabled                  | Enable a service that exposes audit-contoller metrics on port 8889          | `true`                                                   |
+| metricsAudit.serviceMonitor.enabled   | Creates a Prometheus ServiceMonitor to scrape the audit-contoller metrics   | `false`                                                  |
+| metricsWebhook.enabled                | Enable a service that exposes webhook-contoller metrics on port 8888        | `true`                                                   |
+| metricsWebhook.serviceMonitor.enabled | Creates a Prometheus ServiceMonitor to scrape the webhook-contoller metrics | `false`                                                  |
+| nodeSelector                          | The node selector to use for pod scheduling                 | `kubernetes.io/os: linux`                                                   |
+| affinity                              | The node affinity to use for pod scheduling                 | `{}`                                                                      |
+| tolerations                           | The tolerations to use for pod scheduling                   | `[]`                                                                      |
+| replicas                              | The number of Gatekeeper replicas to deploy for the webhook | `1`                                                     |
+| podAnnotations                        | The annotations to add to the Gatekeeper pods               | `container.seccomp.security.alpha.kubernetes.io/manager: runtime/default` |
 
 ## Contributing Changes
 

--- a/cmd/build/helmify/static/templates/audit-metrics-service.yaml
+++ b/cmd/build/helmify/static/templates/audit-metrics-service.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.metricsAudit.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+    gatekeeper.sh/operation: "audit"
+  name: gatekeeper-audit-metrics-service
+  namespace: gatekeeper-system
+spec:
+  ports:
+  - port: 8889
+    name: audit-metrics
+    targetPort: 8888
+  selector:
+    control-plane: audit-controller
+    gatekeeper.sh/operation: audit
+    gatekeeper.sh/system: "yes"
+{{- end }}

--- a/cmd/build/helmify/static/templates/audit-servicemonitor.yaml
+++ b/cmd/build/helmify/static/templates/audit-servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.metricsAudit.enabled) (.Values.metricsAudit.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gatekeeper-audit
+spec:
+  endpoints:
+    - honorLabels: {{ .Values.metricsAudit.serviceMonitor.honorLabels }}
+      interval: {{ .Values.metricsAudit.serviceMonitor.interval }}
+      path: {{ .Values.metricsAudit.serviceMonitor.path }}
+      port: audit-metrics
+      scrapeTimeout: {{ .Values.metricsAudit.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+      - gatekeeper-system
+  selector:
+    matchLabels:
+      gatekeeper.sh/system: "yes"
+      gatekeeper.sh/operation: "audit"
+{{- end }}

--- a/cmd/build/helmify/static/templates/webhook-metrics-service.yaml
+++ b/cmd/build/helmify/static/templates/webhook-metrics-service.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.metricsWebhook.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+    gatekeeper.sh/operation: "webhook"
+  name: gatekeeper-webhook-metrics-service
+  namespace: gatekeeper-system
+spec:
+  ports:
+  - port: 8888
+    name: webhook-metrics
+    targetPort: 8888
+  selector:
+    control-plane: controller-manager
+    gatekeeper.sh/operation: webhook
+    gatekeeper.sh/system: "yes"
+{{- end }}

--- a/cmd/build/helmify/static/templates/webhook-servicemonitor.yaml
+++ b/cmd/build/helmify/static/templates/webhook-servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.metricsWebhook.enabled) (.Values.metricsWebhook.serviceMonitor) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gatekeeper-webhook
+spec:
+  endpoints:
+    - honorLabels: {{ .Values.metricsWebhook.serviceMonitor.honorLabels }}
+      interval: {{ .Values.metricsWebhook.serviceMonitor.interval }}
+      path: {{ .Values.metricsWebhook.serviceMonitor.path }}
+      port: webhook-metrics
+      scrapeTimeout: {{ .Values.metricsWebhook.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+      - gatekeeper-system
+  selector:
+    matchLabels:
+      gatekeeper.sh/system: "yes"
+      gatekeeper.sh/operation: "webhook"
+{{- end }}

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -8,6 +8,22 @@ image:
   repository: openpolicyagent/gatekeeper
   release: v3.1.0-beta.9
   pullPolicy: IfNotPresent
+metricsAudit:
+  enabled: false
+  serviceMonitor:
+    enabled: true
+    honorLabels: true
+    interval: 15s
+    path: /metrics
+    scrapeTimeout: 10s
+metricsWebhook:
+  enabled: false
+  serviceMonitor:
+    enabled: true
+    honorLabels: true
+    interval: 15s
+    path: /metrics
+    scrapeTimeout: 10s
 nodeSelector: { kubernetes.io/os: linux }
 affinity: {}
 tolerations: []

--- a/manifest_staging/charts/gatekeeper/templates/audit-metrics-service.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/audit-metrics-service.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.metricsAudit.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+    gatekeeper.sh/operation: "audit"
+  name: gatekeeper-audit-metrics-service
+  namespace: gatekeeper-system
+spec:
+  ports:
+  - port: 8889
+    name: audit-metrics
+    targetPort: 8888
+  selector:
+    control-plane: audit-controller
+    gatekeeper.sh/operation: audit
+    gatekeeper.sh/system: "yes"
+{{- end }}

--- a/manifest_staging/charts/gatekeeper/templates/audit-servicemonitor.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/audit-servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.metricsAudit.enabled) (.Values.metricsAudit.serviceMonitor.enabled) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gatekeeper-audit
+spec:
+  endpoints:
+    - honorLabels: {{ .Values.metricsAudit.serviceMonitor.honorLabels }}
+      interval: {{ .Values.metricsAudit.serviceMonitor.interval }}
+      path: {{ .Values.metricsAudit.serviceMonitor.path }}
+      port: audit-metrics
+      scrapeTimeout: {{ .Values.metricsAudit.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+      - gatekeeper-system
+  selector:
+    matchLabels:
+      gatekeeper.sh/system: "yes"
+      gatekeeper.sh/operation: "audit"
+{{- end }}

--- a/manifest_staging/charts/gatekeeper/templates/webhook-metrics-service.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/webhook-metrics-service.yaml
@@ -1,0 +1,19 @@
+{{- if (.Values.metricsWebhook.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    gatekeeper.sh/system: "yes"
+    gatekeeper.sh/operation: "webhook"
+  name: gatekeeper-webhook-metrics-service
+  namespace: gatekeeper-system
+spec:
+  ports:
+  - port: 8888
+    name: webhook-metrics
+    targetPort: 8888
+  selector:
+    control-plane: controller-manager
+    gatekeeper.sh/operation: webhook
+    gatekeeper.sh/system: "yes"
+{{- end }}

--- a/manifest_staging/charts/gatekeeper/templates/webhook-servicemonitor.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/webhook-servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if and (.Values.metricsWebhook.enabled) (.Values.metricsWebhook.serviceMonitor) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: gatekeeper-webhook
+spec:
+  endpoints:
+    - honorLabels: {{ .Values.metricsWebhook.serviceMonitor.honorLabels }}
+      interval: {{ .Values.metricsWebhook.serviceMonitor.interval }}
+      path: {{ .Values.metricsWebhook.serviceMonitor.path }}
+      port: webhook-metrics
+      scrapeTimeout: {{ .Values.metricsWebhook.serviceMonitor.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+      - gatekeeper-system
+  selector:
+    matchLabels:
+      gatekeeper.sh/system: "yes"
+      gatekeeper.sh/operation: "webhook"
+{{- end }}

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -8,6 +8,23 @@ image:
   repository: openpolicyagent/gatekeeper
   release: v3.1.0-beta.9
   pullPolicy: IfNotPresent
+metricsAudit:
+  enabled: false
+  serviceMonitor:
+    enabled: true
+    honorLabels: true
+    interval: 15s
+    path: /metrics
+    scrapeTimeout: 10s
+metricsWebhook:
+  enabled: false
+  serviceMonitor:
+    enabled: true
+    honorLabels: true
+    interval: 15s
+    path: /metrics
+    scrapeTimeout: 10s
+
 nodeSelector: {
   kubernetes.io/os: linux
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the option to expose the metrics ports and create Prometheus ServiceMonitors for both the webhook-manager and audit-controller

**Which issue(s) this PR fixes**
Fixes #659 

**Special notes for your reviewer**:

This PR has targeted the helm chart - not sure if you would want the metrics services included in `deploy/gatekeeper.yaml`