### PR TITLE
Remove deprecated kubectl generators from e2e

### DIFF
--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -33,7 +33,7 @@ teardown_file() {
   CLEAN_CMD="${CLEAN_CMD}; rm ${cert}"
   wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "get_ca_cert ${cert}"
 
-  kubectl run temp --generator=run-pod/v1  --image=tutum/curl -- tail -f /dev/null
+  kubectl run temp --image=tutum/curl -- tail -f /dev/null
   kubectl wait --for=condition=Ready --timeout=60s pod temp
   kubectl cp ${cert} temp:/cacert
 
@@ -149,7 +149,7 @@ teardown_file() {
 }
 
 @test "waiting for namespaces to be synced using metrics endpoint" {
-  kubectl run temp --generator=run-pod/v1  --image=tutum/curl -- tail -f /dev/null
+  kubectl run temp --image=tutum/curl -- tail -f /dev/null
   kubectl wait --for=condition=Ready --timeout=60s pod temp
 
   num_namespaces=$(kubectl get ns -o json | jq '.items | length')


### PR DESCRIPTION
Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: