### PR TITLE
Config gate for mutation

### DIFF
--- a/apis/config/v1alpha1/config_types.go
+++ b/apis/config/v1alpha1/config_types.go
@@ -34,6 +34,9 @@ type ConfigSpec struct {
 
 	// Configuration for readiness tracker
 	Readiness ReadinessSpec `json:"readiness,omitempty"`
+
+	// Configuration for mutation feature
+	Mutation Mutation `json:"mutation,omitempty"`
 }
 
 type Validation struct {
@@ -68,6 +71,10 @@ type MatchEntry struct {
 
 type ReadinessSpec struct {
 	StatsEnabled bool `json:"statsEnabled,omitempty"`
+}
+
+type Mutation struct {
+	MutationEnabled bool `json:"mutationEnabled,omitempty"`
 }
 
 // ConfigStatus defines the observed state of Config

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -25,6 +25,7 @@ import (
 	syncc "github.com/open-policy-agent/gatekeeper/pkg/controller/sync"
 	"github.com/open-policy-agent/gatekeeper/pkg/keys"
 	"github.com/open-policy-agent/gatekeeper/pkg/metrics"
+	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/pkg/target"
 	"github.com/open-policy-agent/gatekeeper/pkg/watch"
@@ -242,6 +243,13 @@ func (r *ReconcileConfig) Reconcile(request reconcile.Request) (reconcile.Result
 		log.Info("disabling readiness stats")
 		r.tracker.DisableStats(ctx)
 	}
+
+	// Enable the mutation feature
+	var mutationEnabled bool
+	if exists && instance.GetDeletionTimestamp().IsZero() {
+		mutationEnabled = instance.Spec.Mutation.MutationEnabled
+	}
+	mutation.MutationEnabled = mutationEnabled
 
 	// Remove expectations for resources we no longer watch.
 	diff := r.watched.Difference(newSyncOnly)

--- a/pkg/mutation/mutation.go
+++ b/pkg/mutation/mutation.go
@@ -1,0 +1,16 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+// MutationEnabled indicates if the mutation feature is enabled
+var MutationEnabled bool


### PR DESCRIPTION
Flag gate for the mutation feature
This one is based on config.gatekeeper.sh instead of command line parameters.
An alternative to this is: #930 