### PR TITLE
Enable readOnlyRootFilesystem in Helm chart

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -86,6 +86,7 @@ spec:
               path: /readyz
               port: 9090
           securityContext:
+            readOnlyRootFilesystem: true
             runAsUser: 1000
             runAsGroup: 999
             runAsNonRoot: true
@@ -163,6 +164,7 @@ spec:
               cpu: 100m
               memory: 256Mi
           securityContext:
+            readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -84,6 +84,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -96,6 +96,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -705,6 +705,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000
@@ -802,6 +803,7 @@ spec:
           capabilities:
             drop:
             - all
+          readOnlyRootFilesystem: true
           runAsGroup: 999
           runAsNonRoot: true
           runAsUser: 1000


### PR DESCRIPTION
**What this PR does / why we need it**:

It is best practice to set `readOnlyRootFilesystem: true` in the container's security context.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

**Special notes for your reviewer**:

From a brief review of the code, I don't think Gatekeeper writes anything to its filesystem, but it would be best if someone more familiar with the code base can confirm that.