### PR TITLE
Fix gatekeeper mutation image tag

### DIFF
--- a/deploy/experimental/gatekeeper-mutation.yaml
+++ b/deploy/experimental/gatekeeper-mutation.yaml
@@ -1148,7 +1148,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.4.0-rc.1
+        image: openpolicyagent/gatekeeper:v3.4.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -1244,7 +1244,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: openpolicyagent/gatekeeper:v3.4.0-rc.1
+        image: openpolicyagent/gatekeeper:v3.4.0
         imagePullPolicy: Always
         livenessProbe:
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:

The image tag from git tag v3.4.0 is v3.4.0-rc.1, this PR fixes this.

(This is also a flag to think about this on the next release 😉 )
