### PR TITLE
Fix deprecated add-path in CI

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -26,19 +26,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-        id: go
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: Install golangci-lint
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin
-          echo ::add-path::$GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin v${GOLANGCILINT_VERSION}
         env:
           GOLANGCILINT_VERSION: 1.30.0
@@ -52,21 +46,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+        id: go
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
+
       - name: Unit test
         run: |
-          arch=amd64
-          version=2.3.1
-          curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_linux_${arch}.tar.gz" &&\
-            tar -zxvf kubebuilder_${version}_linux_${arch}.tar.gz &&\
-            sudo mv kubebuilder_${version}_linux_${arch} /usr/local/kubebuilder
-          version=3.7.0
-          curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_v${version}_linux_${arch}.tar.gz" &&\
-            tar -zxvf kustomize_v${version}_linux_${arch}.tar.gz &&\
+          curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64.tar.gz" &&\
+            tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64.tar.gz &&\
+            sudo mv kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64 /usr/local/kubebuilder
+          curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" &&\
+            tar -zxvf kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz &&\
             chmod +x kustomize &&\
             sudo mv kustomize /usr/local/bin
           make native-test
+        env:
+          KUBEBUILDER_VERSION: 2.3.1
+          KUSTOMIZE_VERSION: 3.7.0
+
       - name: Codecov Upload
         uses: codecov/codecov-action@v1
         with:
@@ -79,19 +81,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-        id: go
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: Bootstrap e2e
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin
-          echo ::add-path::$GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           make e2e-bootstrap
 
       - name: Run e2e
@@ -110,19 +106,13 @@ jobs:
       matrix:
         HELM_VERSION: ["2.16.10", "3.3.0"]
     steps:
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-        id: go
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: Bootstrap e2e
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin
-          echo ::add-path::$GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           make e2e-bootstrap
 
       - name: Run e2e
@@ -196,7 +186,7 @@ jobs:
       - name: Bootstrap e2e
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin
-          echo ::add-path::$GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           make e2e-bootstrap
 
       - name: Verify release
@@ -204,10 +194,7 @@ jobs:
           make e2e-verify-release IMG=${{ env.IMAGE_REPO }}:${TAG} USE_LOCAL_IMG=false
 
       - name: Create GitHub release
-        # using latest due to breaking change
-        # TODO: pin to a tagged version when it's out
-        # https://github.com/marvinpinto/actions/issues/39
-        uses: "marvinpinto/action-automatic-releases@latest"
+        uses: "marvinpinto/action-automatic-releases@v1.1.0"
         with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
           prerelease: false


### PR DESCRIPTION
**What this PR does / why we need it**:

- GitHub deprecated `add-path` command. Changing it to the new way.
```
The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

- Remove unnecessary `setup-go` since we build in containers, and added `setup-go` in unit test which calls `go test` natively


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: