### PR TITLE
Fix arm/v7 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILDPLATFORM="linux/amd64"
 ARG BUILDERIMAGE="golang:1.15-alpine"
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-ARG BASEIMAGE="gcr.io/distroless/static:nonroot"
+ARG BASEIMAGE="gcr.io/distroless/static:nonroot-amd64"
 
 FROM --platform=$BUILDPLATFORM $BUILDERIMAGE as builder
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Broken build: https://github.com/open-policy-agent/gatekeeper/runs/1223178572?check_suite_focus=true

Distroless added support for `arm64` which changed `nonroot` tag from a manifest to a manifest list (that includes `amd64` and `arm64` but not `arm/v7`)
https://github.com/GoogleContainerTools/distroless/issues/377#issuecomment-701046893

Reverting to old behavior by specifying `nonroot-amd64` tag which is a manifest

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: