### PR TITLE
Make e2e k8s version configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ USE_LOCAL_IMG ?= false
 VERSION := v3.1.0-rc.1
 
 KIND_VERSION ?= 0.8.1
+# note: k8s version pinned since KIND image availability lags k8s releases
+KUBERNETES_VERSION ?= v1.19.0
 KUSTOMIZE_VERSION ?= 3.7.0
 HELM_VERSION ?= 2.16.10
 
@@ -92,7 +94,7 @@ e2e-bootstrap:
 	# Download and install kind
 	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output ${GITHUB_WORKSPACE}/bin/kind && chmod +x ${GITHUB_WORKSPACE}/bin/kind
 	# Download and install kubectl
-	curl -L https://storage.googleapis.com/kubernetes-release/release/$$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o ${GITHUB_WORKSPACE}/bin/kubectl && chmod +x ${GITHUB_WORKSPACE}/bin/kubectl
+	curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBERNETES_VERSION}/bin/linux/amd64/kubectl -o ${GITHUB_WORKSPACE}/bin/kubectl && chmod +x ${GITHUB_WORKSPACE}/bin/kubectl
 	# Download and install kustomize
 	curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz -o kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && tar -zxvf kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && chmod +x kustomize && mv kustomize ${GITHUB_WORKSPACE}/bin/kustomize
 	# Download and install bats
@@ -100,7 +102,7 @@ e2e-bootstrap:
 	# Check for existing kind cluster
 	if [ $$(kind get clusters) ]; then kind delete cluster; fi
 	# Create a new kind cluster
-	TERM=dumb kind create cluster
+	TERM=dumb kind create cluster --image kindest/node:${KUBERNETES_VERSION}
 
 e2e-build-load-image: docker-buildx
 	kind load docker-image --name kind ${IMG}


### PR DESCRIPTION
**What this PR does / why we need it**: 
Updates the KIND invocation to accept a k8s version, and defaults to the latest published stable version.

**Which issue(s) this PR fixes** : N/A

**Special notes for your reviewer**: Last follow up to https://github.com/open-policy-agent/gatekeeper/pull/811#issuecomment-686850836! :slightly_smiling_face: 