### PR TITLE
set base helm chart url correctly to the release version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,7 @@ promote-staging-manifest:
 	@rm -rf charts
 	@cp -r manifest_staging/charts .
 	@helm package ./charts/gatekeeper -d ./charts/gatekeeper
-	@helm repo index ./charts/gatekeeper --url https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/charts/gatekeeper/
+	@helm repo index ./charts/gatekeeper --url "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/${NEWVERSION}/charts/gatekeeper/"
 
 # Delete gatekeeper from a cluster. Note this is not a complete uninstall, just a dev convenience
 uninstall:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -32,7 +32,7 @@ Publishing involves creating a release tag and creating a new *Release* on GitHu
 1. Promote staging manifest to release.
 
 	```
-	make promote-staging-manifest
+	make promote-staging-manifest NEWVERSION=v3.0.4-beta.x
 	```
 
 1. Preview the changes:


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, every time a new release is made, the base url points to master. This means when you pull the chart index regardless of a commit, it will not find the correct version. Instead the index should be specified correctly in the version.