### PR TITLE
Fix broken `make generate`, which requires CGO

### DIFF
--- a/build/tooling/Dockerfile
+++ b/build/tooling/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.15-alpine
 
+# Alpine lacks CGO libraries needed by `controller-gen`
+RUN apk add --no-cache build-base
+
 RUN GO111MODULE=on go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
 
 RUN mkdir /gatekeeper


### PR DESCRIPTION
The call to `make generate` requires CGO support inside the docker
image.  The golang:1.15-alpine image does not include this support, and
this change adds a RUN command that installs the necessary libraries.

Signed-off-by: juliankatz <juliankatz@google.com>