### PR TITLE
Provide the flag for disable unsafe builtins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ MANAGER_IMAGE_PATCH := "apiVersion: apps/v1\
 \n        - --emit-admission-events\
 \n        - --exempt-namespace=${GATEKEEPER_NAMESPACE}\
 \n        - --operation=webhook\
+\n        - --disable-opa-builtin=http.send\
 \n---\
 \napiVersion: apps/v1\
 \nkind: Deployment\
@@ -128,7 +129,8 @@ e2e-helm-deploy: e2e-helm-install
 	--set image.release=${HELM_RELEASE} \
 	--set emitAdmissionEvents=true \
 	--set emitAuditEvents=true \
-	--set postInstall.labelNamespace.enabled=true;\
+	--set postInstall.labelNamespace.enabled=true \
+	--set disabledBuiltins={http.send};\
 
 e2e-helm-upgrade-init: e2e-helm-install
 		./.staging/helm/linux-amd64/helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts;\
@@ -143,7 +145,8 @@ e2e-helm-upgrade:
 		--set image.repository=${HELM_REPO} \
 		--set image.release=${HELM_RELEASE} \
 		--set emitAdmissionEvents=true \
-		--set emitAuditEvents=true;\
+		--set emitAuditEvents=true \
+		--set disabledBuiltins={http.send};\
 
 # Build manager binary
 manager: generate

--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -69,6 +69,7 @@ spec:
             - --exempt-namespace={{ .Release.Namespace }}
             - --operation=webhook
             - --enable-mutation={{ .Values.experimentalEnableMutation}}
+            - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_DISABLED_BUILTIN
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.release }}"
           resources:

--- a/cmd/build/helmify/replacements.go
+++ b/cmd/build/helmify/replacements.go
@@ -48,4 +48,8 @@ var replacements = map[string]string{
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
     {{- end }}
   {{- end }}`,
+	"- HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_DISABLED_BUILTIN": `
+        {{- range .Values.disabledBuiltins}}
+        - --disable-opa-builtin={{ . }}
+        {{- end }}`,
 }

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -70,3 +70,4 @@ pdb:
   controllerManager:
     minAvailable: 1
 service: {}
+disabledBuiltins:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -49,6 +49,10 @@ spec:
         - --exempt-namespace={{ .Release.Namespace }}
         - --operation=webhook
         - --enable-mutation={{ .Values.experimentalEnableMutation}}
+        
+        {{- range .Values.disabledBuiltins}}
+        - --disable-opa-builtin={{ . }}
+        {{- end }}
         command:
         - /manager
         env:

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -70,3 +70,4 @@ pdb:
   controllerManager:
     minAvailable: 1
 service: {}
+disabledBuiltins:

--- a/pkg/util/flagSet.go
+++ b/pkg/util/flagSet.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"flag"
+	"fmt"
+)
+
+type FlagSet map[string]bool
+
+var _ flag.Value = FlagSet{}
+
+func NewFlagSet() FlagSet {
+	return make(map[string]bool)
+}
+
+func (l FlagSet) ToSlice() []string {
+	contents := make([]string, 0)
+	for k := range l {
+		contents = append(contents, k)
+	}
+	return contents
+}
+
+func (l FlagSet) String() string {
+	return fmt.Sprintf("%s", l.ToSlice())
+}
+
+func (l FlagSet) Set(s string) error {
+	l[s] = true
+	return nil
+}

--- a/pkg/webhook/namespacelabel.go
+++ b/pkg/webhook/namespacelabel.go
@@ -11,6 +11,7 @@ import (
 	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
+	"github.com/open-policy-agent/gatekeeper/pkg/util"
 	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -19,8 +20,8 @@ import (
 )
 
 var (
-	exemptNamespace       = newNSSet()
-	exemptNamespacePrefix = newNSSet()
+	exemptNamespace       = util.NewFlagSet()
+	exemptNamespacePrefix = util.NewFlagSet()
 )
 
 func init() {
@@ -30,27 +31,6 @@ func init() {
 }
 
 const ignoreLabel = "admission.gatekeeper.sh/ignore"
-
-type nsSet map[string]bool
-
-var _ flag.Value = nsSet{}
-
-func newNSSet() nsSet {
-	return make(map[string]bool)
-}
-
-func (l nsSet) String() string {
-	contents := make([]string, 0)
-	for k := range l {
-		contents = append(contents, k)
-	}
-	return fmt.Sprintf("%s", contents)
-}
-
-func (l nsSet) Set(s string) error {
-	l[s] = true
-	return nil
-}
 
 // +kubebuilder:webhook:verbs=CREATE;UPDATE,path=/v1/admitlabel,mutating=false,failurePolicy=fail,groups="",resources=namespaces,versions=*,name=check-ignore-label.gatekeeper.sh
 

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -220,3 +220,12 @@ __required_labels_audit_test() {
   kubectl apply -n ${GATEKEEPER_NAMESPACE} -f ${BATS_TESTS_DIR}/sync_with_exclusion.yaml
   wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl create configmap should-succeed -n gatekeeper-excluded-namespace"
 }
+
+@test "disable http.send" {
+  wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl apply -f ${BATS_TESTS_DIR}/templates/use_http_send_template.yaml"
+  wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "constraint_enforced constrainttemplate k8sdenynamehttpsend"
+  run kubectl apply -f ${BATS_TESTS_DIR}/bad/bad_http_send.yaml
+  assert_failure
+  run kubectl get constrainttemplate/k8sdenynamehttpsend -o jsonpath="{.status}"
+  assert_match 'undefined function http.send' "${output}"
+}

--- a/test/bats/tests/bad/bad_http_send.yaml
+++ b/test/bats/tests/bad/bad_http_send.yaml
@@ -1,0 +1,7 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sDenyNameHttpSend
+metadata:
+  name: dummy-constraint
+spec:
+  parameters:
+    invalidName: "policy-violation"

--- a/test/bats/tests/templates/use_http_send_template.yaml
+++ b/test/bats/tests/templates/use_http_send_template.yaml
@@ -1,0 +1,25 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: k8sdenynamehttpsend
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sDenyNameHttpSend
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          properties:
+            invalidName:
+              type: string
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8sdenynamehttpsend
+        violation[{"msg": msg}] {
+          input.review.object.metadata.name == input.parameters.invalidName
+          response := http.send({"method": "get", "url": "https://github.com/"})
+          msg := sprintf("The name is not allowed, msg= %v", [input.parameters.invalidName, response])
+
+        }


### PR DESCRIPTION
Signed-off-by: Becky Huang <beckyhd@google.com>

**What this PR does / why we need it**:
Provide the flag allowing us to set `--disable-builtin=http.send` to toggle off opa http.send builtin

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1137

**Special notes for your reviewer**:
Reused the flag struct implemented by exempt-namespace, it's now moved to util package.