### PR TITLE
update readme to v3.1.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For either installation method, make sure you have cluster admin permissions:
 If you want to deploy a released version of Gatekeeper in your cluster with a prebuilt image, then you can run the following command:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/deploy/gatekeeper.yaml
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.1/deploy/gatekeeper.yaml
 ```
 
 #### Deploying HEAD Using make


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `master` is pointing to `v3.1.0-rc.1` until we do a new release.
This is a quick fix so new users don't get broken due to k8s v1.19 cert change.

We should discuss versioning installation instead of pulling from master.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: