### PR TITLE
Reduce webhook timeout to 3 seconds

### DIFF
--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -13,11 +13,11 @@ metadata:
 webhooks:
   - name: validation.gatekeeper.sh
     sideEffects: None
-    timeoutSeconds: 5
+    timeoutSeconds: 3
     namespaceSelector:
       matchExpressions:
         - key: admission.gatekeeper.sh/ignore
           operator: DoesNotExist
   - name: check-ignore-label.gatekeeper.sh
     sideEffects: None
-    timeoutSeconds: 5
+    timeoutSeconds: 3

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -34,7 +34,7 @@ webhooks:
     resources:
     - '*'
   sideEffects: None
-  timeoutSeconds: 5
+  timeoutSeconds: 3
 - clientConfig:
     caBundle: Cg==
     service:
@@ -54,5 +54,5 @@ webhooks:
     resources:
     - namespaces
   sideEffects: None
-  timeoutSeconds: 5
+  timeoutSeconds: 3
 {{- end }}

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -866,7 +866,7 @@ webhooks:
     resources:
     - '*'
   sideEffects: None
-  timeoutSeconds: 5
+  timeoutSeconds: 3
 - clientConfig:
     caBundle: Cg==
     service:
@@ -886,4 +886,4 @@ webhooks:
     resources:
     - namespaces
   sideEffects: None
-  timeoutSeconds: 5
+  timeoutSeconds: 3


### PR DESCRIPTION
Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:
This fixes an issue where certain core K8s leader elections can time out if Gatekeeper's webhook is down, preventing self-healing.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #870 

**Special notes for your reviewer**: