### PR TITLE
Reporting violations metrics with constraint specific tags

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -222,8 +222,14 @@ func (am *Manager) audit(ctx context.Context) error {
 	}
 
 	for k, v := range totalViolationsPerEnforcementAction {
-		if err := am.reporter.reportTotalViolations(k, v); err != nil {
-			am.log.Error(err, "failed to report total violations")
+		if err := am.reporter.reportTotalViolationsByEnforcementAction(k, v); err != nil {
+			am.log.Error(err, "failed to report total violations by enforcement_action")
+		}
+	}
+
+	for k, v := range totalViolationsPerConstraint {
+		if err := am.reporter.reportTotalViolationsByConstraint(k, v); err != nil {
+			am.log.Error(err, "failed to report total violations by constraint")
 		}
 	}
 

--- a/pkg/util/selfLink.go
+++ b/pkg/util/selfLink.go
@@ -17,3 +17,11 @@ func GetUniqueKey(obj unstructured.Unstructured) KindVersionResource {
 		resource: obj.GetName(),
 	}
 }
+
+func (r KindVersionResource) Name() string {
+	return r.resource
+}
+
+func (r KindVersionResource) Kind() string {
+	return r.kind
+}

--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -83,6 +83,10 @@ Below are the list of metrics provided by Gatekeeper:
 
     - `enforcement_action`: [`deny`, `dryrun`]
 
+    - `constraint_type`: [`<constraint kind>`]
+
+    - `constraint_name`: [`<constraint name>`]
+
     Aggregation: `LastValue`
 
 - Name: `audit_duration_seconds`


### PR DESCRIPTION
**Reporting violations metrics with constraint specific tags**:

This extends gatekeeper's metrics so users can measure which constraints have how many violations.

**Special notes for your reviewer**:

I tried to introduce this change as non-breaking. Unfortunately this way we don't combine the old and new labels. What do you think?