### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,9 @@ Once data is synced into OPA, rules can access the cached data under the `data.i
 
 The `data.inventory` document has the following format:
 
-  * For cluster-scoped objects: `data.inventory.cluster[<groupVersion>][<kind>][<name>]`
+  * For cluster-scoped objects: `data.inventory.cluster[<apiVersion>][<kind>][<name>]`
      * Example referencing the Gatekeeper namespace: `data.inventory.cluster["v1"].Namespace["gatekeeper"]`
-  * For namespace-scoped objects: `data.inventory.namespace[<namespace>][groupVersion][<kind>][<name>]`
+  * For namespace-scoped objects: `data.inventory.namespace[<namespace>][apiVersion][<kind>][<name>]`
      * Example referencing the Gatekeeper pod: `data.inventory.namespace["gatekeeper"]["v1"]["Pod"]["gatekeeper-controller-manager-d4c98b788-j7d92"]`
 
 ### Audit


### PR DESCRIPTION
The `groupVersion` seems to be misleading. I believe one should provide the complete apiVersion which is `groupName/groupVersion` to access the k8s resources data.

For ex:  If we want to access deployments from `apps` group revision `v1`, the data query should look like `data.inventory.namespace[ns]["apps/v1"].Deployment[name]