### PR TITLE
Common stats reporting for validation and mutation

### DIFF
--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -20,6 +20,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
+type requestResponse string
+
+const (
+	successResponse requestResponse = "success"
+	errorResponse   requestResponse = "error"
+	denyResponse    requestResponse = "deny"
+	allowResponse   requestResponse = "allow"
+	unknownResponse requestResponse = "unknown"
+	skipResponse    requestResponse = "skip"
+)
+
 var log = logf.Log.WithName("webhook")
 
 var (

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -97,15 +97,6 @@ type validationHandler struct {
 	opa *opa.Client
 }
 
-type admissionReqRes string
-
-const (
-	errorResponse   admissionReqRes = "error"
-	denyResponse    admissionReqRes = "deny"
-	allowResponse   admissionReqRes = "allow"
-	unknownResponse admissionReqRes = "unknown"
-)
-
 // Handle the validation request
 func (h *validationHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
 	log := log.WithValues("hookType", "validation")
@@ -149,8 +140,7 @@ func (h *validationHandler) Handle(ctx context.Context, req admission.Request) a
 	requestResponse := unknownResponse
 	defer func() {
 		if h.reporter != nil {
-			if err := h.reporter.ReportAdmissionRequest(
-				requestResponse, time.Since(timeStart)); err != nil {
+			if err := h.reporter.ReportValidationRequest(requestResponse, time.Since(timeStart)); err != nil {
 				log.Error(err, "failed to report request")
 			}
 		}

--- a/pkg/webhook/stats_reporter_test.go
+++ b/pkg/webhook/stats_reporter_test.go
@@ -14,7 +14,7 @@ const expectedDurationMax float64 = 5
 const expectedCount int64 = 2
 const expectedRowLength = 1
 
-func TestReportRequest(t *testing.T) {
+func TestValidationReportRequest(t *testing.T) {
 	expectedTags := map[string]string{
 		"admission_status": "allow",
 	}
@@ -23,20 +23,21 @@ func TestReportRequest(t *testing.T) {
 	if err != nil {
 		t.Errorf("newStatsReporter() error %v", err)
 	}
-	err = r.ReportAdmissionRequest(allowResponse, expectedDurationValueMin)
+	err = r.ReportValidationRequest(allowResponse, expectedDurationValueMin)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
-	err = r.ReportAdmissionRequest(allowResponse, expectedDurationValueMax)
+	err = r.ReportValidationRequest(allowResponse, expectedDurationValueMax)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
 	check(t, expectedTags, requestCountMetricName, requestDurationMetricName)
+	check(t, expectedTags, validationRequestCountMetricName, validationRequestDurationMetricName)
 }
 
 func TestMutationReportRequest(t *testing.T) {
 	expectedTags := map[string]string{
-		"mutation_status": "allow",
+		"mutation_status": "success",
 	}
 
 	r, err := newStatsReporter()
@@ -44,11 +45,11 @@ func TestMutationReportRequest(t *testing.T) {
 	if err != nil {
 		t.Errorf("newStatsReporter() error %v", err)
 	}
-	err = r.ReportMutationRequest(mutationAllowResponse, expectedDurationValueMin)
+	err = r.ReportMutationRequest(successResponse, expectedDurationValueMin)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
-	err = r.ReportMutationRequest(mutationAllowResponse, expectedDurationValueMax)
+	err = r.ReportMutationRequest(successResponse, expectedDurationValueMax)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}


### PR DESCRIPTION
The PR is opened for discussion on [this comment](https://github.com/open-policy-agent/gatekeeper/pull/970#discussion_r527140255).

It extracts some common code for validation and mutation stats reporting.

Depends on #881

