### PR TITLE
Allow a tracker with observations but without expectations to be Satisfied

### DIFF
--- a/pkg/readiness/object_tracker_test.go
+++ b/pkg/readiness/object_tracker_test.go
@@ -358,4 +358,21 @@ func Test_ObjectTracker_TryCancelExpect_CancelBeforeExpected(t *testing.T) {
 	ot.TryCancelExpect(ct) // 0 retries --> DELETE
 
 	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+
+}
+
+// Verify that unexpected observations do not prevent the tracker from reaching its satisfied state.
+func Test_ObjectTracker_Unexpected_Does_Not_Prevent_Satisfied(t *testing.T) {
+	g := gomega.NewWithT(t)
+	ot := newObjTracker(schema.GroupVersionKind{}, nil)
+
+	ct := makeCT("test-ct")
+	ot.Observe(ct)
+
+	g.Expect(ot.Satisfied()).NotTo(gomega.BeTrue(), "unpopulated tracker should not be satisfied")
+
+	// ** Do not expect the above observation **
+
+	ot.ExpectationsDone()
+	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "Nothing expected and ExpectationsDone(): should have been satisfied")
 }


### PR DESCRIPTION
The object tracker maintains a list of all observed resources of it's
specified gvk.  These observations are removed whenever there is a
corresponding expectation for that resource.  The creation of an
expectation or an observation can come in any order for a resource.

It is possible that a resource can be observed, but that it is not
expected.  I.e. the resource is of the type tracked by the object
tracker, but is not one that should block the webhook.

In this case, we should not prevent the webhook from serving.  The
resource should be seen but not be cause to block the webhook.

Fixes #1023

Signed-off-by: juliankatz <juliankatz@google.com>