### PR TITLE
add DNSName to SAN for go1.15 CN deprecation

### DIFF
--- a/pkg/webhook/certs.go
+++ b/pkg/webhook/certs.go
@@ -309,6 +309,9 @@ func (cr *CertRotator) createCertPEM(ca *KeyPairArtifacts) ([]byte, []byte, erro
 		Subject: pkix.Name{
 			CommonName: cr.DNSName,
 		},
+		DNSNames: []string{
+			cr.DNSName,
+		},
 		NotBefore:             begin,
 		NotAfter:              end,
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,


### PR DESCRIPTION
**What this PR does / why we need it**:
Go 1.15 [deprecated the use of the CommonName field as a HostName when no SANs are present](https://golang.org/doc/go1.15#commonname).
Kubernetes v1.19 is [now built with 1.15](https://github.com/kubernetes/kubernetes/blob/release-1.19/build/build-image/cross/VERSION) and so has this deprecation in place.

Thus the default installation on a 1.19 cluster will have webhook TLS errors. e.g., when running the `agilebank` demo:
```
$ kubectl create ns advanced-transaction-system
Error from server (InternalError): Internal error occurred: failed calling webhook "check-ignore-label.gatekeeper.sh": Post "https://gatekeeper-webhook-service.gatekeeper.svc:443/v1/admitlabel?timeout=5s": x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
```

This PR adds the `DNSName` to the certs as a SAN - with this change, the demo executes without error.

**Which issue(s) this PR fixes**: N/A
