### PR TITLE
Update Forbidden Sysctls PSP with separate message for each violation

### DIFF
--- a/library/pod-security-policy/forbidden-sysctls/src.rego
+++ b/library/pod-security-policy/forbidden-sysctls/src.rego
@@ -1,23 +1,20 @@
 package k8spspforbiddensysctls
 
 violation[{"msg": msg, "details": {}}] {
-    sysctls := {x | x = input.review.object.spec.securityContext.sysctls[_][name]}
-    count(sysctls) > 0
-    input_sysctls(sysctls)
-    msg := sprintf("One of the sysctls %v is not allowed, pod: %v. Forbidden sysctls: %v", [sysctls, input.review.object.metadata.name, input.parameters.forbiddenSysctls])
+    sysctl := input.review.object.spec.securityContext.sysctls[_].name
+    forbidden_sysctl(sysctl)
+    msg := sprintf("The sysctl %v is not allowed, pod: %v. Forbidden sysctls: %v", [sysctl, input.review.object.metadata.name, input.parameters.forbiddenSysctls])
 }
 
 # * may be used to forbid all sysctls
-input_sysctls(sysctls) {
+forbidden_sysctl(sysctl) {
     input.parameters.forbiddenSysctls[_] == "*"
 }
 
-input_sysctls(sysctls) {
-    forbidden_sysctls := {x | x = input.parameters.forbiddenSysctls[_]}
-    test := sysctls & forbidden_sysctls
-    count(test) > 0
+forbidden_sysctl(sysctl) {
+    input.parameters.forbiddenSysctls[_] == sysctl
 }
 
-input_sysctls(sysctls) {
-    startswith(sysctls[_], trim(input.parameters.forbiddenSysctls[_], "*"))
+forbidden_sysctl(sysctl) {
+    startswith(sysctl, trim(input.parameters.forbiddenSysctls[_], "*"))
 }

--- a/library/pod-security-policy/forbidden-sysctls/src_test.rego
+++ b/library/pod-security-policy/forbidden-sysctls/src_test.rego
@@ -1,48 +1,134 @@
 package k8spspforbiddensysctls
 
-test_input_sysctls_allowed_all {
+test_input_sysctls_forbidden_all {
     input := { "review": input_review, "parameters": input_parameters_wildcard}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 2
 }
 
-test_input_sysctls_allowed_in_list {
+test_input_sysctls_forbidden_in_list {
     input := { "review": input_review, "parameters": input_parameters_in_list}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 2
 }
 
-test_input_sysctls_allowed_not_in_list {
+test_input_sysctls_forbidden_in_list_mixed {
+    input := { "review": input_review, "parameters": input_parameters_one_in_list}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_sysctls_forbidden_not_in_list {
     input := { "review": input_review, "parameters": input_parameters_not_in_list}
     results := violation with input as input
     count(results) == 0
 }
 
-test_input_sysctls_allowed_in_list_wildcard {
+test_input_sysctls_forbidden_in_list_wildcard {
     input := { "review": input_review, "parameters": input_parameters_in_list_wildcard}
     results := violation with input as input
-    count(results) > 0
+    count(results) == 2
 }
 
-test_input_sysctls_allowed_not_in_list_wildcard {
+test_input_sysctls_forbidden_in_list_wildcard_mixed {
+    input := { "review": input_review, "parameters": input_parameters_one_in_list_wildcard}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_sysctls_forbidden_not_in_list_wildcard {
     input := { "review": input_review, "parameters": input_parameters_not_in_list_wildcard}
     results := violation with input as input
     count(results) == 0
 }
 
-test_input_sysctls_empty_allowed {
+test_input_sysctls_empty_forbidden {
     input := { "review": input_review, "parameters": input_parameters_empty}
     results := violation with input as input
     count(results) == 0
 }
 
-test_input_no_sysctls_wildcard_allowed {
+test_input_no_sysctls_wildcard {
     input := { "review": input_review_empty, "parameters": input_parameters_wildcard}
     results := violation with input as input
     count(results) == 0
 }
 
+test_input_empty_sysctls_wildcard {
+    input := { "review": input_review_sysctls_empty, "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_empty_wildcard {
+    input := { "review": input_review_empty_seccontext, "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_no_sysctls_empty_forbidden {
+    input := { "review": input_review_empty, "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_empty_empty_forbidden {
+    input := { "review": input_review_empty_seccontext, "parameters": input_parameters_empty}
+    results := violation with input as input
+    count(results) == 0
+}
+
+test_input_init_sysctls_forbidden_all {
+    input := { "review": input_init_review, "parameters": input_parameters_wildcard}
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_input_init_sysctls_forbidden_in_list {
+    input := { "review": input_init_review, "parameters": input_parameters_in_list}
+    results := violation with input as input
+    count(results) == 2
+}
+
+test_input_init_sysctls_forbidden_in_list_mixed {
+    input := { "review": input_init_review, "parameters": input_parameters_one_in_list}
+    results := violation with input as input
+    count(results) == 1
+}
+
+test_input_init_sysctls_forbidden_not_in_list {
+    input := { "review": input_init_review, "parameters": input_parameters_not_in_list}
+    results := violation with input as input
+    count(results) == 0
+}
+
 input_review = {
+    "object": {
+        "metadata": {
+            "name": "nginx"
+        },
+        "spec": {
+            "containers": {
+                "name": "nginx",
+                "image": "nginx",
+            },
+            "securityContext": {
+                "sysctls": [
+                    {
+                        "name": "kernel.shm_rmid_forced",
+                        "value": "0"
+                    },
+                    {
+                        "name": "net.core.somaxconn",
+                        "value": "1024"
+                    }
+                ]
+            }
+        }
+    }
+}
+
+input_init_review = {
     "object": {
         "metadata": {
             "name": "nginx"
@@ -84,6 +170,37 @@ input_review_empty = {
     }
 }
 
+input_review_sysctls_empty = {
+    "object": {
+        "metadata": {
+            "name": "nginx"
+        },
+        "spec": {
+            "containers": {
+                "name": "nginx",
+                "image": "nginx",
+            },
+            "securityContext": {
+                "sysctls": []
+            }
+        }
+    }
+}
+
+input_review_empty_seccontext = {
+    "object": {
+        "metadata": {
+            "name": "nginx"
+        },
+        "spec": {
+            "containers": {
+                "name": "nginx",
+                "image": "nginx",
+            }
+        }
+    }
+}
+
 input_parameters_wildcard = {
     "forbiddenSysctls": [
         "*"
@@ -97,6 +214,12 @@ input_parameters_in_list = {
     ]
 }
 
+input_parameters_one_in_list = {
+    "forbiddenSysctls": [
+        "kernel.shm_rmid_forced"
+    ]
+}
+
 input_parameters_not_in_list = {
     "forbiddenSysctls": [
         "kernel.msgmax"
@@ -107,6 +230,12 @@ input_parameters_in_list_wildcard = {
     "forbiddenSysctls": [
         "kernel.*",
         "net.core*"
+    ]
+}
+
+input_parameters_one_in_list_wildcard = {
+    "forbiddenSysctls": [
+        "kernel.*"
     ]
 }
 

--- a/library/pod-security-policy/forbidden-sysctls/template.yaml
+++ b/library/pod-security-policy/forbidden-sysctls/template.yaml
@@ -21,27 +21,20 @@ spec:
         package k8spspforbiddensysctls
 
         violation[{"msg": msg, "details": {}}] {
-            sysctls := {x | x = input.review.object.spec.securityContext.sysctls[_][name]}
-            count(sysctls) > 0
-            input_sysctls(sysctls)
-            msg := sprintf("One of the sysctls %v is not allowed, pod: %v. Forbidden sysctls: %v", [sysctls, input.review.object.metadata.name, input.parameters.forbiddenSysctls])
+            sysctl := input.review.object.spec.securityContext.sysctls[_].name
+            forbidden_sysctl(sysctl)
+            msg := sprintf("The sysctl %v is not allowed, pod: %v. Forbidden sysctls: %v", [sysctl, input.review.object.metadata.name, input.parameters.forbiddenSysctls])
         }
 
         # * may be used to forbid all sysctls
-        input_sysctls(sysctls) {
+        forbidden_sysctl(sysctl) {
             input.parameters.forbiddenSysctls[_] == "*"
         }
 
-        input_sysctls(sysctls) {
-            forbidden_sysctls := {x | x = input.parameters.forbiddenSysctls[_]}
-            test := sysctls & forbidden_sysctls
-            count(test) > 0
+        forbidden_sysctl(sysctl) {
+            input.parameters.forbiddenSysctls[_] == sysctl
         }
 
-        input_sysctls(sysctls) {
-            prefix_matches(input.parameters.forbiddenSysctls[_], sysctls[_])
-        }
-
-        prefix_matches(prefix, sysctl) {
-            contains(sysctl, trim(prefix, "*"))
+        forbidden_sysctl(sysctl) {
+            startswith(sysctl, trim(input.parameters.forbiddenSysctls[_], "*"))
         }


### PR DESCRIPTION
Signed-off-by: Emma McMillan <emma.mcmillan@microsoft.com>

**What this PR does / why we need it**:
The current implementation of the Forbidden Sysctls PSP will emit one message for any number of violations on a pod. This update brings the rego in line with other PSPs and emits a separate violation for each sysctl in error.