### PR TITLE
Prebuilt image installation uses the latest stable release (v3.2.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For either installation method, make sure you have cluster admin permissions:
 If you want to deploy a released version of Gatekeeper in your cluster with a prebuilt image, then you can run the following command:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.1/deploy/gatekeeper.yaml
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.2/deploy/gatekeeper.yaml
 ```
 
 #### Deploying HEAD Using make


### PR DESCRIPTION
Instructions for the prebuilt-image installation currently use the `v3.1.0` `deploy/gatekeeper.yml`, this PR updates to the latest stable release (`v3.2.0`).
