### PR TITLE
Fix (#713) Sync controller cancels expectations for deleted resources

### DIFF
--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -295,7 +295,7 @@ func (r *ReconcileConstraint) Reconcile(request reconcile.Request) (reconcile.Re
 		r.constraintsCache.deleteConstraintKey(constraintKey)
 		reportMetrics = true
 
-		//cancel expectations
+		// cancel expectations
 		t := r.tracker.For(instance.GroupVersionKind())
 		t.CancelExpect(instance)
 

--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -295,6 +295,10 @@ func (r *ReconcileConstraint) Reconcile(request reconcile.Request) (reconcile.Re
 		r.constraintsCache.deleteConstraintKey(constraintKey)
 		reportMetrics = true
 
+		//cancel expectations
+		t := r.tracker.For(instance.GroupVersionKind())
+		t.CancelExpect(instance)
+
 		sName, err := constraintstatusv1beta1.KeyForConstraint(util.GetPodName(), instance)
 		if err != nil {
 			return reconcile.Result{}, err

--- a/pkg/controller/sync/sync_controller.go
+++ b/pkg/controller/sync/sync_controller.go
@@ -173,6 +173,9 @@ func (r *ReconcileSync) Reconcile(request reconcile.Request) (reconcile.Result, 
 			if _, err := r.opa.RemoveData(context.Background(), instance); err != nil {
 				return reconcile.Result{}, err
 			}
+			// cancel expectations
+			t := r.tracker.ForData(instance.GroupVersionKind())
+			t.CancelExpect(instance)
 			r.metricsCache.DeleteObject(syncKey)
 			reportMetrics = true
 			return reconcile.Result{}, nil
@@ -193,6 +196,9 @@ func (r *ReconcileSync) Reconcile(request reconcile.Request) (reconcile.Result, 
 		if _, err := r.opa.RemoveData(context.Background(), instance); err != nil {
 			return reconcile.Result{}, err
 		}
+		// cancel expectations
+		t := r.tracker.ForData(instance.GroupVersionKind())
+		t.CancelExpect(instance)
 		r.metricsCache.DeleteObject(syncKey)
 		reportMetrics = true
 		return reconcile.Result{}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

When the resources are deleted in the sync controller, we need to also cancel their expectations .This is needed as its obstructing the gatekeeper controller to become ready.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #713

**Special notes for your reviewer**: