### PR TITLE
[master] add kustomization.yaml for deploy

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - gatekeeper.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

For users that do not use helm, they would easily be able to reference the gatekeeper file for deployments, compared to copy and pasting the existing `gatekeeper.yaml` within their repo.

An example deployment would look like
`kustomization.yaml` -  would exist in the repo for the engineer that wishes to deploy gatekeeper
```
resources:
  - ssh://github.com/open-policy-agent/gatekeeper/deploy?ref=master
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: