### PR TITLE
Remove unnecessary name fields from template example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,6 @@ spec:
     spec:
       names:
         kind: K8sRequiredLabels
-        listKind: K8sRequiredLabelsList
-        plural: k8srequiredlabels
-        singular: k8srequiredlabels
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:


### PR DESCRIPTION
Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:
We are giving the false impression that constraint template authors need to provide names other than `kind`, we should fix that.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

**Special notes for your reviewer**: