### PR TITLE
fix: add metrics port to helm chart

### DIFF
--- a/charts/gatekeeper/templates/gatekeeper-webhook-service-service.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-webhook-service-service.yaml
@@ -11,8 +11,11 @@ metadata:
   namespace: '{{ include "gatekeeper.namespace" . }}'
 spec:
   ports:
-  - port: 443
+  - name: https
+    port: 443
     targetPort: 8443
+  - name: metrics
+    port: 8888
   selector:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the metrics port to Gatekeeper webhook service in helm chart, which was missing.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
N/A