### PR TITLE
Fix the example template.

### DIFF
--- a/example/templates/k8srequiredlabels_template.yaml
+++ b/example/templates/k8srequiredlabels_template.yaml
@@ -13,7 +13,8 @@ spec:
           properties:
             labels:
               type: array
-              items: string
+              items:
+                type: string
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the example template. The items field of properties is a JSONSchemaPropsOrArray and not a string.
To give a consistent and bug free example. Plus, it was found while investigating an issue.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #832

**Special notes for your reviewer**: