### PR TITLE
Update kustomize url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Currently the most reliable way of installing Gatekeeper is to build and install
 
    * Make sure that:
        * You have Docker version 19.03 or later installed.
-       * [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#getting-started) and [Kustomize](https://github.com/kubernetes-sigs/kustomize/blob/master/docs/INSTALL.md) are installed.
+       * [Kubebuilder](https://github.com/kubernetes-sigs/kubebuilder#getting-started) and [Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) are installed.
        * Your kubectl context is set to the desired installation cluster.
        * You have a container registry you can write to that is readable by the target cluster.
    * Clone the Gatekeeper repository to your local system:


### PR DESCRIPTION
Updates the kustomize install url in the readme to use the current docs -  avoids a redirect.