### PR TITLE
Use constraint match kind on audit

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -50,7 +50,7 @@ var (
 	auditChunkSize            = flag.Uint64("audit-chunk-size", defaultListLimit, "(alpha) Kubernetes API chunking List results when retrieving cluster resources using discovery client. defaulted to 0 if unspecified")
 	auditFromCache            = flag.Bool("audit-from-cache", false, "pull resources from OPA cache when auditing")
 	emitAuditEvents           = flag.Bool("emit-audit-events", false, "(alpha) emit Kubernetes events in gatekeeper namespace with detailed info for each violation from an audit")
-	constraintMatchKindOnly   = flag.Bool("constraint-match-kind-only", false, "only use kinds specified in all constraints for auditing cluster resources. if kind is not specified in any of the constraints, it will audit all resources (same as setting this flag to false)")
+	auditMatchKindOnly        = flag.Bool("audit-match-kind-only", false, "only use kinds specified in all constraints for auditing cluster resources. if kind is not specified in any of the constraints, it will audit all resources (same as setting this flag to false)")
 	emptyAuditResults         []auditResult
 )
 
@@ -276,7 +276,7 @@ func (am *Manager) auditResources(
 	nsCache := newNSCache()
 
 	constraintsList := make(map[string]bool)
-	if *constraintMatchKindOnly {
+	if *auditMatchKindOnly {
 		constraintList := &unstructured.UnstructuredList{}
 		for _, c := range resourceList {
 			constraintList.SetGroupVersionKind(c)

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -306,7 +306,7 @@ func (am *Manager) auditResources(
 							continue
 						}
 						for _, kk := range kindsKind {
-							if kk.(string) == "" {
+							if kk.(string) == "" || kk.(string) == "*" {
 								// no need to continue, all kinds are included
 								matchedKinds["*"] = true
 								break constraintsLoop
@@ -318,6 +318,7 @@ func (am *Manager) auditResources(
 				} else {
 					// if constraint doesn't have match kinds defined, we will look at all kinds
 					matchedKinds["*"] = true
+					break constraintsLoop
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
Adds an opt-in flag to use the match kinds specified by constraints to optimize audit duration. If any constraints does not define this field, it will be same as not having this flag turned off and will check all the resources in the cluster.

Audit times are on a 50 node cluster with 5k pods/serviceaccounts/namespaces with 30 templates (1 constraints each - using `dryrun` enforcement action) and violations limit is set as 0.

without this optimization:
- `constraint-match-kind-only: false` and `emit-audit-events: false`: audit took ~20 minutes
- `constraint-match-kind-only: false` and `emit-audit-events: true`: audit took ~40 minutes

with this optimization, and only `Pod` kind defined in the constraints:
- `constraint-match-kind-only: true` and `emit-audit-events: false`: audit took ~5 minutes
- `constraint-match-kind-only: true` and `emit-audit-events: true`: audit took ~5 minutes 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: