### PR TITLE
Fix helm stable repo for v2

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -109,7 +109,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        HELM_VERSION: ["2.16.10", "3.3.0"]
+        HELM_VERSION: ["2.17.0", "3.3.0"]
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ KIND_VERSION ?= 0.8.1
 KUBERNETES_VERSION ?= v1.19.0
 KUSTOMIZE_VERSION ?= 3.7.0
 KUBECTL_KUSTOMIZE_VERSION ?= 1.18.5-${KUSTOMIZE_VERSION}
-HELM_VERSION ?= 2.16.10
+HELM_VERSION ?= 2.17.0
 
 BUILD_COMMIT := $(shell ./build/get-build-commit.sh)
 BUILD_TIMESTAMP := $(shell ./build/get-build-timestamp.sh)


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

**What this PR does / why we need it**:
Fix broken CI due to helm repo deprecation.

helm used to have https://kubernetes-charts.storage.googleapis.com/index.yaml as the default stable repository, which no longer resolves. Use the argument `--stable-repo-url` to specify the new repository `https://charts.helm.sh/stable`.

UPDATE: Using helm v2.17.0 instead

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: