### PR TITLE
Fix path in ignore label test

### DIFF
--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -32,7 +32,7 @@ teardown() {
   kubectl run temp --generator=run-pod/v1  --image=tutum/curl -- tail -f /dev/null
   kubectl wait --for=condition=Ready --timeout=60s pod temp
   kubectl cp ${cert} temp:/cacert
-  
+
   run wait_for_process $WAIT_TIME $SLEEP_TIME "kubectl exec -it temp -- curl -f --cacert /cacert --connect-timeout 1 --max-time 2  https://gatekeeper-webhook-service.gatekeeper-system.svc:443/v1/admitlabel"
   assert_success
   kubectl delete pod temp
@@ -65,7 +65,8 @@ teardown() {
 }
 
 @test "no ignore label unless namespace is exempt test" {
-  run kubectl apply -f ${BATS_TESTS_DIR}/good/ignore_label_ns.yaml
+  run kubectl apply -f ${BATS_TESTS_DIR}/bad/ignore_label_ns.yaml
+  assert_match 'Only exempt namespace can have the admission.gatekeeper.sh/ignore label' "$output"
   assert_failure
 }
 

--- a/test/bats/tests/bad/ignore_label_ns.yaml
+++ b/test/bats/tests/bad/ignore_label_ns.yaml
@@ -3,4 +3,4 @@ kind: Namespace
 metadata:
   name: bad-ns
   labels:
-    admission.gatekeeper.sh/ignore: yes
+    admission.gatekeeper.sh/ignore: "yes"


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:

This step is expected to fail. It was failing because of file was not found. However, we want it to fail with a deny because of admission flag can only be added when a namespace is added to `--exempt-namespace`. 

- Added a specific string assert match to confirm it is getting denied by Gatekeeper.
- updated `yes` to `"yes"` because of k8s string validation.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #872 

**Special notes for your reviewer**: