### PR TITLE
Specify automountServiceAccountToken: true on Deployments

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,6 +41,7 @@ spec:
                   - webhook
               topologyKey: kubernetes.io/hostname
       serviceAccountName: admin
+      automountServiceAccountToken: true
       containers:
         - command:
             - /manager
@@ -118,6 +119,7 @@ spec:
       annotations:
         container.seccomp.security.alpha.kubernetes.io/manager: runtime/default
     spec:
+      automountServiceAccountToken: true
       containers:
         - args:
             - --operation=audit

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -35,6 +35,7 @@ spec:
         heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --audit-interval={{ .Values.auditInterval }}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -47,6 +47,7 @@ spec:
                   - webhook
               topologyKey: kubernetes.io/hostname
             weight: 100
+      automountServiceAccountToken: true
       containers:
       - args:
         - --port=8443

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -675,6 +675,7 @@ spec:
         gatekeeper.sh/operation: audit
         gatekeeper.sh/system: "yes"
     spec:
+      automountServiceAccountToken: true
       containers:
       - args:
         - --operation=audit
@@ -767,6 +768,7 @@ spec:
                   - webhook
               topologyKey: kubernetes.io/hostname
             weight: 100
+      automountServiceAccountToken: true
       containers:
       - args:
         - --port=8443


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `automountServiceAccountToken: true` within the `PodSpec` of each of the `Deployments`.  

Terraform defaults this field to `false` as the average bespoke service deployed to k8s does not need to access the API server, and thus shouldn't have a service account token mounted to the pod(s).  As gatekeeper pods _do_ talk to the API server, we need this field set to `true`.  

`automountServiceAccountToken: true` is the default value for a Pod, so non-terraform users will see no change in behavior.

**Which issue(s) this PR fixes**:
fixes #922