### PR TITLE
Do not trigger a watch of pods for status owner ref

### DIFF
--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -181,7 +181,7 @@ type ReconcileConstraint struct {
 	constraintsCache *ConstraintsCache
 	tracker          *readiness.Tracker
 	getPod           func() (*corev1.Pod, error)
-	pod *corev1.Pod
+	pod              *corev1.Pod
 }
 
 // +kubebuilder:rbac:groups=constraints.gatekeeper.sh,resources=*,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -39,12 +39,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -233,7 +231,6 @@ type ReconcileConstraintTemplate struct {
 	cs            *watch.ControllerSwitch
 	metrics       *reporter
 	tracker       *readiness.Tracker
-	pod           *corev1.Pod
 	getPod        func() (*corev1.Pod, error)
 }
 
@@ -488,28 +485,9 @@ func (r *ReconcileConstraintTemplate) handleDelete(
 }
 
 func (r *ReconcileConstraintTemplate) defaultGetPod() (*corev1.Pod, error) {
-	if r.pod != nil {
-		return r.pod.DeepCopy(), nil
-	}
-	ns := util.GetNamespace()
-	name := util.GetPodName()
-	key := types.NamespacedName{Namespace: ns, Name: name}
-	pod := &corev1.Pod{}
-	// use unstructured to avoid inadvertently creating a watch on pods
-	uPod := &unstructured.Unstructured{}
-	gvk, err := apiutil.GVKForObject(pod, r.scheme)
-	if err != nil {
-		return nil, err
-	}
-	uPod.SetGroupVersionKind(gvk)
-	if err := r.Get(context.TODO(), key, uPod); err != nil {
-		return nil, err
-	}
-	if err := r.scheme.Convert(uPod, pod, nil); err != nil {
-		return nil, err
-	}
-	r.pod = pod
-	return pod.DeepCopy(), nil
+	// require injection of GetPod in order to control what client we use to
+	// guarantee we don't inadvertently create a watch
+	panic("GetPod must be injected")
 }
 
 func (r *ReconcileConstraintTemplate) deleteAllStatus(ctName string) error {

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -233,7 +233,7 @@ type ReconcileConstraintTemplate struct {
 	cs            *watch.ControllerSwitch
 	metrics       *reporter
 	tracker       *readiness.Tracker
-	pod *corev1.Pod
+	pod           *corev1.Pod
 	getPod        func() (*corev1.Pod, error)
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,13 +17,27 @@ package controller
 
 import (
 	"context"
+	"flag"
+	"os"
+	"sync"
 
 	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
+	podstatus "github.com/open-policy-agent/gatekeeper/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/pkg/readiness"
+	"github.com/open-policy-agent/gatekeeper/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/pkg/watch"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var (
+	debugUseFakePod = flag.Bool("debug-use-fake-pod", false, "Use a fake pod name so the Gatekeeper executable can be run outside of Kubernetes")
 )
 
 type Injector interface {
@@ -59,11 +73,72 @@ type Dependencies struct {
 	ProcessExcluder  *process.Excluder
 }
 
+type defaultPodGetter struct {
+	client client.Client
+	scheme *runtime.Scheme
+	pod    *corev1.Pod
+	mux    sync.RWMutex
+}
+
+func (g *defaultPodGetter) GetPod() (*corev1.Pod, error) {
+	var pod *corev1.Pod
+	pod = func() *corev1.Pod {
+		g.mux.RLock()
+		defer g.mux.RUnlock()
+		return g.pod
+	}()
+	if pod != nil {
+		return pod.DeepCopy(), nil
+	}
+	g.mux.Lock()
+	defer g.mux.Unlock()
+	// guard against the race condition where the pod has been retrieved
+	// between releasing the read lock and acquiring the write lock
+	if g.pod != nil {
+		return g.pod.DeepCopy(), nil
+	}
+	ns := util.GetNamespace()
+	name := util.GetPodName()
+	key := types.NamespacedName{Namespace: ns, Name: name}
+	// use unstructured to avoid inadvertently creating a watch on pods
+	uPod := &unstructured.Unstructured{}
+	gvk, err := apiutil.GVKForObject(pod, r.scheme)
+	if err != nil {
+		return nil, err
+	}
+	uPod.SetGroupVersionKind(gvk)
+	if err := g.client.Get(context.TODO(), key, uPod); err != nil {
+		return nil, err
+	}
+	if err := g.scheme.Convert(uPod, pod, nil); err != nil {
+		return nil, err
+	}
+	g.pod = pod
+	return pod.DeepCopy(), nil
+}
+
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager, deps Dependencies) error {
 	// Reset cache on start - this is to allow for the future possibility that the OPA cache is stored remotely
 	if err := deps.Opa.Reset(context.Background()); err != nil {
 		return err
+	}
+	if deps.GetPod == nil {
+		podGetter := &defaultPodGetter{
+			scheme: m.GetScheme(),
+			client: m.GetClient(),
+		}
+		deps.GetPod = podGetter.GetPod
+	}
+	if *debugUseFakePod {
+		os.Setenv("POD_NAME", "no-pod")
+		podstatus.DisablePodOwnership()
+		fakePodGetter := func() (*corev1.Pod, error) {
+			pod := &corev1.Pod{}
+			pod.Name = util.GetPodName()
+			return pod, nil
+		}
+		deps.GetPod = fakePodGetter
 	}
 	for _, a := range Injectors {
 		a.InjectOpa(deps.Opa)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -81,8 +81,7 @@ type defaultPodGetter struct {
 }
 
 func (g *defaultPodGetter) GetPod() (*corev1.Pod, error) {
-	var pod *corev1.Pod
-	pod = func() *corev1.Pod {
+	pod := func() *corev1.Pod {
 		g.mux.RLock()
 		defer g.mux.RUnlock()
 		return g.pod
@@ -102,7 +101,7 @@ func (g *defaultPodGetter) GetPod() (*corev1.Pod, error) {
 	key := types.NamespacedName{Namespace: ns, Name: name}
 	// use unstructured to avoid inadvertently creating a watch on pods
 	uPod := &unstructured.Unstructured{}
-	gvk, err := apiutil.GVKForObject(pod, r.scheme)
+	gvk, err := apiutil.GVKForObject(pod, g.scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -96,6 +96,7 @@ func (g *defaultPodGetter) GetPod() (*corev1.Pod, error) {
 	if g.pod != nil {
 		return g.pod.DeepCopy(), nil
 	}
+	pod = &corev1.Pod{}
 	ns := util.GetNamespace()
 	name := util.GetPodName()
 	key := types.NamespacedName{Namespace: ns, Name: name}


### PR DESCRIPTION
Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:

This PR should avoid triggering a watch of all pods in the cluster when getting the self-referenced pod.

This also re-adds the ability to run Gatekeeper outside of a Kubernetes cluster for testing purposes, per #738 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #742 

**Special notes for your reviewer**: