### PR TITLE
Chart version must follow the SemVer2 standard

### DIFF
--- a/charts/gatekeeper/Chart.yaml
+++ b/charts/gatekeeper/Chart.yaml
@@ -3,7 +3,7 @@ description: A Helm chart for Gatekeeper
 name: gatekeeper
 keywords:
   - open policy agent
-version: v3.1.0-beta.12
+version: 3.1.0-beta.12
 home: https://github.com/open-policy-agent/gatekeeper
 sources:
   - https://github.com/open-policy-agent/gatekeeper.git


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the chart version to comply with SemVer2.

**Special notes for your reviewer**:

A SemVer2 version is not prepended with `v`.

See: https://helm.sh/docs/topics/charts/#charts-and-versioning and https://semver.org/spec/v2.0.0.html#backusnaur-form-grammar-for-valid-semver-versions
