### PR TITLE
website: fix markdown heading

### DIFF
--- a/website/docs/mutation.md
+++ b/website/docs/mutation.md
@@ -3,8 +3,6 @@ id: mutation
 title: Mutation
 ---
 
-## Gatekeeper mutation
-
 The mutation feature allows Gatekeeper to not only validate created Kubernetes resources but also modify them based on defined mutation policies.
 The feature is still in an alpha stage, so the final form can still change.
 

--- a/website/docs/mutation.md
+++ b/website/docs/mutation.md
@@ -3,7 +3,7 @@ id: mutation
 title: Mutation
 ---
 
-#Gatekeeper mutation
+## Gatekeeper mutation
 
 The mutation feature allows Gatekeeper to not only validate created Kubernetes resources but also modify them based on defined mutation policies.
 The feature is still in an alpha stage, so the final form can still change.


### PR DESCRIPTION
Signed-off-by: Takao Shibata <chise.alter.pasta@gmail.com>

**What this PR does / why we need it**:

Heading in following website is broken. This PR fix it.

- https://open-policy-agent.github.io/gatekeeper/website/docs/mutation

I add space to fix broken heading and set heading level as level 2 according to other headings.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

None

**Special notes for your reviewer**:

None