### PR TITLE
Add support for emit k8s events for audit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ MANAGER_IMAGE_PATCH := "apiVersion: apps/v1\
 \n        args:\
 \n        - --port=8443\
 \n        - --logtostderr\
-\n        - --emit-deny-events\
+\n        - --emit-admission-events\
 \n        - --exempt-namespace=gatekeeper-system\
 \n        - --operation=webhook\
 \n---\
@@ -118,7 +118,7 @@ e2e-helm-deploy:
 	cd .staging/helm && tar -xvf helmbin.tar.gz
 	./.staging/helm/linux-amd64/helm init --wait --history-max=5
 	kubectl -n kube-system wait --for=condition=Ready pod -l name=tiller --timeout=300s
-	./.staging/helm/linux-amd64/helm install manifest_staging/charts/gatekeeper --name=tiger --set image.repository=${HELM_REPO} --set image.release=${HELM_RELEASE} --set emitDenyEvents=true --set emitAuditEvents=true
+	./.staging/helm/linux-amd64/helm install manifest_staging/charts/gatekeeper --name=tiger --set image.repository=${HELM_REPO} --set image.release=${HELM_RELEASE} --set emitAdmissionEvents=true --set emitAuditEvents=true
 
 # Build manager binary
 manager: generate fmt vet

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,12 @@ MANAGER_IMAGE_PATCH := "apiVersion: apps/v1\
 \n      containers:\
 \n      - image: <your image file>\
 \n        name: manager\
+\n        args:\
+\n        - --port=8443\
+\n        - --logtostderr\
+\n        - --emit-deny-events\
+\n        - --exempt-namespace=gatekeeper-system\
+\n        - --operation=webhook\
 \n---\
 \napiVersion: apps/v1\
 \nkind: Deployment\
@@ -43,7 +49,12 @@ MANAGER_IMAGE_PATCH := "apiVersion: apps/v1\
 \n    spec:\
 \n      containers:\
 \n      - image: <your image file>\
-\n        name: auditcontainer"
+\n        name: auditcontainer\
+\n        args:\
+\n        - --emit-audit-events\
+\n        - --operation=audit\
+\n        - --operation=status\
+\n        - --logtostderr"
 
 
 FRAMEWORK_PACKAGE := github.com/open-policy-agent/frameworks/constraint
@@ -107,7 +118,7 @@ e2e-helm-deploy:
 	cd .staging/helm && tar -xvf helmbin.tar.gz
 	./.staging/helm/linux-amd64/helm init --wait --history-max=5
 	kubectl -n kube-system wait --for=condition=Ready pod -l name=tiller --timeout=300s
-	./.staging/helm/linux-amd64/helm install manifest_staging/charts/gatekeeper --name=tiger --set image.repository=${HELM_REPO} --set image.release=${HELM_RELEASE}
+	./.staging/helm/linux-amd64/helm install manifest_staging/charts/gatekeeper --name=tiger --set image.repository=${HELM_REPO} --set image.release=${HELM_RELEASE} --set emitDenyEvents=true --set emitAuditEvents=true
 
 # Build manager binary
 manager: generate fmt vet

--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -53,7 +53,7 @@ spec:
           args:
             - --port=8443
             - --logtostderr
-            - --emit-deny-events
+            - --emit-deny-events={{ .Values.emitDenyEvents }}
             - --log-level={{ .Values.logLevel }}
             - --exempt-namespace=gatekeeper-system
             - --operation=webhook
@@ -83,6 +83,7 @@ spec:
         - --log-level={{ .Values.logLevel }}
         - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
         - --audit-from-cache={{ .Values.auditFromCache }}
+        - --emit-audit-events={{ .Values.emitAuditEvents }}
         - --operation=audit
         - --operation=status
         - --logtostderr

--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -53,7 +53,7 @@ spec:
           args:
             - --port=8443
             - --logtostderr
-            - --emit-deny-events={{ .Values.emitDenyEvents }}
+            - --emit-admission-events={{ .Values.emitAdmissionEvents }}
             - --log-level={{ .Values.logLevel }}
             - --exempt-namespace=gatekeeper-system
             - --operation=webhook

--- a/cmd/build/helmify/static/README.md
+++ b/cmd/build/helmify/static/README.md
@@ -8,6 +8,8 @@
 | constraintViolationsLimit | The maximum # of audit violations reported on a constraint  | `20`                                                                      |
 | auditFromCache            | Take the roster of resources to audit from the OPA cache    | `false`                                                                   |
 | disableValidatingWebhook  | Disable ValidatingWebhook                                   | `false`                                                                   |
+| emitDenyEvents            | Emit K8s events in gatekeeper namespace for admission denies| `false`                                                                   |
+| emitAuditEvents           | Emit K8s events in gatekeeper namespace for audit violations| `false`                                                                   |
 | logLevel                  | Minimum log level                                           | `INFO`                                                                    |
 | image.pullPolicy          | The image pull policy                                       | `IfNotPresent`                                                            |
 | image.repository          | Image repository                                            | `openpolicyagent/gatekeeper`                                              |

--- a/cmd/build/helmify/static/README.md
+++ b/cmd/build/helmify/static/README.md
@@ -8,7 +8,7 @@
 | constraintViolationsLimit | The maximum # of audit violations reported on a constraint  | `20`                                                                      |
 | auditFromCache            | Take the roster of resources to audit from the OPA cache    | `false`                                                                   |
 | disableValidatingWebhook  | Disable ValidatingWebhook                                   | `false`                                                                   |
-| emitDenyEvents            | Emit K8s events in gatekeeper namespace for admission denies| `false`                                                                   |
+| emitAdmissionEvents      | Emit K8s events in gatekeeper namespace for admission violations| `false`                                                                   |
 | emitAuditEvents           | Emit K8s events in gatekeeper namespace for audit violations| `false`                                                                   |
 | logLevel                  | Minimum log level                                           | `INFO`                                                                    |
 | image.pullPolicy          | The image pull policy                                       | `IfNotPresent`                                                            |

--- a/cmd/build/helmify/static/README.md
+++ b/cmd/build/helmify/static/README.md
@@ -8,8 +8,8 @@
 | constraintViolationsLimit | The maximum # of audit violations reported on a constraint  | `20`                                                                      |
 | auditFromCache            | Take the roster of resources to audit from the OPA cache    | `false`                                                                   |
 | disableValidatingWebhook  | Disable ValidatingWebhook                                   | `false`                                                                   |
-| emitAdmissionEvents      | Emit K8s events in gatekeeper namespace for admission violations| `false`                                                                   |
-| emitAuditEvents           | Emit K8s events in gatekeeper namespace for audit violations| `false`                                                                   |
+| emitAdmissionEvents       | Emit K8s events in gatekeeper namespace for admission violations (alpha feature)| `false`                                                                   |
+| emitAuditEvents           | Emit K8s events in gatekeeper namespace for audit violations (alpha feature)| `false`                                                                   |
 | logLevel                  | Minimum log level                                           | `INFO`                                                                    |
 | image.pullPolicy          | The image pull policy                                       | `IfNotPresent`                                                            |
 | image.repository          | Image repository                                            | `openpolicyagent/gatekeeper`                                              |

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -4,7 +4,7 @@ constraintViolationsLimit: 20
 auditFromCache: false
 disableValidatingWebhook: false
 logLevel: INFO
-emitDenyEvents: false
+emitAdmissionEvents: false
 emitAuditEvents: false
 image:
   repository: openpolicyagent/gatekeeper

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -4,6 +4,8 @@ constraintViolationsLimit: 20
 auditFromCache: false
 disableValidatingWebhook: false
 logLevel: INFO
+emitDenyEvents: false
+emitAuditEvents: false
 image:
   repository: openpolicyagent/gatekeeper
   release: v3.1.0-beta.10

--- a/config/crd/bases/config.gatekeeper.sh_configs.yaml
+++ b/config/crd/bases/config.gatekeeper.sh_configs.yaml
@@ -48,6 +48,12 @@ spec:
                     type: array
                 type: object
               type: array
+            readiness:
+              description: Configuration for readiness tracker
+              properties:
+                statsEnabled:
+                  type: boolean
+              type: object
             sync:
               description: Configuration for syncing k8s objects
               properties:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -123,6 +123,7 @@ spec:
         - args:
             - --operation=audit
             - --operation=status
+            - "--emit-audit-events"
             - --logtostderr
           command:
             - /manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,7 +47,6 @@ spec:
           args:
             - "--port=8443"
             - "--logtostderr"
-            - "--emit-admission-events=false"
             - "--exempt-namespace=gatekeeper-system"
             - "--operation=webhook"
           image: openpolicyagent/gatekeeper:v3.1.0-beta.10
@@ -123,7 +122,6 @@ spec:
         - args:
             - --operation=audit
             - --operation=status
-            - --emit-audit-events=false
             - --logtostderr
           command:
             - /manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,7 +47,7 @@ spec:
           args:
             - "--port=8443"
             - "--logtostderr"
-            - "--emit-deny-events=false"
+            - "--emit-admission-events=false"
             - "--exempt-namespace=gatekeeper-system"
             - "--operation=webhook"
           image: openpolicyagent/gatekeeper:v3.1.0-beta.10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -47,7 +47,7 @@ spec:
           args:
             - "--port=8443"
             - "--logtostderr"
-            - "--emit-deny-events"
+            - "--emit-deny-events=false"
             - "--exempt-namespace=gatekeeper-system"
             - "--operation=webhook"
           image: openpolicyagent/gatekeeper:v3.1.0-beta.10
@@ -123,7 +123,7 @@ spec:
         - args:
             - --operation=audit
             - --operation=status
-            - "--emit-audit-events"
+            - --emit-audit-events=false
             - --logtostderr
           command:
             - /manager

--- a/manifest_staging/charts/gatekeeper/README.md
+++ b/manifest_staging/charts/gatekeeper/README.md
@@ -8,6 +8,8 @@
 | constraintViolationsLimit | The maximum # of audit violations reported on a constraint  | `20`                                                                      |
 | auditFromCache            | Take the roster of resources to audit from the OPA cache    | `false`                                                                   |
 | disableValidatingWebhook  | Disable ValidatingWebhook                                   | `false`                                                                   |
+| emitAdmissionEvents      | Emit K8s events in gatekeeper namespace for admission violations| `false`                                                                   |
+| emitAuditEvents           | Emit K8s events in gatekeeper namespace for audit violations| `false`                                                                   |
 | logLevel                  | Minimum log level                                           | `INFO`                                                                    |
 | image.pullPolicy          | The image pull policy                                       | `IfNotPresent`                                                            |
 | image.repository          | Image repository                                            | `openpolicyagent/gatekeeper`                                              |

--- a/manifest_staging/charts/gatekeeper/README.md
+++ b/manifest_staging/charts/gatekeeper/README.md
@@ -8,8 +8,8 @@
 | constraintViolationsLimit | The maximum # of audit violations reported on a constraint  | `20`                                                                      |
 | auditFromCache            | Take the roster of resources to audit from the OPA cache    | `false`                                                                   |
 | disableValidatingWebhook  | Disable ValidatingWebhook                                   | `false`                                                                   |
-| emitAdmissionEvents      | Emit K8s events in gatekeeper namespace for admission violations| `false`                                                                   |
-| emitAuditEvents           | Emit K8s events in gatekeeper namespace for audit violations| `false`                                                                   |
+| emitAdmissionEvents       | Emit K8s events in gatekeeper namespace for admission violations (alpha feature)| `false`                                                                   |
+| emitAuditEvents           | Emit K8s events in gatekeeper namespace for audit violations (alpha feature)| `false`                                                                   |
 | logLevel                  | Minimum log level                                           | `INFO`                                                                    |
 | image.pullPolicy          | The image pull policy                                       | `IfNotPresent`                                                            |
 | image.repository          | Image repository                                            | `openpolicyagent/gatekeeper`                                              |

--- a/manifest_staging/charts/gatekeeper/templates/config-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/config-customresourcedefinition.yaml
@@ -56,6 +56,12 @@ spec:
                     type: array
                 type: object
               type: array
+            readiness:
+              description: Configuration for readiness tracker
+              properties:
+                statsEnabled:
+                  type: boolean
+              type: object
             sync:
               description: Configuration for syncing k8s objects
               properties:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - --log-level={{ .Values.logLevel }}
         - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
         - --audit-from-cache={{ .Values.auditFromCache }}
+        - --emit-audit-events={{ .Values.emitAuditEvents }}
         - --operation=audit
         - --operation=status
         - --logtostderr

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -51,7 +51,7 @@ spec:
       - args:
         - --port=8443
         - --logtostderr
-        - --emit-deny-events={{ .Values.emitDenyEvents }}
+        - --emit-admission-events={{ .Values.emitAdmissionEvents }}
         - --log-level={{ .Values.logLevel }}
         - --exempt-namespace=gatekeeper-system
         - --operation=webhook

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -51,7 +51,7 @@ spec:
       - args:
         - --port=8443
         - --logtostderr
-        - --emit-deny-events
+        - --emit-deny-events={{ .Values.emitDenyEvents }}
         - --log-level={{ .Values.logLevel }}
         - --exempt-namespace=gatekeeper-system
         - --operation=webhook

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -4,7 +4,7 @@ constraintViolationsLimit: 20
 auditFromCache: false
 disableValidatingWebhook: false
 logLevel: INFO
-emitDenyEvents: false
+emitAdmissionEvents: false
 emitAuditEvents: false
 image:
   repository: openpolicyagent/gatekeeper

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -4,6 +4,8 @@ constraintViolationsLimit: 20
 auditFromCache: false
 disableValidatingWebhook: false
 logLevel: INFO
+emitDenyEvents: false
+emitAuditEvents: false
 image:
   repository: openpolicyagent/gatekeeper
   release: v3.1.0-beta.10

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -639,6 +639,7 @@ spec:
       - args:
         - --operation=audit
         - --operation=status
+        - --emit-audit-events
         - --logtostderr
         command:
         - /manager

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -639,7 +639,7 @@ spec:
       - args:
         - --operation=audit
         - --operation=status
-        - --emit-audit-events
+        - --emit-audit-events=false
         - --logtostderr
         command:
         - /manager
@@ -732,7 +732,7 @@ spec:
       - args:
         - --port=8443
         - --logtostderr
-        - --emit-deny-events
+        - --emit-deny-events=false
         - --exempt-namespace=gatekeeper-system
         - --operation=webhook
         command:

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -645,7 +645,6 @@ spec:
       - args:
         - --operation=audit
         - --operation=status
-        - --emit-audit-events=false
         - --logtostderr
         command:
         - /manager
@@ -738,7 +737,6 @@ spec:
       - args:
         - --port=8443
         - --logtostderr
-        - --emit-admission-events=false
         - --exempt-namespace=gatekeeper-system
         - --operation=webhook
         command:

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -57,6 +57,12 @@ spec:
                     type: array
                 type: object
               type: array
+            readiness:
+              description: Configuration for readiness tracker
+              properties:
+                statsEnabled:
+                  type: boolean
+              type: object
             sync:
               description: Configuration for syncing k8s objects
               properties:

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -732,7 +732,7 @@ spec:
       - args:
         - --port=8443
         - --logtostderr
-        - --emit-deny-events=false
+        - --emit-admission-events=false
         - --exempt-namespace=gatekeeper-system
         - --operation=webhook
         command:

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -24,6 +24,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -43,6 +48,7 @@ var (
 	auditInterval             = flag.Uint("audit-interval", defaultAuditInterval, "interval to run audit in seconds. defaulted to 60 secs if unspecified, 0 to disable ")
 	constraintViolationsLimit = flag.Uint("constraint-violations-limit", defaultConstraintViolationsLimit, "limit of number of violations per constraint. defaulted to 20 violations if unspecified ")
 	auditFromCache            = flag.Bool("audit-from-cache", false, "pull resources from OPA cache when auditing")
+	emitAuditEvents           = flag.Bool("emit-audit-events", false, "emit Kubernetes events in gatekeeper namespace with detailed info for each violation from an audit")
 	emptyAuditResults         []auditResult
 )
 
@@ -58,6 +64,8 @@ type Manager struct {
 	reporter        *reporter
 	log             logr.Logger
 	processExcluder *process.Excluder
+	eventRecorder   record.EventRecorder
+	gkNamespace     string
 }
 
 type auditResult struct {
@@ -111,6 +119,12 @@ func New(ctx context.Context, mgr manager.Manager, opa *opa.Client, processExclu
 		log.Error(err, "StatsReporter could not start")
 		return nil, err
 	}
+	eventBroadcaster := record.NewBroadcaster()
+	kubeClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
+	eventBroadcaster.StartRecordingToSink(&clientcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(
+		scheme.Scheme,
+		corev1.EventSource{Component: "gatekeeper-audit"})
 
 	am := &Manager{
 		opa:             opa,
@@ -120,6 +134,8 @@ func New(ctx context.Context, mgr manager.Manager, opa *opa.Client, processExclu
 		ctx:             ctx,
 		reporter:        reporter,
 		processExcluder: processExcluder,
+		eventRecorder:   recorder,
+		gkNamespace:     util.GetNamespace(),
 	}
 	return am, nil
 }
@@ -183,7 +199,7 @@ func (am *Manager) audit(ctx context.Context) error {
 		am.log.Info("Audit discovery client results", "violations", len(res))
 	}
 
-	updateLists, totalViolationsPerConstraint, totalViolationsPerEnforcementAction, err := am.getUpdateListsFromAuditResponses(res)
+	updateLists, totalViolationsPerConstraint, totalViolationsPerEnforcementAction, err := am.getUpdateListsFromAuditResponses(res, timestamp)
 	if err != nil {
 		return err
 	}
@@ -343,7 +359,7 @@ func (am *Manager) getAllConstraintKinds() ([]schema.GroupVersionKind, error) {
 	return ret, nil
 }
 
-func (am *Manager) getUpdateListsFromAuditResponses(res []*constraintTypes.Result) (map[string][]auditResult, map[string]int64, map[util.EnforcementAction]int64, error) {
+func (am *Manager) getUpdateListsFromAuditResponses(res []*constraintTypes.Result, timestamp string) (map[string][]auditResult, map[string]int64, map[util.EnforcementAction]int64, error) {
 	updateLists := make(map[string][]auditResult)
 	totalViolationsPerConstraint := make(map[string]int64)
 	totalViolationsPerEnforcementAction := make(map[util.EnforcementAction]int64)
@@ -384,6 +400,9 @@ func (am *Manager) getUpdateListsFromAuditResponses(res []*constraintTypes.Resul
 		ea := util.EnforcementAction(enforcementAction)
 		totalViolationsPerEnforcementAction[ea]++
 		logViolation(am.log, r.Constraint, r.EnforcementAction, result)
+		if *emitAuditEvents {
+			emitEvent(r.Constraint, r.EnforcementAction, result, am.eventRecorder, timestamp, am.gkNamespace)
+		}
 	}
 	// log constraints with violations
 	for link := range updateLists {
@@ -625,4 +644,32 @@ func logViolation(l logr.Logger, constraint *unstructured.Unstructured, enforcem
 		logging.ResourceNamespace, violation.rnamespace,
 		logging.ResourceName, violation.rname,
 	)
+}
+
+func emitEvent(constraint *unstructured.Unstructured, enforcementAction string, violation auditResult, eventRecorder record.EventRecorder, timestamp string, gkNamespace string) {
+	annotations := map[string]string{
+		"process":                   "audit",
+		"auditTimestamp":            timestamp,
+		logging.EventType:           "violation_audited",
+		logging.ConstraintKind:      constraint.GetKind(),
+		logging.ConstraintName:      constraint.GetName(),
+		logging.ConstraintNamespace: constraint.GetNamespace(),
+		logging.ConstraintAction:    enforcementAction,
+		logging.ResourceKind:        violation.rkind,
+		logging.ResourceNamespace:   violation.rnamespace,
+		logging.ResourceName:        violation.rname,
+	}
+	reason := "AuditViolation"
+	ref := getViolationRef(gkNamespace, violation.rkind, violation.rname, timestamp)
+
+	eventRecorder.AnnotatedEventf(ref, annotations, corev1.EventTypeWarning, reason, "Timestamp: %s, Resource Namespace: %s, Constraint: %s, Message: %s", timestamp, violation.rnamespace, constraint.GetName(), violation.message)
+}
+
+func getViolationRef(gkNamespace, kind, name, timestamp string) *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		Kind:      kind,
+		Name:      name,
+		UID:       types.UID(name + timestamp),
+		Namespace: gkNamespace,
+	}
 }

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -47,7 +47,7 @@ var (
 	auditInterval             = flag.Uint("audit-interval", defaultAuditInterval, "interval to run audit in seconds. defaulted to 60 secs if unspecified, 0 to disable ")
 	constraintViolationsLimit = flag.Uint("constraint-violations-limit", defaultConstraintViolationsLimit, "limit of number of violations per constraint. defaulted to 20 violations if unspecified ")
 	auditFromCache            = flag.Bool("audit-from-cache", false, "pull resources from OPA cache when auditing")
-	emitAuditEvents           = flag.Bool("emit-audit-events", false, "emit Kubernetes events in gatekeeper namespace with detailed info for each violation from an audit")
+	emitAuditEvents           = flag.Bool("emit-audit-events", false, "(alpha) emit Kubernetes events in gatekeeper namespace with detailed info for each violation from an audit")
 	emptyAuditResults         []auditResult
 )
 

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -396,6 +395,7 @@ func (am *Manager) getUpdateListsFromAuditResponses(res []*constraintTypes.Resul
 			enforcementAction: enforcementAction,
 			constraint:        r.Constraint,
 		}
+
 		updateLists[selfLink] = append(updateLists[selfLink], result)
 		ea := util.EnforcementAction(enforcementAction)
 		totalViolationsPerEnforcementAction[ea]++
@@ -660,16 +660,16 @@ func emitEvent(constraint *unstructured.Unstructured, enforcementAction string, 
 		logging.ResourceName:        violation.rname,
 	}
 	reason := "AuditViolation"
-	ref := getViolationRef(gkNamespace, violation.rkind, violation.rname, timestamp)
+	ref := getViolationRef(gkNamespace, violation.rkind, violation.rname, violation.rnamespace, constraint.GetKind(), constraint.GetName(), constraint.GetNamespace())
 
 	eventRecorder.AnnotatedEventf(ref, annotations, corev1.EventTypeWarning, reason, "Timestamp: %s, Resource Namespace: %s, Constraint: %s, Message: %s", timestamp, violation.rnamespace, constraint.GetName(), violation.message)
 }
 
-func getViolationRef(gkNamespace, kind, name, timestamp string) *corev1.ObjectReference {
+func getViolationRef(gkNamespace, rkind, rname, rnamespace, ckind, cname, cnamespace string) *corev1.ObjectReference {
 	return &corev1.ObjectReference{
-		Kind:      kind,
-		Name:      name,
-		UID:       types.UID(name + timestamp),
+		Kind:      rkind,
+		Name:      rname,
+		UID:       types.UID(rkind + "/" + rnamespace + "/" + rname + "/" + ckind + "/" + cnamespace + "/" + cname),
 		Namespace: gkNamespace,
 	}
 }

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -34,7 +34,6 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/target"
 	"github.com/open-policy-agent/gatekeeper/pkg/util"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,7 +46,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	clientcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -66,7 +64,6 @@ var log = logf.Log.WithName("webhook")
 
 const (
 	serviceAccountName = "gatekeeper-admin"
-	deploymentName     = "gatekeeper-controller-manager"
 )
 
 var (
@@ -90,38 +87,20 @@ func AddPolicyWebhook(mgr manager.Manager, opa *opa.Client, processExcluder *pro
 		return err
 	}
 	eventBroadcaster := record.NewBroadcaster()
-
 	kubeClient := kubernetes.NewForConfigOrDie(mgr.GetConfig())
-	if err != nil {
-		return err
-	}
 	eventBroadcaster.StartRecordingToSink(&clientcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(
 		scheme.Scheme,
 		corev1.EventSource{Component: "gatekeeper-webhook"})
-	client := mgr.GetClient()
-	var ref *corev1.ObjectReference
-	if *emitDenyEvents {
-		gkDeploy := &appsv1.Deployment{}
-		deploy := types.NamespacedName{Namespace: util.GetNamespace(), Name: deploymentName}
-		err = client.Get(context.Background(), deploy, gkDeploy)
-		if err != nil {
-			return err
-		}
-		ref, err = reference.GetReference(scheme.Scheme, gkDeploy)
-		if err != nil {
-			return err
-		}
-	}
 	wh := &admission.Webhook{
 		Handler: &validationHandler{
 			opa:             opa,
-			client:          client,
+			client:          mgr.GetClient(),
 			reader:          mgr.GetAPIReader(),
 			reporter:        reporter,
 			processExcluder: processExcluder,
 			eventRecorder:   recorder,
-			reference:       ref,
+			gkNamespace:     util.GetNamespace(),
 		},
 	}
 	// TODO(https://github.com/open-policy-agent/gatekeeper/issues/661): remove log injection if the race condition in the cited bug is eliminated.
@@ -146,7 +125,7 @@ type validationHandler struct {
 	injectedConfig  *v1alpha1.Config
 	processExcluder *process.Excluder
 	eventRecorder   record.EventRecorder
-	reference       *corev1.ObjectReference
+	gkNamespace     string
 }
 
 type requestResponse string
@@ -271,7 +250,7 @@ func (h *validationHandler) getDenyMessages(res []*rtypes.Result, req admission.
 					"request_username", req.AdmissionRequest.UserInfo.Username,
 				).Info("denied admission")
 			}
-			if *emitDenyEvents && h.reference != nil {
+			if *emitDenyEvents {
 				annotations := map[string]string{
 					"process":            "admission",
 					"event_type":         "violation",
@@ -289,7 +268,8 @@ func (h *validationHandler) getDenyMessages(res []*rtypes.Result, req admission.
 					eventMsg = "Dryrun violation"
 					reason = "DryrunViolation"
 				}
-				h.eventRecorder.AnnotatedEventf(h.reference, annotations, corev1.EventTypeWarning, reason, "%s: [Namespace: %s Kind: %s Name: %s] by constraint %s %s", eventMsg, req.AdmissionRequest.Namespace, req.AdmissionRequest.Kind.Kind, resourceName, r.Constraint.GetName(), r.Msg)
+				ref := getViolationRef(h.gkNamespace, req.AdmissionRequest.Kind.Kind, resourceName)
+				h.eventRecorder.AnnotatedEventf(ref, annotations, corev1.EventTypeWarning, reason, "%s, Resource Namespace: %s, Constraint %s, Message: %s", eventMsg, req.AdmissionRequest.Namespace, r.Constraint.GetName(), r.Msg)
 			}
 
 		}
@@ -429,4 +409,15 @@ func (h *validationHandler) tracingLevel(ctx context.Context, req admission.Requ
 
 func (h *validationHandler) skipExcludedNamespace(namespace string) bool {
 	return h.processExcluder.IsNamespaceExcluded(process.Webhook, namespace)
+}
+
+func getViolationRef(gkNamespace, kind, name string) *corev1.ObjectReference {
+	now := time.Now()
+	timestamp := now.UTC().Format(time.RFC3339)
+	return &corev1.ObjectReference{
+		Kind:      kind,
+		Name:      name,
+		UID:       types.UID(name + timestamp),
+		Namespace: gkNamespace,
+	}
 }

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -72,7 +72,7 @@ var (
 	deserializer                       = codecs.UniversalDeserializer()
 	disableEnforcementActionValidation = flag.Bool("disable-enforcementaction-validation", false, "disable validation of the enforcementAction field of a constraint")
 	logDenies                          = flag.Bool("log-denies", false, "log detailed info on each deny")
-	emitAdmissionEvents                = flag.Bool("emit-admission-events", false, "emit Kubernetes events in gatekeeper namespace for each admission violation")
+	emitAdmissionEvents                = flag.Bool("emit-admission-events", false, "(alpha) emit Kubernetes events in gatekeeper namespace for each admission violation")
 	serviceaccount                     = fmt.Sprintf("system:serviceaccount:%s:%s", util.GetNamespace(), serviceAccountName)
 	// webhookName is deprecated, set this on the manifest YAML if needed"
 )

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -181,6 +181,9 @@ teardown() {
 
   events=$(kubectl get events -n gatekeeper-system --field-selector reason=DryrunViolation -o json | jq -r '.items[] | select(.metadata.annotations.constraint_kind=="K8sRequiredLabels" )' | jq -s '. | length')
   [[ "$events" -eq 1 ]]
+
+  events=$(kubectl get events -n gatekeeper-system --field-selector reason=AuditViolation -o json | jq -r '.items[] | select(.metadata.annotations.constraint_kind=="K8sRequiredLabels" )' | jq -s '. | length')
+  [[ "$events" -ge 6 ]]
 }
 
 @test "config namespace exclusion test" {


### PR DESCRIPTION
**What this PR does / why we need it**:

- [x] Emit K8s events in gatekeeper namespace for audit violations. NOTE: Event object's Reference object `UUID = violating resource kind + violating resource name + violating resource namespace +  constraint kind + constraint name + constraint namespace` e.g: `"uid": "Namespace//tt2/K8sRequiredLabels//ns-must-have-gk"`
- [x] Update logic for emit K8s events in gatekeeper namespace for admission denies. Reference object matches the kind and name of the violating resource
- [x] Update e2e to get events with the following reasons: `FailedAdmission`, `DryrunViolation`, and `AuditViolation`
- [x] Update deployment yaml and chart to default `emit-admission-events` and `emit-audit-events` to `false`
- [x] Update Makefile to enable `emit-admission-events` and `emit-audit-events` to `true` for e2e

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #579 

**Special notes for your reviewer**:

Sample event outputs for reasons `FailedAdmission`, `DryrunViolation`, and `AuditViolation` respectively:
```sh
kubectl get event -n gatekeeper-system                                                                                                                                
LAST SEEN   TYPE      REASON              OBJECT                                   MESSAGE
53m         Warning   FailedAdmission   pod/opa-test-deployment-566fc979b4-zxkrm   Admission webhook "validation.gatekeeper.sh" denied request, Resource Namespace: default, Constraint container-must-have-limits, Message: container <opa-test> has no resource limits

11m         Warning   DryrunViolation   namespace/tt                               Dryrun violation, Resource Namespace: , Constraint ns-must-have-gk, Message: you must provide labels: {"gatekeeper"}

13m         Warning   AuditViolation    namespace/local-path-storage               Timestamp: 2020-07-22T03:45:21Z, Resource Namespace: , Constraint: ns-must-have-gk, Message: you must provide labels: {"gatekeeper"}
```