### PR TITLE
Allow different settings for audit vs controller

### DIFF
--- a/cmd/build/helmify/replacements.go
+++ b/cmd/build/helmify/replacements.go
@@ -8,11 +8,11 @@ var replacements = map[string]string{
 {{ toYaml .Values.audit.resources | indent 10 }}`,
 
 	"HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_POD_SCHEDULING": `
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.controllerManager.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.controllerManager.affinity | indent 8 }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.controllerManager.tolerations | indent 8 }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
 {{- if .Values.controllerManager.priorityClassName }}
@@ -20,11 +20,11 @@ var replacements = map[string]string{
 {{- end }}`,
 
 	"HELMSUBST_DEPLOYMENT_AUDIT_POD_SCHEDULING": `
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.audit.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.audit.affinity | indent 8 }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.audit.tolerations | indent 8 }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
 {{- if .Values.audit.priorityClassName }}

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -13,14 +13,25 @@ image:
   release: v3.3.0-beta.2
   pullPolicy: IfNotPresent
   pullSecrets: []
-nodeSelector: { kubernetes.io/os: linux }
-affinity: {}
-tolerations: []
 podAnnotations:
   { container.seccomp.security.alpha.kubernetes.io/manager: runtime/default }
 secretAnnotations: {}
 controllerManager:
   priorityClassName: system-cluster-critical
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: gatekeeper.sh/operation
+                  operator: In
+                  values:
+                    - webhook
+            topologyKey: kubernetes.io/hostname
+          weight: 100
+  tolerations: []
+  nodeSelector: { kubernetes.io/os: linux }
   resources:
     limits:
       cpu: 1000m
@@ -30,6 +41,9 @@ controllerManager:
       memory: 256Mi
 audit:
   priorityClassName: system-cluster-critical
+  affinity: {}
+  tolerations: []
+  nodeSelector: { kubernetes.io/os: linux }
   resources:
     limits:
       cpu: 1000m

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -88,11 +88,11 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
       nodeSelector: 
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.audit.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.audit.affinity | indent 8 }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.audit.tolerations | indent 8 }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
 {{- if .Values.audit.priorityClassName }}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -104,11 +104,11 @@ spec:
           name: cert
           readOnly: true
       nodeSelector: 
-{{ toYaml .Values.nodeSelector | indent 8 }}
+{{ toYaml .Values.controllerManager.nodeSelector | indent 8 }}
       affinity:
-{{ toYaml .Values.affinity | indent 8 }}
+{{ toYaml .Values.controllerManager.affinity | indent 8 }}
       tolerations:
-{{ toYaml .Values.tolerations | indent 8 }}
+{{ toYaml .Values.controllerManager.tolerations | indent 8 }}
       imagePullSecrets:
 {{ toYaml .Values.image.pullSecrets | indent 8 }}
 {{- if .Values.controllerManager.priorityClassName }}

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -13,14 +13,25 @@ image:
   release: v3.3.0-beta.2
   pullPolicy: IfNotPresent
   pullSecrets: []
-nodeSelector: { kubernetes.io/os: linux }
-affinity: {}
-tolerations: []
 podAnnotations:
   { container.seccomp.security.alpha.kubernetes.io/manager: runtime/default }
 secretAnnotations: {}
 controllerManager:
   priorityClassName: system-cluster-critical
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: gatekeeper.sh/operation
+                  operator: In
+                  values:
+                    - webhook
+            topologyKey: kubernetes.io/hostname
+          weight: 100
+  tolerations: []
+  nodeSelector: { kubernetes.io/os: linux }
   resources:
     limits:
       cpu: 1000m
@@ -30,6 +41,9 @@ controllerManager:
       memory: 256Mi
 audit:
   priorityClassName: system-cluster-critical
+  affinity: {}
+  tolerations: []
+  nodeSelector: { kubernetes.io/os: linux }
   resources:
     limits:
       cpu: 1000m


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows users to set different affinities,
nodeSelectors and tolerations for the audit deployment
versus the controller manager deployment.
Also the set affinity on controllermanager was overridden
by a second affinity key. This affinity is now set as
default in the values.

**Special notes for your reviewer**:

