### PR TITLE
Fix server-side apply checks of namespaces

### DIFF
--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -353,6 +353,12 @@ func (h *validationHandler) validateConstraint(ctx context.Context, req admissio
 // traceSwitch returns true if a request should be traced
 func (h *validationHandler) reviewRequest(ctx context.Context, req admission.Request) (*rtypes.Responses, error) {
 	trace, dump := h.tracingLevel(ctx, req)
+	// Coerce server-side apply admission requests into treating namespaces
+	// the same way as older admission requests. See
+	// https://github.com/open-policy-agent/gatekeeper/issues/792
+	if req.Kind.Kind == "Namespace" && req.Kind.Group == "" {
+		req.Namespace = ""
+	}
 	review := &target.AugmentedReview{AdmissionRequest: &req.AdmissionRequest}
 	if req.AdmissionRequest.Namespace != "" {
 		ns := &corev1.Namespace{}


### PR DESCRIPTION
Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:
This makes sure server-side apply requests of Namespaces look like non-server-side apply requests to avoid breaking any code that detects cluster-scoped objects by checking for `req.namespace == ""`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #792

**Special notes for your reviewer**: