### PR TITLE
Remove redundant hard-coded affinity in controller-manager deployment

### DIFF
--- a/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -35,18 +35,6 @@ spec:
         heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: gatekeeper.sh/operation
-                  operator: In
-                  values:
-                  - webhook
-              topologyKey: kubernetes.io/hostname
-            weight: 100
       automountServiceAccountToken: true
       containers:
       - args:


### PR DESCRIPTION
Remove a duplicated affinity value from the helm chart template for the controller-manager deployment.

**Special notes for your reviewer**: n/a