### PR TITLE
Rebase controller-runtime/pkg/cache fork over v0.8.2

### DIFF
--- a/third_party/sigs.k8s.io/controller-runtime/README.md
+++ b/third_party/sigs.k8s.io/controller-runtime/README.md
@@ -1,10 +1,10 @@
 # sigs.k8s.io/controller-runtime
 
-Forked from sigs.k8s.io/controller-runtime@f7a3dc6a7650289b6ca7afca12b97819329b0d06 (v0.7.0).
+Forked from sigs.k8s.io/controller-runtime@a8c19c49e49cfba2aa486ff322cbe5222d6da533 (v0.8.2).
 
 This fork adds the ability to dynamically
 remove informers from the informer cache. Additionally, non-blocking APIs were added to fetch informers
 without waiting for cache sync. `pkg/cache` was renamed to `pkg/dynamiccache` for clarity.
 
-The original code can be found at https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache.
+The original code can be found at https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache.
 

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Modified from the original source (available at
-// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache)
+// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache)
 
 package dynamiccache
 

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache_suite_test.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache_suite_test.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Modified from the original source (available at
-// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache)
+// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache)
 
 package dynamiccache_test
 

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/doc.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Modified from the original source (available at
-// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache)
+// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache)
 
 // Package cache provides object caches that act as caching client.Reader
 // instances and help drive Kubernetes-object-based event handlers.

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/informer_cache.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/informer_cache.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Modified from the original source (available at
-// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache)
+// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache)
 
 package dynamiccache
 

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/informer_cache_test.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/informer_cache_test.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Modified from the original source (available at
-// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache)
+// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache)
 
 package dynamiccache_test
 

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/informer_cache_unit_test.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/informer_cache_unit_test.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Modified from the original source (available at
-// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache)
+// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache)
 
 package dynamiccache
 

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/internal/cache_reader.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/internal/cache_reader.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/cache"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,10 +43,16 @@ type CacheReader struct {
 
 	// groupVersionKind is the group-version-kind of the resource.
 	groupVersionKind schema.GroupVersionKind
+
+	// scopeName is the scope of the resource (namespaced or cluster-scoped).
+	scopeName apimeta.RESTScopeName
 }
 
 // Get checks the indexer for the object and writes a copy of it if found
 func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out client.Object) error {
+	if c.scopeName == apimeta.RESTScopeNameRoot {
+		key.Namespace = ""
+	}
 	storeKey := objectKeyToStoreKey(key)
 
 	// Lookup the object from the indexer cache

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/internal/deleg_map.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/internal/deleg_map.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Modified from the original source (available at
-// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache)
+// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache)
 
 package internal
 

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/multi_namespace_cache.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/multi_namespace_cache.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Modified from the original source (available at
-// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.7.0/pkg/cache)
+// https://github.com/kubernetes-sigs/controller-runtime/tree/v0.8.2/pkg/cache)
 
 package dynamiccache
 


### PR DESCRIPTION
Rebases the dynamic cache patch over controller-runtime v0.8.2.
Does not upgrade the direct controller-runtime dependency, that will be handled in a separate PR.