### PR TITLE
[WIP] Load test

### DIFF
--- a/.github/workflows/load.yaml
+++ b/.github/workflows/load.yaml
@@ -1,0 +1,113 @@
+name: load_test
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger:
+    name: Trigger load test
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
+    timeout-minutes: 1
+    steps:
+      - uses: khan/pull-request-comment-trigger@1.0.0
+        id: comment-check
+        with:
+          trigger: '/load-test'
+          reaction: rocket
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - run: |
+          # cancel run if the comment didn't trigger load test
+          curl \
+            -X POST https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/cancel \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: token $GITHUB_TOKEN"
+        if: steps.comment-check.outputs.triggered == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  load_test:
+    name: "Run load test"
+    runs-on: ubuntu-latest
+    if: ${{ github.event.issue.pull_request }}
+    needs: trigger
+    timeout-minutes: 30
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Checkout clusterloader2
+        run: |
+          git clone https://github.com/kubernetes/perf-tests.git
+
+      - name: Bootstrap e2e
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+          make e2e-bootstrap
+
+      - name: Deploy Gatekeeper
+        run: |
+          make e2e-build-load-image IMG=gatekeeper-e2e:latest
+          make deploy IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
+
+      - name: Deploy policies
+        run: |
+          ./test/load/deploy-policies.sh
+        env:
+          NUMBER_TEMPLATES: 5
+          NUMBER_CONSTRAINTS: 5
+
+      - name: Run load tests
+        run: |
+          ./run-e2e.sh cluster-loader2 \
+            --nodes=1 \
+            --provider=local \
+            --report-dir="$GITHUB_WORKSPACE/_artifacts" \
+            --testconfig="$GITHUB_WORKSPACE/test/load/config.yaml"
+        working-directory: perf-tests
+        env:
+          CL2_POD_COUNT: 50
+          CL2_POD_THROUGHPUT: 5
+          CL2_WAIT_TIME: 5m
+
+      - name: Fix invalid characters
+        run: |
+          for f in *:*; do mv -v "$f" $(echo "$f" | tr ':' '-'); done
+        working-directory: _artifacts
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: load_test_results
+          path: |
+            _artifacts/*.json
+
+      - name: Build results
+        id: get-comment-body
+        env:
+          URL: ${{ github.event.issue.comments_url }}
+        run: |
+          echo "### Load test [results](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" > results.txt
+          echo "Resource usage summary for 100 percentile:" >> results.txt
+          echo "\`\`\`" >> results.txt
+          cat _artifacts/*.json | \
+            jq -r '["NAME","CPU","MEMORY"], ["----","---","------"], (."100"[] | select((.Name | startswith("gatekeeper")) or (.Name | startswith("kube-apiserver"))) | [.Name, .CPU, .Mem]) | @tsv' | \
+            column -t >> results.txt
+          echo "\`\`\`" >> results.txt
+          cat results.txt
+
+          body=$(cat results.txt)
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo ::set-output name=body::$body
+
+      - name: Create commit comment
+        uses: peter-evans/commit-comment@v1
+        with:
+          body: ${{ steps.get-comment-body.outputs.body }}
+          sha: ${{ github.event.pull_request.head.sha }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/test/load/allowedrepos-constraint-template.yaml
+++ b/test/load/allowedrepos-constraint-template.yaml
@@ -1,0 +1,13 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: $TEMPLATE_NAME
+metadata:
+  name: $CONSTRAINT_NAME
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+  parameters:
+    repos:
+      - $CONSTRAINT_NAME

--- a/test/load/allowedrepos-ct-template.yaml
+++ b/test/load/allowedrepos-ct-template.yaml
@@ -1,0 +1,35 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: $TEMPLATE_NAME
+spec:
+  crd:
+    spec:
+      names:
+        kind: $TEMPLATE_NAME
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            repos:
+              type: array
+              items:
+                type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sallowedrepos
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.containers[_]
+          satisfied := [good | repo = input.parameters.repos[_] ; good = startswith(container.image, repo)]
+          not any(satisfied)
+          msg := sprintf("container <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
+        }
+
+        violation[{"msg": msg}] {
+          container := input.review.object.spec.initContainers[_]
+          satisfied := [good | repo = input.parameters.repos[_] ; good = startswith(container.image, repo)]
+          not any(satisfied)
+          msg := sprintf("container <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
+        }

--- a/test/load/config.yaml
+++ b/test/load/config.yaml
@@ -1,0 +1,58 @@
+{{$POD_COUNT := DefaultParam .CL2_POD_COUNT 100}}
+{{$POD_THROUGHPUT := DefaultParam .CL2_POD_THROUGHPUT 5}}
+{{$CONTAINER_IMAGE := DefaultParam .CONTAINER_IMAGE "k8s.gcr.io/pause:3.1"}}
+{{$OPERATION_TIMEOUT := DefaultParam .OPERATION_TIMEOUT "15m"}}
+{{$WAIT_TIME := DefaultParam .CL2_WAIT_TIME "1m"}}
+
+name: load-test
+automanagedNamespaces: {{$POD_COUNT}}
+tuningSets:
+  - name: UniformQPS
+    qpsLoad:
+      qps: {{$POD_THROUGHPUT}}
+steps:
+  - name: Starting measurements
+    measurements:
+      - Identifier: ResourceUsageSummary
+        Method: ResourceUsageSummary
+        Params:
+          action: start
+          namespace: ""
+  - measurements:
+      - Identifier: WaitForRunningLatencyRCs
+        Method: WaitForControlledPodsRunning
+        Params:
+          action: start
+          apiVersion: v1
+          kind: ReplicationController
+          labelSelector: group = latency
+          operationTimeout: {{$OPERATION_TIMEOUT}}
+  - phases:
+      - namespaceRange:
+          min: 1
+          max: {{$POD_COUNT}}
+        replicasPerNamespace: 1
+        tuningSet: UniformQPS
+        objectBundle:
+          - basename: latency-pod-rc
+            objectTemplatePath: rc.yaml
+            templateFillMap:
+              Replicas: 1
+              Group: latency
+  - measurements:
+      - Identifier: WaitForRunningLatencyRCs
+        Method: WaitForControlledPodsRunning
+        Params:
+          action: gather
+# waiting for audit to finish
+  - name: Wait
+    measurements:
+      - Identifier: Wait
+        Method: Sleep
+        Params:
+          duration: {{$WAIT_TIME}}
+  - measurements:
+      - Identifier: ResourceUsageSummary
+        Method: ResourceUsageSummary
+        Params:
+          action: gather

--- a/test/load/deploy-policies.sh
+++ b/test/load/deploy-policies.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+source test/bats/helpers.bash
+
+WAIT_TIME=120
+SLEEP_TIME=1
+
+wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl wait -n gatekeeper-system --for=condition=Ready --timeout=60s pod -l control-plane=audit-controller"
+wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl wait -n gatekeeper-system --for=condition=Ready --timeout=60s pod -l control-plane=controller-manager"
+wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl wait --for condition=established --timeout=60s crd/constrainttemplates.templates.gatekeeper.sh"
+wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl wait --for condition=established --timeout=60s crd/configs.config.gatekeeper.sh"
+
+# deploying templates
+t="1"
+while [ $t -le $NUMBER_TEMPLATES ]; do
+    export TEMPLATE_NAME=template-$(openssl rand -hex 6)
+
+    envsubst <test/load/allowedrepos-ct-template.yaml >test/load/allowedrepos-ct.yaml
+    kubectl apply -f test/load/allowedrepos-ct.yaml
+
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl wait --for condition=established --timeout=60s crd/$TEMPLATE_NAME.constraints.gatekeeper.sh"
+    t=$(($t + 1))
+
+    # number of constraints per template
+    c="1"
+    while [ $c -le $NUMBER_CONSTRAINTS ]; do
+        export CONSTRAINT_NAME=repo-$(openssl rand -hex 6)
+
+        envsubst <test/load/allowedrepos-constraint-template.yaml >test/load/allowedrepos-constraint.yaml
+        kubectl apply -f test/load/allowedrepos-constraint.yaml
+
+        wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "constraint_enforced $TEMPLATE_NAME $CONSTRAINT_NAME"
+        c=$(($c + 1))
+    done
+done

--- a/test/load/rc.yaml
+++ b/test/load/rc.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: {{.Name}}
+  labels:
+    group: {{.Group}}
+spec:
+  replicas: {{.Replicas}}
+  selector:
+    name: {{.Name}}
+  template:
+    metadata:
+      labels:
+        name: {{.Name}}
+        group: {{.Group}}
+    spec:
+      # Do not automount default service account, to eliminate its impact.
+      automountServiceAccountToken: false
+      containers:
+      - image: k8s.gcr.io/pause:3.1
+        imagePullPolicy: IfNotPresent
+        name: {{.Name}}
+        ports:
+      # Add not-ready/unreachable tolerations for 15 minutes so that node
+      # failure doesn't trigger pod deletion.
+      tolerations:
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 900


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
- Adds load test as a GitHub action, which can be triggered by anyone with `/load-test` comment. 
- Full results are uploaded as artifacts to the run and bot will comment on the PR with gatekeeper-specific results
Sample: https://github.com/sozercan/gatekeeper/pull/30#commitcomment-46125156

@shomron @maxsmythe @ritazh let me know what you think of the below variables

- Uses a kind cluster with a single node
- Default audit interval (60s)
- Deploys 5 templates (allowed-images) with 5 constraints each (all constraints are violations) with dryrun enforcement action
- Deploys a RC with 5 QPS - adapted from https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/testing/node-throughput/config.yaml
- Waits for audit results
- Bot comments with 100 percentile CPU (in vCPU units) and memory (in bytes) metrics for Gatekeeper pods and kube-apiserver. We can also do 99, 90, 50 if wanted (full artifact json includes all pods in the cluster with these percentiles)
- Anything else?

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #692 

**Special notes for your reviewer**: