### PR TITLE
fix: e2e teardown.

### DIFF
--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -13,9 +13,11 @@ teardown() {
 }
 
 teardown_file() {
+  kubectl label ns ${GATEKEEPER_NAMESPACE} admission.gatekeeper.sh/ignore=no-self-managing --overwrite || true
   kubectl delete ns gatekeeper-test-playground gatekeeper-excluded-namespace || true
-  kubectl delete constrainttemplates k8scontainerlimits k8srequiredlabels k8suniquelabel || true
-  kubectl delete configs.config.gatekeeper.sh config -n ${GATEKEEPER_NAMESPACE} || true
+  kubectl delete "$(kubectl api-resources --api-group=constraints.gatekeeper.sh -o name | tr "\n" "," | sed -e 's/,$//')" -l gatekeeper.sh/tests=yes || true
+  kubectl delete ConstraintTemplates -l gatekeeper.sh/tests=yes || true
+  kubectl delete configs.config.gatekeeper.sh -n ${GATEKEEPER_NAMESPACE} -l gatekeeper.sh/tests=yes || true
 }
 
 @test "gatekeeper-controller-manager is running" {

--- a/test/bats/tests/constraints/all_cm_gatekeeper_label_unique.yaml
+++ b/test/bats/tests/constraints/all_cm_gatekeeper_label_unique.yaml
@@ -2,6 +2,8 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sUniqueLabel
 metadata:
   name: cm-gk-label-unique
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   match:
     namespaces: ["gatekeeper-test-playground"]

--- a/test/bats/tests/constraints/all_cm_must_have_gatekeeper-dryrun.yaml
+++ b/test/bats/tests/constraints/all_cm_must_have_gatekeeper-dryrun.yaml
@@ -2,6 +2,8 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
   name: cm-must-have-gk
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   enforcementAction: dryrun
   match:

--- a/test/bats/tests/constraints/all_cm_must_have_gatekeeper.yaml
+++ b/test/bats/tests/constraints/all_cm_must_have_gatekeeper.yaml
@@ -2,6 +2,8 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
   name: cm-must-have-gk
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   match:
     namespaces: ["gatekeeper-test-playground", "gatekeeper-excluded-namespace"]

--- a/test/bats/tests/constraints/all_cm_must_have_gatekeeper_audit.yaml
+++ b/test/bats/tests/constraints/all_cm_must_have_gatekeeper_audit.yaml
@@ -2,6 +2,8 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
   name: cm-must-have-gk-audit
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   match:
     namespaces: ["gatekeeper-test-playground"]

--- a/test/bats/tests/constraints/containers_must_be_limited.yaml
+++ b/test/bats/tests/constraints/containers_must_be_limited.yaml
@@ -2,6 +2,8 @@ apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sContainerLimits
 metadata:
   name: container-must-have-limits
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   match:
     kinds:

--- a/test/bats/tests/sync.yaml
+++ b/test/bats/tests/sync.yaml
@@ -2,6 +2,8 @@ apiVersion: config.gatekeeper.sh/v1alpha1
 kind: Config
 metadata:
   name: config
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   sync:
     syncOnly:

--- a/test/bats/tests/sync_with_exclusion.yaml
+++ b/test/bats/tests/sync_with_exclusion.yaml
@@ -2,6 +2,8 @@ apiVersion: config.gatekeeper.sh/v1alpha1
 kind: Config
 metadata:
   name: config
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   match:
     - excludedNamespaces: ["gatekeeper-excluded-namespace"]

--- a/test/bats/tests/templates/k8scontainterlimits_template.yaml
+++ b/test/bats/tests/templates/k8scontainterlimits_template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8scontainerlimits
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   crd:
     spec:

--- a/test/bats/tests/templates/k8srequiredlabels_template.yaml
+++ b/test/bats/tests/templates/k8srequiredlabels_template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8srequiredlabels
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   crd:
     spec:

--- a/test/bats/tests/templates/k8suniquelabel_template.yaml
+++ b/test/bats/tests/templates/k8suniquelabel_template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8suniquelabel
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   crd:
     spec:


### PR DESCRIPTION
This will allow the tests to be re-run.

Signed-off-by: Julian Dolce <jdolce@qnx.com>

**What this PR does / why we need it**:
Cleans up after an e2e test run so that tests can be re-run and will pass.


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1119

**Special notes for your reviewer**: