### PR TITLE
Add value testing to the assign mutator

### DIFF
--- a/apis/mutations/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/mutations/v1alpha1/zz_generated.deepcopy.go
@@ -334,16 +334,7 @@ func (in *Parameters) DeepCopyInto(out *Parameters) {
 		*out = make([]PathTest, len(*in))
 		copy(*out, *in)
 	}
-	if in.IfIn != nil {
-		in, out := &in.IfIn, &out.IfIn
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
-	if in.IfNotIn != nil {
-		in, out := &in.IfNotIn, &out.IfNotIn
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
+	in.AssignIf.DeepCopyInto(&out.AssignIf)
 	in.Assign.DeepCopyInto(&out.Assign)
 }
 

--- a/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
@@ -195,21 +195,13 @@ spec:
                   description: Assign.value holds the value to be assigned
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-                ifIn:
-                  description: IfIn Only mutate if the current value is in the supplied
-                    list
-                  items:
-                    type: string
-                  type: array
-                ifNotIn:
-                  description: IfNotIn Only mutate if the current value is NOT in
-                    the supplied list
-                  items:
-                    type: string
-                  type: array
+                assignIf:
+                  description: once https://github.com/kubernetes-sigs/controller-tools/pull/528
+                    is merged, we can use an actual object
+                  type: object
                 pathTests:
                   items:
-                    description: "PathTests allows the user to customize how the mutation
+                    description: "PathTest allows the user to customize how the mutation
                       works if parent paths are missing. It traverses the list in
                       order. All sub paths are tested against the provided condition,
                       if the test fails, the mutation is not applied. All `subPath`

--- a/pkg/mutation/assign_mutator.go
+++ b/pkg/mutation/assign_mutator.go
@@ -20,11 +20,12 @@ import (
 // AssignMutator is a mutator object built out of a
 // Assign instance.
 type AssignMutator struct {
-	id       types.ID
-	assign   *mutationsv1alpha1.Assign
-	path     *parser.Path
-	bindings []schema.Binding
-	tester   *patht.Tester
+	id        types.ID
+	assign    *mutationsv1alpha1.Assign
+	path      *parser.Path
+	bindings  []schema.Binding
+	tester    *patht.Tester
+	valueTest *mutationsv1alpha1.AssignIf
 }
 
 // AssignMutator implements mutatorWithSchema
@@ -40,8 +41,41 @@ func (m *AssignMutator) Matches(obj runtime.Object, ns *corev1.Namespace) bool {
 }
 
 func (m *AssignMutator) Mutate(obj *unstructured.Unstructured) error {
-	return mutate(m, m.tester, obj)
+	return mutate(m, m.tester, m.testValue, obj)
 }
+
+// valueTest returns true if it is okay for the mutation func to override the value
+func (m *AssignMutator) testValue(v interface{}, exists bool) bool {
+	if len(m.valueTest.In) != 0 {
+		ifInMatched := false
+		if !exists {
+			// a missing value cannot satisfy the "In" test
+			return false
+		}
+		for _, obj := range m.valueTest.In {
+			if cmp.Equal(v, obj) {
+				ifInMatched = true
+				break
+			}
+		}
+		if !ifInMatched {
+			return false
+		}
+	}
+
+	if !exists {
+		// a missing value cannot violate NotIn
+		return true
+	}
+
+	for _, obj := range m.valueTest.NotIn {
+		if cmp.Equal(v, obj) {
+			return false
+		}
+	}
+	return true
+}
+
 func (m *AssignMutator) ID() types.ID {
 	return m.id
 }
@@ -94,6 +128,7 @@ func (m *AssignMutator) DeepCopy() types.Mutator {
 	copy(res.path.Nodes, m.path.Nodes)
 	copy(res.bindings, m.bindings)
 	res.tester = m.tester.DeepCopy()
+	res.valueTest = m.valueTest.DeepCopy()
 	return res
 }
 
@@ -102,12 +137,12 @@ func (m *AssignMutator) DeepCopy() types.Mutator {
 func MutatorForAssign(assign *mutationsv1alpha1.Assign) (*AssignMutator, error) {
 	id, err := types.MakeID(assign)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to retrieve id for assign type")
+		return nil, errors.Wrap(err, "failed to retrieve id for assign type")
 	}
 
 	path, err := parser.Parse(assign.Spec.Location)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to parse the location specified")
+		return nil, errors.Wrap(err, "failed to parse the location specified")
 	}
 
 	pathTests, err := gatherPathTests(assign)
@@ -122,13 +157,18 @@ func MutatorForAssign(assign *mutationsv1alpha1.Assign) (*AssignMutator, error) 
 	if err != nil {
 		return nil, err
 	}
+	valueTests, err := assign.ValueTests()
+	if err != nil {
+		return nil, err
+	}
 
 	return &AssignMutator{
-		id:       id,
-		assign:   assign.DeepCopy(),
-		bindings: applyToToBindings(assign.Spec.ApplyTo),
-		path:     path,
-		tester:   tester,
+		id:        id,
+		assign:    assign.DeepCopy(),
+		bindings:  applyToToBindings(assign.Spec.ApplyTo),
+		path:      path,
+		tester:    tester,
+		valueTest: &valueTests,
 	}, nil
 }
 
@@ -199,10 +239,10 @@ func IsValidAssign(assign *mutationsv1alpha1.Assign) error {
 	if err != nil {
 		return err
 	}
-	_, err = MutatorForAssign(assign)
-	if err != nil {
+	if _, err := MutatorForAssign(assign); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/mutation/assign_mutator.go
+++ b/pkg/mutation/assign_mutator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/google/go-cmp/cmp"
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
@@ -25,6 +26,7 @@ type AssignMutator struct {
 	path     *parser.Path
 	bindings []schema.Binding
 	tester   *patht.Tester
+	mux      sync.RWMutex
 }
 
 // AssignMutator implements mutatorWithSchema

--- a/pkg/mutation/assign_mutator.go
+++ b/pkg/mutation/assign_mutator.go
@@ -131,6 +131,8 @@ func (m *AssignMutator) DeepCopy() types.Mutator {
 	}
 	copy(res.path.Nodes, m.path.Nodes)
 	copy(res.bindings, m.bindings)
+	m.mux.RLock()
+	defer m.mux.RUnlock()
 	res.tester = m.tester.DeepCopy()
 	return res
 }

--- a/pkg/mutation/assignmeta_mutator.go
+++ b/pkg/mutation/assignmeta_mutator.go
@@ -63,7 +63,7 @@ func (m *AssignMetadataMutator) Mutate(obj *unstructured.Unstructured) error {
 	if err != nil {
 		return err
 	}
-	return mutate(m, t, obj)
+	return mutate(m, t, nil, obj)
 }
 func (m *AssignMetadataMutator) ID() types.ID {
 	return m.id

--- a/pkg/mutation/conversion_test.go
+++ b/pkg/mutation/conversion_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
 	mschema "github.com/open-policy-agent/gatekeeper/pkg/mutation/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -145,7 +146,7 @@ func TestAssignHasDiff(t *testing.T) {
 		{
 			"differentParameters",
 			func(a *mutationsv1alpha1.Assign) {
-				a.Spec.Parameters.IfIn = []string{"Foo", "Bar"}
+				a.Spec.Parameters.AssignIf = runtime.RawExtension{Raw: []byte(`{"in": ["Foo","Bar"]}`)}
 			},
 			true,
 		},

--- a/pkg/mutation/mutation_function_test.go
+++ b/pkg/mutation/mutation_function_test.go
@@ -380,7 +380,7 @@ func (m *TestMutator) Value() (interface{}, error) {
 
 func (m *TestMutator) Mutate(obj *unstructured.Unstructured) error {
 	t, _ := pathtester.New(nil)
-	return mutate(m, t, obj)
+	return mutate(m, t, func(_ interface{}, _ bool) bool { return true }, obj)
 }
 
 // TODO: rename after TestListsAsLastElementAlreadyExistsWithKeyConflict is deleted


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds value testing to the assign mutator, per the mutation design.

Note that the schema of the value tests has been changed slightly, I now assume a format like:

```yaml
spec:
   parameters:
      assignIf:
         in: ["one", "two"]
         notIn: ["three"]
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1080 

**Special notes for your reviewer**: