### PR TITLE
Fix gh workflow tagged release

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -239,6 +239,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
       - name: Get tag
         id: get_version
         run: |


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

**What this PR does / why we need it**:

During release, ran into issue with the `tagged release` job step `Verify release` with error:
```console
note: module requires Go 1.16
make: *** [Makefile:195: manifests] Error 2
Error: Process completed with exit code 2.
```
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**: