### PR TITLE
Update Volumes PSP with a separate message for each violation.

### DIFF
--- a/library/pod-security-policy/volumes/src.rego
+++ b/library/pod-security-policy/volumes/src.rego
@@ -2,17 +2,16 @@ package k8spspvolumetypes
 
 violation[{"msg": msg, "details": {}}] {
     volume_fields := {x | input.review.object.spec.volumes[_][x]; x != "name"}
-    not input_volume_type_allowed(volume_fields)
-    msg := sprintf("One of the volume types %v is not allowed, pod: %v. Allowed volume types: %v", [volume_fields, input.review.object.metadata.name, input.parameters.volumes])
+    field := volume_fields[_]
+    not input_volume_type_allowed(field)
+    msg := sprintf("The volume type %v is not allowed, pod: %v. Allowed volume types: %v", [field, input.review.object.metadata.name, input.parameters.volumes])
 }
 
 # * may be used to allow all volume types
-input_volume_type_allowed(volume_fields) {
+input_volume_type_allowed(field) {
     input.parameters.volumes[_] == "*"
 }
 
-input_volume_type_allowed(volume_fields) {
-    allowed_set := {x | x = input.parameters.volumes[_]}
-    test := volume_fields - allowed_set
-    count(test) == 0
+input_volume_type_allowed(field) {
+    field == input.parameters.volumes[_]
 }

--- a/library/pod-security-policy/volumes/src_test.rego
+++ b/library/pod-security-policy/volumes/src_test.rego
@@ -6,6 +6,37 @@ test_input_volume_type_allowed_all {
     count(results) == 0
 }
 
+test_input_volume_type_allowed_all_many_volumes {
+    input := { "review": input_review_many, "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
+}
+test_input_volume_type_none_allowed {
+    input := { "review": input_review, "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 1
+}
+test_input_volume_type_none_allowed_many_volumes {
+    input := { "review": input_review_many, "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 2
+}
+test_input_volume_type_allowed_all_no_volumes {
+    input := { "review": input_review_no_volumes, "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
+}
+test_input_volume_type_none_allowed_no_volumes {
+    input := { "review": input_review_no_volumes, "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 0
+}
+test_input_volume_type_allowed_in_list_no_volumes {
+    input := { "review": input_review_no_volumes, "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 0
+}
+
 test_input_volume_type_allowed_in_list {
     input := { "review": input_review, "parameters": input_parameters_in_list}
     results := violation with input as input
@@ -15,7 +46,7 @@ test_input_volume_type_allowed_in_list {
 test_input_volume_type_allowed_not_in_list {
     input := { "review": input_review, "parameters": input_parameters_not_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 1
 }
 
 test_input_volume_type_allowed_in_list_many_volumes {
@@ -27,7 +58,13 @@ test_input_volume_type_allowed_in_list_many_volumes {
 test_input_volume_type_allowed_not_all_in_list_many_volumes {
     input := { "review": input_review_many, "parameters": input_parameters_not_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 2
+}
+
+test_input_volume_type_allowed_in_list_many_volumes_mixed {
+    input := { "review": input_review_many, "parameters": input_parameters_mixed}
+    results := violation with input as input
+    count(results) == 1
 }
 
 input_review = {
@@ -54,6 +91,17 @@ input_review_many = {
     }
 }
 
+input_review_no_volumes = {
+    "object": {
+        "metadata": {
+            "name": "nginx"
+        },
+        "spec": {
+            "containers": input_containers_no_volumes,
+      }
+    }
+}
+
 input_containers = [
 {
     "name": "nginx",
@@ -63,6 +111,12 @@ input_containers = [
         "mountPath": "/cache",
         "name": "cache-volume"
     }]
+}]
+
+input_containers_no_volumes = [
+{
+    "name": "nginx",
+    "image": "nginx"
 }]
 
 input_containers_many = [
@@ -105,6 +159,10 @@ input_volumes_many = [
     "emptyDir": {}
 }]
 
+input_parameters_empty = {
+     "volumes": []
+}
+
 input_parameters_wildcard = {
      "volumes": [
          "*"
@@ -118,9 +176,16 @@ input_parameters_in_list = {
     ]
 }
 
-input_parameters_not_in_list = {
+input_parameters_mixed = {
      "volumes": [
          "configMap",
          "emptyDir"
+    ]
+}
+
+input_parameters_not_in_list = {
+     "volumes": [
+         "configMap",
+         "secret"
     ]
 }

--- a/library/pod-security-policy/volumes/template.yaml
+++ b/library/pod-security-policy/volumes/template.yaml
@@ -21,18 +21,17 @@ spec:
         package k8spspvolumetypes
 
         violation[{"msg": msg, "details": {}}] {
-          volume_fields := {x | input.review.object.spec.volumes[_][x]; x != "name"}
-          not input_volume_type_allowed(volume_fields)
-          msg := sprintf("One of the volume types %v is not allowed, pod: %v. Allowed volume types: %v", [volume_fields, input.review.object.metadata.name, input.parameters.volumes])
+            volume_fields := {x | input.review.object.spec.volumes[_][x]; x != "name"}
+            field := volume_fields[_]
+            not input_volume_type_allowed(field)
+            msg := sprintf("The volume type %v is not allowed, pod: %v. Allowed volume types: %v", [field, input.review.object.metadata.name, input.parameters.volumes])
         }
 
         # * may be used to allow all volume types
-        input_volume_type_allowed(volume_fields) {
-          input.parameters.volumes[_] == "*"
+        input_volume_type_allowed(field) {
+            input.parameters.volumes[_] == "*"
         }
 
-        input_volume_type_allowed(volume_fields) {
-          allowed_set := {x | x = input.parameters.volumes[_]}
-          test := volume_fields - allowed_set
-          count(test) == 0
+        input_volume_type_allowed(field) {
+            field == input.parameters.volumes[_]
         }


### PR DESCRIPTION
**What this PR does / why we need it**:
The current implementation of the Volumes PSP will emit one message for any number of violations on a pod. This update brings the rego in line with other PSPs and emits a separate violation for each volume in error.
