### PR TITLE
Use ID only for cache deletion.

### DIFF
--- a/pkg/mutation/system.go
+++ b/pkg/mutation/system.go
@@ -52,7 +52,7 @@ func (s *System) Upsert(m Mutator) error {
 	s.mutatorsMap[toAdd.ID()] = toAdd
 
 	i := sort.Search(len(s.orderedMutators), func(i int) bool {
-		return greaterOrEqual(s.orderedMutators[i], toAdd)
+		return greaterOrEqual(s.orderedMutators[i].ID(), toAdd.ID())
 	})
 
 	if i == len(s.orderedMutators) { // Adding to the bottom of the list
@@ -60,7 +60,7 @@ func (s *System) Upsert(m Mutator) error {
 		return nil
 	}
 
-	found := equal(s.orderedMutators[i], toAdd)
+	found := equal(s.orderedMutators[i].ID(), toAdd.ID())
 	if found {
 		s.orderedMutators[i] = toAdd
 		return nil
@@ -98,15 +98,15 @@ func (s *System) Mutate(obj *unstructured.Unstructured, ns *corev1.Namespace) er
 }
 
 // Remove removes the mutator from the mutation system
-func (s *System) Remove(m Mutator) error {
+func (s *System) Remove(id ID) error {
 	s.Lock()
 	defer s.Unlock()
 
-	if _, ok := s.mutatorsMap[m.ID()]; !ok {
+	if _, ok := s.mutatorsMap[id]; !ok {
 		return nil
 	}
 
-	err := s.schemaDB.Remove(m.ID())
+	err := s.schemaDB.Remove(id)
 	// TODO: get back on this once schemaDB implementation is done
 	// and understand how to recover from a failed remove.
 	// One option is to rebuild the schema from scratch using the cache content.
@@ -115,21 +115,21 @@ func (s *System) Remove(m Mutator) error {
 	}
 
 	i := sort.Search(len(s.orderedMutators), func(i int) bool {
-		res := equal(s.orderedMutators[i], m)
+		res := equal(s.orderedMutators[i].ID(), id)
 		if res {
 			return true
 		}
-		return greaterOrEqual(s.orderedMutators[i], m)
+		return greaterOrEqual(s.orderedMutators[i].ID(), id)
 	})
 
-	delete(s.mutatorsMap, m.ID())
+	delete(s.mutatorsMap, id)
 
-	found := equal(s.orderedMutators[i], m)
+	found := equal(s.orderedMutators[i].ID(), id)
 
 	// The map is expected to be in sync with the list, so if we don't find it
 	// we return an error.
 	if !found {
-		return fmt.Errorf("Failed to find mutator with ID %v on sorted list", m.ID())
+		return fmt.Errorf("Failed to find mutator with ID %v on sorted list", id)
 	}
 	copy(s.orderedMutators[i:], s.orderedMutators[i+1:])
 	s.orderedMutators[len(s.orderedMutators)-1] = nil
@@ -137,39 +137,39 @@ func (s *System) Remove(m Mutator) error {
 	return nil
 }
 
-func greaterOrEqual(mutator1, mutator2 Mutator) bool {
-	if mutator1.ID().Group > mutator2.ID().Group {
+func greaterOrEqual(id1, id2 ID) bool {
+	if id1.Group > id2.Group {
 		return true
 	}
-	if mutator1.ID().Group < mutator2.ID().Group {
+	if id1.Group < id2.Group {
 		return false
 	}
-	if mutator1.ID().Kind > mutator2.ID().Kind {
+	if id1.Kind > id2.Kind {
 		return true
 	}
-	if mutator1.ID().Kind < mutator2.ID().Kind {
+	if id1.Kind < id2.Kind {
 		return false
 	}
-	if mutator1.ID().Namespace > mutator2.ID().Namespace {
+	if id1.Namespace > id2.Namespace {
 		return true
 	}
-	if mutator1.ID().Namespace < mutator2.ID().Namespace {
+	if id1.Namespace < id2.Namespace {
 		return false
 	}
-	if mutator1.ID().Name > mutator2.ID().Name {
+	if id1.Name > id2.Name {
 		return true
 	}
-	if mutator1.ID().Name < mutator2.ID().Name {
+	if id1.Name < id2.Name {
 		return false
 	}
 	return true
 }
 
-func equal(mutator1, mutator2 Mutator) bool {
-	if mutator1.ID().Group == mutator2.ID().Group &&
-		mutator1.ID().Kind == mutator2.ID().Kind &&
-		mutator1.ID().Namespace == mutator2.ID().Namespace &&
-		mutator1.ID().Name == mutator2.ID().Name {
+func equal(id1, id2 ID) bool {
+	if id1.Group == id2.Group &&
+		id1.Kind == id2.Kind &&
+		id1.Namespace == id2.Namespace &&
+		id1.Name == id2.Name {
 		return true
 	}
 	return false

--- a/pkg/mutation/system_test.go
+++ b/pkg/mutation/system_test.go
@@ -133,7 +133,7 @@ func TestSorting(t *testing.T) {
 				&MockMutator{Mocked: ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 			},
 			action: func(s *System) error {
-				return s.Remove(&MockMutator{Mocked: ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}})
+				return s.Remove(ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"})
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

When we reconcile deletions, we don't have the full object.
This is causing a panic in parsing. Here we change the Remove method to take the ID of the object instead of the object itself.
