### PR TITLE
Remove the shortname from the constraint template.

### DIFF
--- a/charts/gatekeeper/templates/constrainttemplate-customresourcedefinition.yaml
+++ b/charts/gatekeeper/templates/constrainttemplate-customresourcedefinition.yaml
@@ -18,8 +18,6 @@ spec:
   names:
     kind: ConstraintTemplate
     plural: constrainttemplates
-    shortNames:
-    - constraints
   scope: Cluster
   subresources:
     status: {}

--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -25,10 +25,6 @@ metadata:
     helm.sh/hook: crd-install
     helm.sh/hook-delete-policy: before-hook-creation
 status: null
-spec:
-  names:
-    shortNames:
-      - constraints # add shortName to CRD until https://github.com/kubernetes-sigs/kubebuilder/issues/404 is solved
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
**What this PR does / why we need it**:

The current shortname (constraints) is misleading as constraint (singular) is used to refer generated CRDs.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #677 (the first bit)

**Special notes for your reviewer**: