### PR TITLE
Fix instructions on how to deploy from master.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Currently the most reliable way of installing Gatekeeper is to build and install
    * Build and push your Docker image:
       ```sh
       make docker-buildx REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
-      make docker-push-release REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
+      make docker-push REPOSITORY="$DESTINATION_GATEKEEPER_DOCKER_IMAGE"
       ```
    * Finally, deploy:
      ```sh


### PR DESCRIPTION
**What this PR does / why we need it**:

After https://github.com/open-policy-agent/gatekeeper/commit/451614181e5d63b21c3e14f5c87ad36eb7d29793,
make docker-push-release does not push the "latest" tag anymore.
Following the instructions have the effect of pushing only the VERSION tag but not latest.
make docker-push pushes latest, having the desired effect.


