### PR TITLE
feat: Add Validation request queue depth metric to Gatekeeper

### DIFF
--- a/pkg/webhook/mutation.go
+++ b/pkg/webhook/mutation.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/cert-controller/pkg/rotator"
-	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/gatekeeper/apis"
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
@@ -54,7 +53,7 @@ func init() {
 // TODO enable this once mutation is beta +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch;update
 
 // AddMutatingWebhook registers the mutating webhook server with the manager
-func AddMutatingWebhook(mgr manager.Manager, client *opa.Client, processExcluder *process.Excluder, mutationSystem *mutation.System) error {
+func AddMutatingWebhook(mgr manager.Manager, _ OpaClient, processExcluder *process.Excluder, mutationSystem *mutation.System) error {
 	if !*mutation.MutationEnabled {
 		return nil
 	}

--- a/pkg/webhook/namespacelabel.go
+++ b/pkg/webhook/namespacelabel.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 
-	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
 	"github.com/pkg/errors"
@@ -52,7 +51,7 @@ func (l nsSet) Set(s string) error {
 // +kubebuilder:webhook:verbs=CREATE;UPDATE,path=/v1/admitlabel,mutating=false,failurePolicy=fail,groups="",resources=namespaces,versions=*,name=check-ignore-label.gatekeeper.sh
 
 // AddLabelWebhook registers the label webhook server with the manager
-func AddLabelWebhook(mgr manager.Manager, _ *opa.Client, _ *process.Excluder, mutationCache *mutation.System) error {
+func AddLabelWebhook(mgr manager.Manager, _ OpaClient, _ *process.Excluder, mutationCache *mutation.System) error {
 	wh := &admission.Webhook{Handler: &namespaceLabelHandler{}}
 	// TODO(https://github.com/open-policy-agent/gatekeeper/issues/661): remove log injection if the race condition in the cited bug is eliminated.
 	// Otherwise we risk having unstable logger names for the webhook.

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -16,14 +16,28 @@ limitations under the License.
 package webhook
 
 import (
+	"context"
+
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client"
+	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
+	rtypes "github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+type OpaClient interface {
+	CreateCRD(ctx context.Context, templ *templates.ConstraintTemplate) (*apiextensions.CustomResourceDefinition, error)
+	Dump(ctx context.Context) (string, error)
+	Review(ctx context.Context, obj interface{}, opts ...opa.QueryOpt) (*rtypes.Responses, error)
+	ValidateConstraint(ctx context.Context, constraint *unstructured.Unstructured) error
+}
+
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, *client.Client, *process.Excluder, *mutation.System) error
+var AddToManagerFuncs []func(manager.Manager, OpaClient, *process.Excluder, *mutation.System) error
 
 // The below autogen directive is currently disabled because controller-gen has
 // no way of specifying the resource name restriction


### PR DESCRIPTION
Adds a new gauge metric, "validation_request_pending" indicating the
number of blocked validation requests waiting on the semaphore
that limits validation concurrency (configured via -max-serving-threads).

Limitations:
* Not tracked if a statsReporter is not configured.
* Emitted only after the first validation request has been received.
* The semaphore currently wraps a subset of the admission request - some
  validation takes place before the lock is acquired.
* Does not track concurrent validation requests overall. This is already
  captured by `controller_runtime_webhook_requests_in_flight` so we
  probably do not need to duplicate.

Signed-off-by: Oren Shomron <shomron@gmail.com>

**What this PR does / why we need it**:

This PR adds a metric giving visibility into pending validation requests when limiting concurrency.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1064

**Special notes for your reviewer**:
Take note of the metric name and plurality (`request` vs `requests`).
Also note the linked discussion in #976 which discusses how we should demarcate metrics for various webhook endpoints.