### PR TITLE
set klog global logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
+	k8s.io/klog/v2 v2.2.0
 	sigs.k8s.io/controller-runtime v0.7.0
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -132,7 +133,9 @@ func main() {
 		eCfg := zap.NewDevelopmentEncoderConfig()
 		eCfg.LevelKey = *logLevelKey
 		eCfg.EncodeLevel = encoder
-		ctrl.SetLogger(crzap.New(crzap.UseDevMode(true), crzap.Encoder(zapcore.NewConsoleEncoder(eCfg))))
+		logger := crzap.New(crzap.UseDevMode(true), crzap.Encoder(zapcore.NewConsoleEncoder(eCfg)))
+		ctrl.SetLogger(logger)
+		klog.SetLogger(logger)
 	case "WARNING", "ERROR":
 		setLoggerForProduction(encoder)
 	case "INFO":
@@ -141,7 +144,9 @@ func main() {
 		eCfg := zap.NewProductionEncoderConfig()
 		eCfg.LevelKey = *logLevelKey
 		eCfg.EncodeLevel = encoder
-		ctrl.SetLogger(crzap.New(crzap.UseDevMode(false), crzap.Encoder(zapcore.NewJSONEncoder(eCfg))))
+		logger := crzap.New(crzap.UseDevMode(false), crzap.Encoder(zapcore.NewJSONEncoder(eCfg)))
+		ctrl.SetLogger(logger)
+		klog.SetLogger(logger)
 	}
 	config := ctrl.GetConfigOrDie()
 	config.UserAgent = version.GetUserAgent()
@@ -324,4 +329,5 @@ func setLoggerForProduction(encoder zapcore.LevelEncoder) {
 	zlog = zlog.WithOptions(opts...)
 	newlogger := zapr.NewLogger(zlog)
 	ctrl.SetLogger(newlogger)
+	klog.SetLogger(newlogger)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -634,6 +634,7 @@ k8s.io/component-base/metrics
 k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/version
 # k8s.io/klog/v2 v2.2.0
+## explicit
 k8s.io/klog/v2
 # k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6
 k8s.io/kube-openapi/pkg/util/proto


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
Set klog logger to align with existing logger. This applies to logs coming from client-go.

Before:
```
W0416 02:20:51.562994       1 warnings.go:67] admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration
{"level":"info","ts":1618539651.6613297,"logger":"controller-runtime.manager.controller.cert-rotator","msg":"Starting EventSource","source":{}}
W0416 02:20:51.662346       1 warnings.go:67] admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration
W0416 02:20:53.227272       1 warnings.go:67] apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
```
After:
```
{"level":"info","ts":1618540783.254945,"logger":"controller-runtime.manager.controller.cert-rotator","msg":"Starting EventSource","source":{}}
{"level":"info","ts":1618540783.3578596,"msg":"admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration\n"}
{"level":"info","ts":1618540783.4583204,"msg":"admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration\n"}
{"level":"info","ts":1618540785.5252585,"msg":"apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition\n"}
```
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1169

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: