### PR TITLE
Add more details to mutation related errors

### DIFF
--- a/pkg/mutation/assign_mutator.go
+++ b/pkg/mutation/assign_mutator.go
@@ -142,7 +142,7 @@ func MutatorForAssign(assign *mutationsv1alpha1.Assign) (*AssignMutator, error) 
 
 	path, err := parser.Parse(assign.Spec.Location)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse the location specified")
+		return nil, errors.Wrapf(err, "failed to parse the location specified for mutator %v, location: %s", id, assign.Spec.Location)
 	}
 
 	pathTests, err := gatherPathTests(assign)
@@ -178,7 +178,7 @@ func gatherPathTests(assign *mutationsv1alpha1.Assign) ([]patht.Test, error) {
 	for _, pt := range pts {
 		p, err := parser.Parse(pt.SubPath)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("problem parsing sub path `%s`", pt.SubPath))
+			return nil, errors.Wrap(err, fmt.Sprintf("problem parsing sub path `%s` for Assign %s", pt.SubPath, assign.GetName()))
 		}
 		pathTests = append(pathTests, patht.Test{SubPath: p, Condition: pt.Condition})
 	}
@@ -212,14 +212,14 @@ func applyToToBindings(applyTos []mutationsv1alpha1.ApplyTo) []schema.Binding {
 func IsValidAssign(assign *mutationsv1alpha1.Assign) error {
 	path, err := parser.Parse(assign.Spec.Location)
 	if err != nil {
-		return errors.Wrap(err, "invalid location format")
+		return errors.Wrapf(err, "invalid location format `%s` for Assign %s", assign.Spec.Location, assign.GetName())
 	}
 
 	if hasMetadataRoot(path) {
-		return errors.New("assign can't change metadata")
+		return errors.New(fmt.Sprintf("assign %s can't change metadata", assign.GetName()))
 	}
 
-	err = checkKeyNotChanged(path)
+	err = checkKeyNotChanged(path, assign.GetName())
 	if err != nil {
 		return err
 	}
@@ -227,15 +227,15 @@ func IsValidAssign(assign *mutationsv1alpha1.Assign) error {
 	toAssign := make(map[string]interface{})
 	err = json.Unmarshal([]byte(assign.Spec.Parameters.Assign.Raw), &toAssign)
 	if err != nil {
-		return errors.Wrap(err, "invalid format for parameters.assign")
+		return errors.Wrapf(err, "invalid format for parameters.assign %s for Assign %s", assign.Spec.Parameters.Assign.Raw, assign.GetName())
 	}
 
 	value, ok := toAssign["value"]
 	if !ok {
-		return errors.New("spec.parameters.assign must have a value field")
+		return errors.New(fmt.Sprintf("spec.parameters.assign for Assign %s must have a value field", assign.GetName()))
 	}
 
-	err = validateObjectAssignedToList(path, value)
+	err = validateObjectAssignedToList(path, value, assign.GetName())
 	if err != nil {
 		return err
 	}
@@ -259,7 +259,7 @@ func hasMetadataRoot(path *parser.Path) bool {
 
 // checkKeyNotChanged does not allow to change the key field of
 // a list element. A path like foo[name: bar].name is rejected
-func checkKeyNotChanged(p *parser.Path) error {
+func checkKeyNotChanged(p *parser.Path, assignName string) error {
 	if len(p.Nodes) == 0 || p.Nodes == nil {
 		return errors.New("empty path")
 	}
@@ -273,24 +273,24 @@ func checkKeyNotChanged(p *parser.Path) error {
 		return nil
 	}
 	if lastNode.Type() != parser.ObjectNode {
-		return errors.New("invalid path format: child of a list can't be a list")
+		return errors.New(fmt.Sprintf("invalid path format in Assign %s: child of a list can't be a list", assignName))
 	}
 	addedObject, ok := lastNode.(*parser.Object)
 	if !ok {
-		return errors.New("failed converting an ObjectNodeType to Object")
+		return errors.New("failed converting an ObjectNodeType to Object in Assign " + assignName)
 	}
 	listNode, ok := secondLastNode.(*parser.List)
 	if !ok {
-		return errors.New("failed converting a ListNodeType to List")
+		return errors.New("failed converting a ListNodeType to List in Assign " + assignName)
 	}
 
 	if addedObject.Reference == listNode.KeyField {
-		return errors.New("invalid path format: changing the item key is not allowed")
+		return errors.New(fmt.Sprintf("invalid path format in Assign %s: changing the item key is not allowed", assignName))
 	}
 	return nil
 }
 
-func validateObjectAssignedToList(p *parser.Path, value interface{}) error {
+func validateObjectAssignedToList(p *parser.Path, value interface{}, assignName string) error {
 	if len(p.Nodes) == 0 || p.Nodes == nil {
 		return errors.New("empty path")
 	}
@@ -299,20 +299,20 @@ func validateObjectAssignedToList(p *parser.Path, value interface{}) error {
 	}
 	listNode, ok := p.Nodes[len(p.Nodes)-1].(*parser.List)
 	if !ok {
-		return errors.New("failed converting a ListNodeType to List")
+		return errors.New("failed converting a ListNodeType to List, Assign: " + assignName)
 	}
 	if listNode.Glob {
-		return errors.New("can't append to a globbed list")
+		return errors.New("can't append to a globbed list, Assign: " + assignName)
 	}
 	if listNode.KeyValue == nil {
-		return errors.New("invalid key value for a non globbed object")
+		return errors.New("invalid key value for a non globbed object, Assign: " + assignName)
 	}
 	valueMap, ok := value.(map[string]interface{})
 	if !ok {
-		return errors.New("only full objects can be appended to lists")
+		return errors.New("only full objects can be appended to lists, Assign: " + assignName)
 	}
 	if *listNode.KeyValue != valueMap[listNode.KeyField] {
-		return fmt.Errorf("adding object to list with different key %s: list key %s, object key %s", listNode.KeyField, *listNode.KeyValue, valueMap[listNode.KeyField])
+		return fmt.Errorf("adding object to list with different key %s: list key %s, object key %s, assign: %s", listNode.KeyField, *listNode.KeyValue, valueMap[listNode.KeyField], assignName)
 	}
 
 	return nil

--- a/pkg/mutation/assignmeta_mutator.go
+++ b/pkg/mutation/assignmeta_mutator.go
@@ -160,10 +160,10 @@ func isValidMetadataPath(path *parser.Path) bool {
 func IsValidAssignMetadata(assignMeta *mutationsv1alpha1.AssignMetadata) error {
 	path, err := parser.Parse(assignMeta.Spec.Location)
 	if err != nil {
-		return errors.Wrap(err, "invalid location format")
+		return errors.Wrapf(err, "invalid location format for Assign %s: %s", assignMeta.GetName(), assignMeta.Spec.Location)
 	}
 	if !isValidMetadataPath(path) {
-		return fmt.Errorf("invalid location for assignmetadata: %s", assignMeta.Spec.Location)
+		return fmt.Errorf("invalid location for assignmetadata %s: %s", assignMeta.GetName(), assignMeta.Spec.Location)
 	}
 
 	assign := make(map[string]interface{})
@@ -173,10 +173,10 @@ func IsValidAssignMetadata(assignMeta *mutationsv1alpha1.AssignMetadata) error {
 	}
 	value, ok := assign["value"]
 	if !ok {
-		return errors.New("spec.parameters.assign must have a string value field")
+		return errors.New("spec.parameters.assign must have a string value field for AssignMetadata " + assignMeta.GetName())
 	}
 	if _, ok := value.(string); !ok {
-		return errors.New("spec.parameters.assign must be a string")
+		return errors.New("spec.parameters.assign must be a string for AssignMetadata " + assignMeta.GetName())
 	}
 	return nil
 }

--- a/pkg/mutation/types/mutator.go
+++ b/pkg/mutation/types/mutator.go
@@ -50,12 +50,12 @@ func MakeID(obj runtime.Object) (ID, error) {
 	}, nil
 }
 
-// UnmarshalValue unmarhsals the value a mutation is meant to assign
+// UnmarshalValue unmarshals the value a mutation is meant to assign
 func UnmarshalValue(data []byte) (interface{}, error) {
 	value := make(map[string]interface{})
 	err := json.Unmarshal(data, &value)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to unmarshal value")
+		return nil, errors.Wrapf(err, "Failed to unmarshal value %s", data)
 	}
 	return value["value"], nil
 }


### PR DESCRIPTION
The mutations error messages are sometimes missing information about the mutation for which a failure occurred. 
This patch add some more info to some of the error messages.