### PR TITLE
Add cert readiness tracker

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,6 +187,14 @@ func main() {
 		setupLog.Error(err, "unable to register readiness tracker")
 		os.Exit(1)
 	}
+	if operations.IsAssigned(operations.Webhook) {
+		// Setup cert tracker and register readiness probe.
+		err = readiness.SetupCertTracker(mgr, *certDir, dnsName)
+		if err != nil {
+			setupLog.Error(err, "unable to register readiness cert tracker")
+			os.Exit(1)
+		}
+	}
 
 	// +kubebuilder:scaffold:builder
 

--- a/pkg/readiness/cert_tracker.go
+++ b/pkg/readiness/cert_tracker.go
@@ -1,0 +1,112 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readiness
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var ctLog = logf.Log.WithName("cert-tracker")
+
+// CertTracker tracks readiness for certs of the webhook.
+type CertTracker struct {
+	certDir string
+	dnsName string
+}
+
+// NewCertTracker creates a new CertTracker
+func NewCertTracker(certDir string, dnsName string) *CertTracker {
+	return &CertTracker{
+		certDir: certDir,
+		dnsName: dnsName,
+	}
+}
+
+// CheckCert implements healthz.Checker to report readiness based on cert validity
+// the readiness probe returns nil if valid, otherwise returns an error.
+func (c *CertTracker) CheckCert(req *http.Request) error {
+	ctLog.V(1).Info("readiness checker CheckCert started")
+
+	// Load files
+	caCrt, err := ioutil.ReadFile(filepath.Join(c.certDir, "ca.crt"))
+	if err != nil {
+		return errors.Wrap(err, "Unable to open CA cert")
+	}
+
+	tlsCrt, err := ioutil.ReadFile(filepath.Join(c.certDir, "tls.crt"))
+	if err != nil {
+		return errors.Wrap(err, "Unable to open tls crt")
+	}
+	tlsKey, err := ioutil.ReadFile(filepath.Join(c.certDir, "tls.key"))
+	if err != nil {
+		return errors.Wrap(err, "Unable to open tls key")
+	}
+	err = ValidCert(caCrt, tlsCrt, tlsKey, c.dnsName)
+	if err != nil {
+		return errors.Wrap(err, "readiness checker CheckCert certs not valid")
+	}
+	ctLog.V(1).Info("readiness checker CheckCert completed")
+	return nil
+}
+
+// ValidCert checks validity of cert
+func ValidCert(caCert, cert, key []byte, dnsName string) error {
+	if len(caCert) == 0 || len(cert) == 0 || len(key) == 0 {
+		return errors.New("empty cert")
+	}
+
+	pool := x509.NewCertPool()
+	caDer, _ := pem.Decode(caCert)
+	if caDer == nil {
+		return errors.New("bad CA cert")
+	}
+	cac, err := x509.ParseCertificate(caDer.Bytes)
+	if err != nil {
+		return errors.Wrap(err, "parsing CA cert")
+	}
+	pool.AddCert(cac)
+
+	_, err = tls.X509KeyPair(cert, key)
+	if err != nil {
+		return errors.Wrap(err, "building key pair")
+	}
+
+	b, _ := pem.Decode(cert)
+	if b == nil {
+		return errors.New("bad private key")
+	}
+
+	crt, err := x509.ParseCertificate(b.Bytes)
+	if err != nil {
+		return errors.Wrap(err, "parsing cert")
+	}
+	_, err = crt.Verify(x509.VerifyOptions{
+		DNSName: dnsName,
+		Roots:   pool,
+	})
+	if err != nil {
+		return errors.Wrap(err, "verifying cert")
+	}
+	return nil
+}

--- a/pkg/readiness/cert_tracker_test.go
+++ b/pkg/readiness/cert_tracker_test.go
@@ -1,0 +1,224 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readiness_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/open-policy-agent/gatekeeper/pkg/readiness"
+	"github.com/pkg/errors"
+)
+
+const (
+	certName       = "tls.crt"
+	keyName        = "tls.key"
+	caCertName     = "ca.crt"
+	caName         = "ca"
+	caOrganization = "org"
+	certDir        = ""
+	dnsName        = "service.namespace"
+)
+
+// Test_CertTracker periodically verifies the webhook tls cert is valid,
+// the generated cert is valid before it's expired
+// the readiness probe returns nil if valid, otherwise returns an error.
+func Test_CertTracker(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mgr, _ := setupManager(t)
+
+	caArtifacts, err := createCACert()
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "creating ca cert")
+
+	cert, key, err := createCertPEM(caArtifacts, 3*time.Second)
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "creating cert pem")
+
+	caCrtFile := filepath.Join(certDir, caCertName)
+	defer os.Remove(caCrtFile)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+	err = ioutil.WriteFile(caCrtFile, caArtifacts.CertPEM, 0644)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+
+	crtFile := filepath.Join(certDir, certName)
+	defer os.Remove(crtFile)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+	err = ioutil.WriteFile(crtFile, cert, 0644)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+
+	keyFile := filepath.Join(certDir, keyName)
+	defer os.Remove(keyFile)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+	err = ioutil.WriteFile(keyFile, key, 0644)
+	if err != nil {
+		t.Fatalf("expected error to be nil, got: %+v", err)
+	}
+
+	err = readiness.SetupCertTracker(mgr, certDir, dnsName)
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "setting up cert tracker")
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	g.Eventually(func() (bool, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		return probeIsReady(ctx)
+	}, 5*time.Second, 1*time.Second).Should(gomega.BeFalse())
+}
+
+// Test_CertTracker_NoFile verifies the webhook tls cert is valid,
+// the readiness probe returns returns an error if there's no file.
+func Test_CertTracker_NoFile(t *testing.T) {
+	g := gomega.NewWithT(t)
+
+	mgr, _ := setupManager(t)
+	err := readiness.SetupCertTracker(mgr, "", "")
+	g.Expect(err).NotTo(gomega.HaveOccurred(), "setting up cert tracker")
+
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	g.Eventually(func() (bool, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		return probeIsReady(ctx)
+	}, 3*time.Second, 1*time.Second).Should(gomega.BeFalse())
+}
+
+// KeyPairArtifacts stores cert artifacts.
+type KeyPairArtifacts struct {
+	Cert    *x509.Certificate
+	Key     *rsa.PrivateKey
+	CertPEM []byte
+	KeyPEM  []byte
+}
+
+// createCACert creates the self-signed CA cert and private key that will
+// be used to sign the server certificate
+func createCACert() (*KeyPairArtifacts, error) {
+	now := time.Now()
+	begin := now.Add(-1 * time.Hour)
+	end := now.Add(5 * time.Minute)
+	templ := &x509.Certificate{
+		SerialNumber: big.NewInt(0),
+		Subject: pkix.Name{
+			CommonName:   caName,
+			Organization: []string{caOrganization},
+		},
+		DNSNames: []string{
+			caName,
+		},
+		NotBefore:             begin,
+		NotAfter:              end,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, errors.Wrap(err, "generating key")
+	}
+	der, err := x509.CreateCertificate(rand.Reader, templ, templ, key.Public(), key)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating certificate")
+	}
+	certPEM, keyPEM, err := pemEncode(der, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "encoding PEM")
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing certificate")
+	}
+
+	return &KeyPairArtifacts{Cert: cert, Key: key, CertPEM: certPEM, KeyPEM: keyPEM}, nil
+}
+
+// createCertPEM takes the results of createCACert and uses it to create the
+// PEM-encoded public certificate and private key, respectively
+func createCertPEM(ca *KeyPairArtifacts, duration time.Duration) ([]byte, []byte, error) {
+	now := time.Now()
+	begin := now.Add(-1 * time.Hour)
+	end := now.Add(duration)
+	templ := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: dnsName,
+		},
+		DNSNames: []string{
+			dnsName,
+		},
+		NotBefore:             begin,
+		NotAfter:              end,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "generating key")
+	}
+	der, err := x509.CreateCertificate(rand.Reader, templ, ca.Cert, key.Public(), ca.Key)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "creating certificate")
+	}
+	certPEM, keyPEM, err := pemEncode(der, key)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "encoding PEM")
+	}
+	return certPEM, keyPEM, nil
+}
+
+// pemEncode takes a certificate and encodes it as PEM
+func pemEncode(certificateDER []byte, key *rsa.PrivateKey) ([]byte, []byte, error) {
+	certBuf := &bytes.Buffer{}
+	if err := pem.Encode(certBuf, &pem.Block{Type: "CERTIFICATE", Bytes: certificateDER}); err != nil {
+		return nil, nil, errors.Wrap(err, "encoding cert")
+	}
+	keyBuf := &bytes.Buffer{}
+	if err := pem.Encode(keyBuf, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}); err != nil {
+		return nil, nil, errors.Wrap(err, "encoding key")
+	}
+	return certBuf.Bytes(), keyBuf.Bytes(), nil
+}

--- a/pkg/readiness/setup.go
+++ b/pkg/readiness/setup.go
@@ -39,8 +39,21 @@ func SetupTracker(mgr manager.Manager) (*Tracker, error) {
 	}
 
 	if err := mgr.AddReadyzCheck("tracker", tracker.CheckSatisfied); err != nil {
-		return nil, fmt.Errorf("registering readiness check: %w", err)
+		return nil, fmt.Errorf("registering readiness CheckSatisfied: %w", err)
 	}
 
 	return tracker, nil
+}
+
+// SetupCertTracker sets up a readiness cert tracker and registers it to run under control of the
+// provided Manager object.
+// NOTE: Must be called _before_ the manager is started.
+func SetupCertTracker(mgr manager.Manager, certDir string, dnsName string) error {
+	certTracker := NewCertTracker(certDir, dnsName)
+
+	if err := mgr.AddReadyzCheck("certtracker", certTracker.CheckCert); err != nil {
+		return fmt.Errorf("registering readiness CheckCert: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

**What this PR does / why we need it**:
Setup cert tracker and register readiness probe for the webhook. The cert tracker implements healthz.Checker to report readiness based on cert validity. The readiness probe returns nil if valid, otherwise returns an error.

Cert generation code in the test is copied from https://github.com/open-policy-agent/cert-controller

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: