### PR TITLE
remove duplicate isValidMetadataPath in assignMetadata

### DIFF
--- a/pkg/mutation/assignmeta_mutator.go
+++ b/pkg/mutation/assignmeta_mutator.go
@@ -144,9 +144,6 @@ func MutatorForAssignMetadata(assignMeta *mutationsv1alpha1.AssignMetadata) (*As
 		return nil, errors.Wrap(err, "failed to retrieve id for assignMetadata type")
 	}
 
-	if !isValidMetadataPath(path) {
-		return nil, fmt.Errorf("invalid location for assignmetadata: %s", assignMeta.Spec.Location)
-	}
 	return &AssignMetadataMutator{
 		id:             id,
 		assignMetadata: assignMeta.DeepCopy(),


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
we are checking `isValidMetadataPath` already in line 126

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: