### PR TITLE
Fix typo in mutation kustomize

### DIFF
--- a/config/overlays/mutation/kustomization.yaml
+++ b/config/overlays/mutation/kustomization.yaml
@@ -12,7 +12,7 @@ commonLabels:
   gatekeeper.sh/system: "yes"    
 
 resources:
-- ../../crd/bases/mutations.gatekeeper.sh_assigns.yaml  
+- ../../crd/bases/mutations.gatekeeper.sh_assign.yaml  
 - ../../crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
 
 patchesStrategicMerge:


### PR DESCRIPTION
Typo in file name
The related file is here:
https://github.com/open-policy-agent/gatekeeper/blob/f3ec64a56154cd991e98387329083d243c967879/config/crd/bases/mutations.gatekeeper.sh_assign.yaml