### PR TITLE
Fix for selfLink removal

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -185,8 +185,8 @@ func (am *Manager) audit(ctx context.Context) error {
 	var resp *constraintTypes.Responses
 	var res []*constraintTypes.Result
 
-	updateLists := make(map[string][]auditResult)
-	totalViolationsPerConstraint := make(map[string]int64)
+	updateLists := make(map[util.KindVersionResource][]auditResult)
+	totalViolationsPerConstraint := make(map[util.KindVersionResource]int64)
 	totalViolationsPerEnforcementAction := make(map[util.EnforcementAction]int64)
 	// resetting total violations per enforcement action
 	for _, action := range util.KnownEnforcementActions {
@@ -236,8 +236,8 @@ func (am *Manager) audit(ctx context.Context) error {
 func (am *Manager) auditResources(
 	ctx context.Context,
 	constraintsGVK []schema.GroupVersionKind,
-	updateLists map[string][]auditResult,
-	totalViolationsPerConstraint map[string]int64,
+	updateLists map[util.KindVersionResource][]auditResult,
+	totalViolationsPerConstraint map[util.KindVersionResource]int64,
 	totalViolationsPerEnforcementAction map[util.EnforcementAction]int64,
 	timestamp string) error {
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(am.mgr.GetConfig())
@@ -464,14 +464,14 @@ func (am *Manager) getAllConstraintKinds() ([]schema.GroupVersionKind, error) {
 }
 
 func (am *Manager) addAuditResponsesToUpdateLists(
-	updateLists map[string][]auditResult,
+	updateLists map[util.KindVersionResource][]auditResult,
 	res []*constraintTypes.Result,
-	totalViolationsPerConstraint map[string]int64,
+	totalViolationsPerConstraint map[util.KindVersionResource]int64,
 	totalViolationsPerEnforcementAction map[util.EnforcementAction]int64,
 	timestamp string) error {
 	for _, r := range res {
-		selfLink := util.GetSelfLink(*r.Constraint)
-		totalViolationsPerConstraint[selfLink]++
+		key := util.GetUniqueKey(*r.Constraint)
+		totalViolationsPerConstraint[key]++
 		name := r.Constraint.GetName()
 		namespace := r.Constraint.GetNamespace()
 		apiVersion := r.Constraint.GetAPIVersion()
@@ -486,7 +486,7 @@ func (am *Manager) addAuditResponsesToUpdateLists(
 		rkind := resource.GetKind()
 		rnamespace := resource.GetNamespace()
 		// append audit results only if it is below violations limit
-		if uint(len(updateLists[selfLink])) < *constraintViolationsLimit {
+		if uint(len(updateLists[key])) < *constraintViolationsLimit {
 			result := auditResult{
 				cgvk:              gvk,
 				capiversion:       apiVersion,
@@ -499,7 +499,7 @@ func (am *Manager) addAuditResponsesToUpdateLists(
 				enforcementAction: enforcementAction,
 				constraint:        r.Constraint,
 			}
-			updateLists[selfLink] = append(updateLists[selfLink], result)
+			updateLists[key] = append(updateLists[key], result)
 		}
 		ea := util.EnforcementAction(enforcementAction)
 		totalViolationsPerEnforcementAction[ea]++
@@ -511,7 +511,7 @@ func (am *Manager) addAuditResponsesToUpdateLists(
 	return nil
 }
 
-func (am *Manager) writeAuditResults(ctx context.Context, constraintsGVKs []schema.GroupVersionKind, updateLists map[string][]auditResult, timestamp string, totalViolations map[string]int64) {
+func (am *Manager) writeAuditResults(ctx context.Context, constraintsGVKs []schema.GroupVersionKind, updateLists map[util.KindVersionResource][]auditResult, timestamp string, totalViolations map[util.KindVersionResource]int64) {
 	// if there is a previous reporting thread, close it before starting a new one
 	if am.ucloop != nil {
 		// this is closing the previous audit reporting thread
@@ -622,20 +622,20 @@ func truncateString(str string, size int) string {
 }
 
 type updateConstraintLoop struct {
-	uc      map[string]unstructured.Unstructured
+	uc      map[util.KindVersionResource]unstructured.Unstructured
 	client  client.Client
 	stop    chan struct{}
 	stopped chan struct{}
-	ul      map[string][]auditResult
+	ul      map[util.KindVersionResource][]auditResult
 	ts      string
-	tv      map[string]int64
+	tv      map[util.KindVersionResource]int64
 	log     logr.Logger
 }
 
 func (ucloop *updateConstraintLoop) update(ctx context.Context, constraintsGVKs []schema.GroupVersionKind) {
 	defer close(ucloop.stopped)
 
-	ucloop.uc = make(map[string]unstructured.Unstructured)
+	ucloop.uc = make(map[util.KindVersionResource]unstructured.Unstructured)
 
 	// get constraints for each Kind
 	for _, constraintGvk := range constraintsGVKs {
@@ -657,8 +657,8 @@ func (ucloop *updateConstraintLoop) update(ctx context.Context, constraintsGVKs 
 
 		// get each constraint
 		for _, item := range instanceList.Items {
-			selfLink := util.GetSelfLink(item)
-			ucloop.uc[selfLink] = item
+			key := util.GetUniqueKey(item)
+			ucloop.uc[key] = item
 		}
 	}
 
@@ -683,21 +683,21 @@ func (ucloop *updateConstraintLoop) update(ctx context.Context, constraintsGVKs 
 					Name:      name,
 					Namespace: namespace,
 				}
-				selfLink := util.GetSelfLink(item)
+				key := util.GetUniqueKey(item)
 				// get the latest constraint
 				err := ucloop.client.Get(ctx, namespacedName, &latestItem)
 				if err != nil {
 					if k8serrors.IsNotFound(err) {
 						ucloop.log.Info("could not find constraint", "name", name, "namespace", namespace)
-						delete(ucloop.uc, selfLink)
+						delete(ucloop.uc, key)
 					} else {
 						ucloop.log.Error(err, "could not get latest constraint during update", "name", name, "namespace", namespace)
 						continue
 					}
 				}
-				latestItemSelfLink := util.GetSelfLink(latestItem)
-				totalViolations := ucloop.tv[latestItemSelfLink]
-				if constraintAuditResults, ok := ucloop.ul[latestItemSelfLink]; !ok {
+				latestItemKey := util.GetUniqueKey(latestItem)
+				totalViolations := ucloop.tv[latestItemKey]
+				if constraintAuditResults, ok := ucloop.ul[latestItemKey]; !ok {
 					err := ucloop.updateConstraintStatus(ctx, &latestItem, emptyAuditResults, ucloop.ts, totalViolations)
 					if err != nil {
 						ucloop.log.Error(err, "could not update constraint status", "name", name, "namespace", namespace)
@@ -711,7 +711,7 @@ func (ucloop *updateConstraintLoop) update(ctx context.Context, constraintsGVKs 
 						continue
 					}
 				}
-				delete(ucloop.uc, selfLink)
+				delete(ucloop.uc, key)
 			}
 		}
 		if len(ucloop.uc) == 0 {

--- a/pkg/upgrade/manager.go
+++ b/pkg/upgrade/manager.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/open-policy-agent/gatekeeper/pkg/util"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -140,7 +141,8 @@ func (um *Manager) upgradeGroupVersion(ctx context.Context, groupVersion string)
 		updateResources := make(map[string]unstructured.Unstructured, len(instanceList.Items))
 		// get each resource
 		for _, item := range instanceList.Items {
-			updateResources[item.GetSelfLink()] = item
+			selfLink := util.GetSelfLink(item)
+			updateResources[selfLink] = item
 		}
 
 		if len(updateResources) > 0 {
@@ -193,7 +195,8 @@ func (urloop *updateResourceLoop) update() {
 					log.Error(err, "could not update resource", "name", name, "namespace", namespace)
 				}
 				if !failure {
-					delete(urloop.ur, latestItem.GetSelfLink())
+					selfLink := util.GetSelfLink(latestItem)
+					delete(urloop.ur, selfLink)
 				}
 			}
 		}

--- a/pkg/upgrade/manager.go
+++ b/pkg/upgrade/manager.go
@@ -138,11 +138,11 @@ func (um *Manager) upgradeGroupVersion(ctx context.Context, groupVersion string)
 			return err
 		}
 		log.Info("resource count", "count", len(instanceList.Items))
-		updateResources := make(map[string]unstructured.Unstructured, len(instanceList.Items))
+		updateResources := make(map[util.KindVersionResource]unstructured.Unstructured, len(instanceList.Items))
 		// get each resource
 		for _, item := range instanceList.Items {
-			selfLink := util.GetSelfLink(item)
-			updateResources[selfLink] = item
+			key := util.GetUniqueKey(item)
+			updateResources[key] = item
 		}
 
 		if len(updateResources) > 0 {
@@ -160,7 +160,7 @@ func (um *Manager) upgradeGroupVersion(ctx context.Context, groupVersion string)
 }
 
 type updateResourceLoop struct {
-	ur      map[string]unstructured.Unstructured
+	ur      map[util.KindVersionResource]unstructured.Unstructured
 	client  client.Client
 	stop    chan struct{}
 	stopped chan struct{}
@@ -195,8 +195,8 @@ func (urloop *updateResourceLoop) update() {
 					log.Error(err, "could not update resource", "name", name, "namespace", namespace)
 				}
 				if !failure {
-					selfLink := util.GetSelfLink(latestItem)
-					delete(urloop.ur, selfLink)
+					key := util.GetUniqueKey(latestItem)
+					delete(urloop.ur, key)
 				}
 			}
 		}

--- a/pkg/util/selfLink.go
+++ b/pkg/util/selfLink.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func GetSelfLink(obj unstructured.Unstructured) string {
+	return fmt.Sprintf("/apis/%s/%s/%s", obj.GetAPIVersion(), obj.GetKind(), obj.GetName())
+}

--- a/pkg/util/selfLink.go
+++ b/pkg/util/selfLink.go
@@ -1,11 +1,19 @@
 package util
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func GetSelfLink(obj unstructured.Unstructured) string {
-	return fmt.Sprintf("/apis/%s/%s/%s", obj.GetAPIVersion(), obj.GetKind(), obj.GetName())
+type KindVersionResource struct {
+	kind     string
+	version  string
+	resource string
+}
+
+func GetUniqueKey(obj unstructured.Unstructured) KindVersionResource {
+	return KindVersionResource{
+		version:  obj.GetAPIVersion(),
+		kind:     obj.GetKind(),
+		resource: obj.GetName(),
+	}
 }

--- a/pkg/util/selfLink_test.go
+++ b/pkg/util/selfLink_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestGetSelfLink(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	gvk := schema.GroupVersionKind{
+		Group:   "constraints.gatekeeper.sh",
+		Version: "v1beta1",
+		Kind:    "myTemplate",
+	}
+	name := "myConstraint"
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetName(name)
+
+	selfLink := GetSelfLink(*obj)
+	expected := "/apis/constraints.gatekeeper.sh/v1beta1/myTemplate/myConstraint"
+	g.Expect(selfLink).To(gomega.Equal(expected))
+}

--- a/pkg/util/selfLink_test.go
+++ b/pkg/util/selfLink_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestGetSelfLink(t *testing.T) {
+func TestGetUniqueKey(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	gvk := schema.GroupVersionKind{
 		Group:   "constraints.gatekeeper.sh",
@@ -20,7 +20,11 @@ func TestGetSelfLink(t *testing.T) {
 	obj.SetGroupVersionKind(gvk)
 	obj.SetName(name)
 
-	selfLink := GetSelfLink(*obj)
-	expected := "/apis/constraints.gatekeeper.sh/v1beta1/myTemplate/myConstraint"
-	g.Expect(selfLink).To(gomega.Equal(expected))
+	key := GetUniqueKey(*obj)
+	expected := KindVersionResource{
+		version:  "constraints.gatekeeper.sh/v1beta1",
+		kind:     "myTemplate",
+		resource: "myConstraint",
+	}
+	g.Expect(key).To(gomega.Equal(expected))
 }


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
`selfLink` is disabled by default in k8s v1.20 and will be removed in v1.21

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1002 

**Special notes for your reviewer**: