### PR TITLE
Mitigate race condition setting logger on webhook initialization

### DIFF
--- a/pkg/webhook/namespacelabel.go
+++ b/pkg/webhook/namespacelabel.go
@@ -55,7 +55,9 @@ func AddLabelWebhook(mgr manager.Manager, _ *opa.Client, _ *process.Excluder) er
 	wh := &admission.Webhook{Handler: &namespaceLabelHandler{}}
 	// TODO(https://github.com/open-policy-agent/gatekeeper/issues/661): remove log injection if the race condition in the cited bug is eliminated.
 	// Otherwise we risk having unstable logger names for the webhook.
-	wh.InjectLogger(log)
+	if err := wh.InjectLogger(log); err != nil {
+		return err
+	}
 	mgr.GetWebhookServer().Register("/v1/admitlabel", wh)
 	return nil
 }

--- a/pkg/webhook/namespacelabel.go
+++ b/pkg/webhook/namespacelabel.go
@@ -53,6 +53,9 @@ func (l nsSet) Set(s string) error {
 // AddLabelWebhook registers the label webhook server with the manager
 func AddLabelWebhook(mgr manager.Manager, _ *opa.Client, _ *process.Excluder) error {
 	wh := &admission.Webhook{Handler: &namespaceLabelHandler{}}
+	// TODO(https://github.com/open-policy-agent/gatekeeper/issues/661): remove log injection if the race condition in the cited bug is eliminated.
+	// Otherwise we risk having unstable logger names for the webhook.
+	wh.InjectLogger(log)
 	mgr.GetWebhookServer().Register("/v1/admitlabel", wh)
 	return nil
 }

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -92,7 +92,9 @@ func AddPolicyWebhook(mgr manager.Manager, opa *opa.Client, processExcluder *pro
 	}
 	// TODO(https://github.com/open-policy-agent/gatekeeper/issues/661): remove log injection if the race condition in the cited bug is eliminated.
 	// Otherwise we risk having unstable logger names for the webhook.
-	wh.InjectLogger(log)
+	if err := wh.InjectLogger(log); err != nil {
+		return err
+	}
 	mgr.GetWebhookServer().Register("/v1/admit", wh)
 	return nil
 }

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -90,6 +90,9 @@ func AddPolicyWebhook(mgr manager.Manager, opa *opa.Client, processExcluder *pro
 			processExcluder: processExcluder,
 		},
 	}
+	// TODO(https://github.com/open-policy-agent/gatekeeper/issues/661): remove log injection if the race condition in the cited bug is eliminated.
+	// Otherwise we risk having unstable logger names for the webhook.
+	wh.InjectLogger(log)
 	mgr.GetWebhookServer().Register("/v1/admit", wh)
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:

This mitigates the hard-down webhook bug cited in #661

**Special notes for your reviewer**:

This should be a temporary mitigation, as it doesn't fix the full race condition. Now the controller-runtime webhook logs will be tagged with semi-random names.