### PR TITLE
fix nil crash for assignmeta.spec.location on delete

### DIFF
--- a/pkg/mutation/assignmeta_mutator.go
+++ b/pkg/mutation/assignmeta_mutator.go
@@ -107,6 +107,12 @@ func MutatorForAssignMetadata(assignMeta *mutationsv1alpha1.AssignMetadata) (*As
 		return nil, errors.Wrap(err, "failed to retrieve id for assignMetadata type")
 	}
 
+	if assignMeta.Spec.Location == "" {
+		return &AssignMetadataMutator{
+			id: id,
+		}, nil
+	}
+
 	path, err := parser.Parse(assignMeta.Spec.Location)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse location for assign metadata")


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
There is a crash on assignmeta when spec.location does not exist on delete

alternatively, we can also pass in deleted, and then return id if true

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: