### PR TITLE
Add retry support to objectTracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,14 @@ The `data.inventory` document has the following format:
   * For namespace-scoped objects: `data.inventory.namespace[<namespace>][groupVersion][<kind>][<name>]`
      * Example referencing the Gatekeeper pod: `data.inventory.namespace["gatekeeper"]["v1"]["Pod"]["gatekeeper-controller-manager-d4c98b788-j7d92"]`
 
+### Customize Startup Behavior
+
+#### Allow retries when adding objects to OPA
+
+Gatekeeper's webhook servers undergo a bootstrapping period during which they are unavailable until the initial set of resources (constraints, templates, synced objects, etc...) have been ingested. This prevents Gatekeeper's webhook from validating based on an incomplete set of policies. This wait-for-bootstrapping behavior can be configured.
+
+The `--readiness-retries` flag defines the number of retry attempts allowed for an object (a Constraint, for example) to be successfully added to OPA.  The default is `0`.  A value of `-1` allows for infinite retries, blocking the webhook until all objects have been added to OPA.  This guarantees complete enforcement, but has the potential to indefinitely block the webhook from serving requests.
+
 ### Audit
 
 The audit functionality enables periodic evaluations of replicated resources against the policies enforced in the cluster to detect pre-existing misconfigurations. Audit results are stored as violations listed in the `status` field of the failed constraint.

--- a/apis/mutations/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/mutations/v1alpha1/zz_generated.deepcopy.go
@@ -20,7 +20,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -387,7 +387,7 @@ func (r *ReconcileConstraint) cacheConstraint(instance *unstructured.Unstructure
 	unstructured.RemoveNestedField(obj.Object, "status")
 	_, err := r.opa.AddConstraint(context.Background(), obj)
 	if err != nil {
-		t.CancelExpect(obj)
+		t.TryCancelExpect(obj)
 		return err
 	}
 

--- a/pkg/readiness/noop_expectations.go
+++ b/pkg/readiness/noop_expectations.go
@@ -18,20 +18,17 @@ package readiness
 import "k8s.io/apimachinery/pkg/runtime"
 
 // noopExpectations returns an Expectations that is always satisfied.
-type noopExpectations struct {
-}
+type noopExpectations struct{}
 
-func (n noopExpectations) Expect(o runtime.Object) {
-}
+func (n noopExpectations) Expect(o runtime.Object) {}
 
-func (n noopExpectations) CancelExpect(o runtime.Object) {
-}
+func (n noopExpectations) CancelExpect(o runtime.Object) {}
 
-func (n noopExpectations) ExpectationsDone() {
-}
+func (n noopExpectations) TryCancelExpect(o runtime.Object) {}
 
-func (n noopExpectations) Observe(o runtime.Object) {
-}
+func (n noopExpectations) ExpectationsDone() {}
+
+func (n noopExpectations) Observe(o runtime.Object) {}
 
 func (n noopExpectations) Satisfied() bool {
 	return true

--- a/pkg/readiness/objset.go
+++ b/pkg/readiness/objset.go
@@ -27,9 +27,39 @@ type objKey struct {
 	namespacedName types.NamespacedName
 }
 
-type objSet map[objKey]struct{}
-
 func (k objKey) String() string {
 	return fmt.Sprintf("%s [%s]", k.namespacedName.String(), k.gvk.String())
+}
 
+// objSet is a set of objKey types with no data
+type objSet map[objKey]struct{}
+
+// retryObjSet holds the allowed retries for a specific object
+type objRetrySet map[objKey]objData
+
+type objData struct {
+	retries int
+}
+
+// decrementRetries handles objData retries, and returns `true` if it's time to delete the objData entry
+func (o *objData) decrementRetries() bool {
+	// if retries is less than 0, allowed retries are infinite
+	if o.retries < 0 {
+		return false
+	}
+
+	// If we have retries left, use one
+	if o.retries > 0 {
+		o.retries--
+		return false
+	}
+
+	// if we have zero retries, we can delete
+	return true
+}
+
+type objDataFactory func() objData
+
+func objDataFromFlags() objData {
+	return objData{retries: *readinessRetries}
 }

--- a/pkg/readiness/ready_tracker.go
+++ b/pkg/readiness/ready_tracker.go
@@ -70,8 +70,8 @@ type Tracker struct {
 func NewTracker(lister Lister) *Tracker {
 	return &Tracker{
 		lister:             lister,
-		templates:          newObjTracker(v1beta1.SchemeGroupVersion.WithKind("ConstraintTemplate")),
-		config:             newObjTracker(configv1alpha1.GroupVersion.WithKind("Config")),
+		templates:          newObjTracker(v1beta1.SchemeGroupVersion.WithKind("ConstraintTemplate"), nil),
+		config:             newObjTracker(configv1alpha1.GroupVersion.WithKind("Config"), nil),
 		constraints:        newTrackerMap(),
 		data:               newTrackerMap(),
 		ready:              make(chan struct{}),

--- a/pkg/readiness/tracker_map.go
+++ b/pkg/readiness/tracker_map.go
@@ -64,7 +64,7 @@ func (t *trackerMap) Get(gvk schema.GroupVersionKind) Expectations {
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	entry := newObjTracker(gvk)
+	entry := newObjTracker(gvk, nil)
 	t.m[gvk] = entry
 	return entry
 }


### PR DESCRIPTION
Add the readiness-retries flag, allowing the user to configure how many 
attempts should be made to injest a resource into OPA while blocking the
webhook.

Previously, a failure to injest an object into the OPA cache would
strike that object from the ObjectTracker, a type tasked with blocking
the webhook from serving requests until all the necessary objects had
been observed on the API server.  This setup optimizes for availability
(the webhook serving requests ASAP) over security.

By adding retry functionality, we configure gatekeeper to block the
webhook for longer, but unblock with a more complete set of constraints.

Signed-off-by: juliankatz <juliankatz@google.com>