### PR TITLE
Mutation webhook should not return any patches when nothing was mutated

### DIFF
--- a/pkg/mutation/system_test.go
+++ b/pkg/mutation/system_test.go
@@ -283,7 +283,7 @@ func TestMutation(t *testing.T) {
 					t.Errorf(tc.tname, "Failed inserting %dth object", i)
 				}
 			}
-			err = c.Mutate(toMutate, nil)
+			mutated, err := c.Mutate(toMutate, nil)
 			if tc.expectError && err == nil {
 				t.Fatal(tc.tname, "Expecting error from mutate, did not fail")
 			}
@@ -302,6 +302,11 @@ func TestMutation(t *testing.T) {
 			}
 
 			newLabels := accessor.GetLabels()
+
+			if !mutated {
+				t.Error(tc.tname, "Mutation not as expected", cmp.Diff(newLabels, tc.expectedLabels))
+			}
+
 			if !cmp.Equal(newLabels, tc.expectedLabels) {
 				t.Error(tc.tname, "Mutation not as expected", cmp.Diff(newLabels, tc.expectedLabels))
 			}

--- a/pkg/webhook/mutation.go
+++ b/pkg/webhook/mutation.go
@@ -201,10 +201,13 @@ func (h *mutationHandler) mutateRequest(ctx context.Context, req admission.Reque
 		return admission.Errored(int32(http.StatusInternalServerError), err), nil
 	}
 
-	err = h.mutationSystem.Mutate(&obj, ns)
+	mutated, err := h.mutationSystem.Mutate(&obj, ns)
 	if err != nil {
 		log.Error(err, "failed to mutate object", "object", string(req.Object.Raw))
 		return admission.Errored(int32(http.StatusInternalServerError), err), nil
+	}
+	if !mutated {
+		return admission.ValidationResponse(true, "Resource was not mutated"), nil
 	}
 
 	newJSON, err := obj.MarshalJSON()


### PR DESCRIPTION
A follow up to #1015 ([here](https://github.com/open-policy-agent/gatekeeper/pull/1015#discussion_r539469397))
Mutation webhook will return no patches when no mutation was done.