### PR TITLE
New process excluder for mutation

### DIFF
--- a/pkg/controller/config/process/excluder.go
+++ b/pkg/controller/config/process/excluder.go
@@ -13,10 +13,11 @@ import (
 type Process string
 
 const (
-	Audit   = Process("audit")
-	Sync    = Process("sync")
-	Webhook = Process("webhook")
-	Star    = Process("*")
+	Audit    = Process("audit")
+	Sync     = Process("sync")
+	Webhook  = Process("webhook")
+	Mutation = Process("mutation-webhook")
+	Star     = Process("*")
 )
 
 type Excluder struct {

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -121,13 +121,13 @@ func (h *webhookHandler) tracingLevel(ctx context.Context, req admission.Request
 	return traceEnabled, dump
 }
 
-func (h *webhookHandler) skipExcludedNamespace(req admissionv1beta1.AdmissionRequest) (bool, error) {
+func (h *webhookHandler) skipExcludedNamespace(req admissionv1beta1.AdmissionRequest, excludedProcess process.Process) (bool, error) {
 	obj := &unstructured.Unstructured{}
 	if _, _, err := deserializer.Decode(req.Object.Raw, nil, obj); err != nil {
 		return false, err
 	}
 
-	isNamespaceExcluded, err := h.processExcluder.IsNamespaceExcluded(process.Webhook, obj)
+	isNamespaceExcluded, err := h.processExcluder.IsNamespaceExcluded(excludedProcess, obj)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/webhook/mutation.go
+++ b/pkg/webhook/mutation.go
@@ -144,7 +144,7 @@ func (h *mutationHandler) Handle(ctx context.Context, req admission.Request) adm
 	}()
 
 	// namespace is excluded from webhook using config
-	isExcludedNamespace, err := h.skipExcludedNamespace(req.AdmissionRequest)
+	isExcludedNamespace, err := h.skipExcludedNamespace(req.AdmissionRequest, process.Mutation)
 	if err != nil {
 		log.Error(err, "error while excluding namespace")
 	}

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -157,12 +157,13 @@ func (h *validationHandler) Handle(ctx context.Context, req admission.Request) a
 	}()
 
 	// namespace is excluded from webhook using config
-	isExcludedNamespace, err := h.skipExcludedNamespace(req.AdmissionRequest)
+	isExcludedNamespace, err := h.skipExcludedNamespace(req.AdmissionRequest, process.Webhook)
 	if err != nil {
 		log.Error(err, "error while excluding namespace")
 	}
 
 	if isExcludedNamespace {
+
 		requestResponse = allowResponse
 		return admission.ValidationResponse(true, "Namespace is set to be ignored by Gatekeeper config")
 	}


### PR DESCRIPTION
Should the mutation webook have a separate process excluder to allow skipping a different set of namespaces?
Please share your thought on this PR

Depends on #881 