### PR TITLE
Reduce copying of admission.Request

### DIFF
--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -93,7 +93,7 @@ func (h *webhookHandler) getConfig(ctx context.Context) (*v1alpha1.Config, error
 }
 
 // isGatekeeperResource returns true if the request relates to a gatekeeper resource
-func (h *webhookHandler) isGatekeeperResource(ctx context.Context, req admission.Request) bool {
+func (h *webhookHandler) isGatekeeperResource(ctx context.Context, req *admission.Request) bool {
 	if req.AdmissionRequest.Kind.Group == "templates.gatekeeper.sh" ||
 		req.AdmissionRequest.Kind.Group == "constraints.gatekeeper.sh" ||
 		req.AdmissionRequest.Kind.Group == mutationsGroup ||
@@ -105,7 +105,7 @@ func (h *webhookHandler) isGatekeeperResource(ctx context.Context, req admission
 	return false
 }
 
-func (h *webhookHandler) tracingLevel(ctx context.Context, req admission.Request) (bool, bool) {
+func (h *webhookHandler) tracingLevel(ctx context.Context, req *admission.Request) (bool, bool) {
 	cfg, _ := h.getConfig(ctx)
 	traceEnabled := false
 	dump := false
@@ -128,7 +128,7 @@ func (h *webhookHandler) tracingLevel(ctx context.Context, req admission.Request
 	return traceEnabled, dump
 }
 
-func (h *webhookHandler) skipExcludedNamespace(req admissionv1.AdmissionRequest, excludedProcess process.Process) (bool, error) {
+func (h *webhookHandler) skipExcludedNamespace(req *admissionv1.AdmissionRequest, excludedProcess process.Process) (bool, error) {
 	obj := &unstructured.Unstructured{}
 	if _, _, err := deserializer.Decode(req.Object.Raw, nil, obj); err != nil {
 		return false, err

--- a/pkg/webhook/mutation.go
+++ b/pkg/webhook/mutation.go
@@ -114,7 +114,7 @@ func (h *mutationHandler) Handle(ctx context.Context, req admission.Request) adm
 		return admission.ValidationResponse(true, "Mutating only on create or update")
 	}
 
-	if h.isGatekeeperResource(ctx, req) {
+	if h.isGatekeeperResource(ctx, &req) {
 		return admission.ValidationResponse(true, "Not mutating gatekeeper resources")
 	}
 
@@ -128,7 +128,7 @@ func (h *mutationHandler) Handle(ctx context.Context, req admission.Request) adm
 	}()
 
 	// namespace is excluded from webhook using config
-	isExcludedNamespace, err := h.skipExcludedNamespace(req.AdmissionRequest, process.Mutation)
+	isExcludedNamespace, err := h.skipExcludedNamespace(&req.AdmissionRequest, process.Mutation)
 	if err != nil {
 		log.Error(err, "error while excluding namespace")
 	}
@@ -138,7 +138,7 @@ func (h *mutationHandler) Handle(ctx context.Context, req admission.Request) adm
 		return admission.ValidationResponse(true, "Namespace is set to be ignored by Gatekeeper config")
 	}
 
-	resp, err := h.mutateRequest(ctx, req)
+	resp, err := h.mutateRequest(ctx, &req)
 
 	if err != nil {
 		requestResponse = errorResponse
@@ -148,7 +148,7 @@ func (h *mutationHandler) Handle(ctx context.Context, req admission.Request) adm
 	return resp
 }
 
-func (h *mutationHandler) mutateRequest(ctx context.Context, req admission.Request) (admission.Response, error) {
+func (h *mutationHandler) mutateRequest(ctx context.Context, req *admission.Request) (admission.Response, error) {
 
 	ns := &corev1.Namespace{}
 

--- a/pkg/webhook/mutator_validation_test.go
+++ b/pkg/webhook/mutator_validation_test.go
@@ -102,7 +102,7 @@ spec:
 			if err != nil {
 				t.Fatalf("Error parsing yaml: %s", err)
 			}
-			review := atypes.Request{
+			review := &atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Kind: metav1.GroupVersionKind{
 						Group:   "mutations.gatekeeper.sh",
@@ -351,7 +351,7 @@ spec:
 			if err != nil {
 				t.Fatalf("Error parsing yaml: %s", err)
 			}
-			review := atypes.Request{
+			review := &atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Kind: metav1.GroupVersionKind{
 						Group:   "mutations.gatekeeper.sh",

--- a/pkg/webhook/policy_test.go
+++ b/pkg/webhook/policy_test.go
@@ -200,7 +200,7 @@ func TestTemplateValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error parsing yaml: %s", err)
 			}
-			review := atypes.Request{
+			review := &atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Kind: metav1.GroupVersionKind{
 						Group:   "templates.gatekeeper.sh",
@@ -294,7 +294,7 @@ func TestReviewRequest(t *testing.T) {
 			if maxThreads > 0 {
 				handler.semaphore = make(chan struct{}, maxThreads)
 			}
-			review := atypes.Request{
+			review := &atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Kind: metav1.GroupVersionKind{
 						Group:   "",
@@ -390,7 +390,7 @@ func TestConstraintValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error parsing yaml: %s", err)
 			}
-			review := atypes.Request{
+			review := &atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Kind: metav1.GroupVersionKind{
 						Group:   "constraints.gatekeeper.sh",
@@ -510,7 +510,7 @@ func TestTracing(t *testing.T) {
 			if maxThreads > 0 {
 				handler.semaphore = make(chan struct{}, maxThreads)
 			}
-			review := atypes.Request{
+			review := &atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Kind: metav1.GroupVersionKind{
 						Group:   "",
@@ -681,7 +681,7 @@ func TestGetValidationMessages(t *testing.T) {
 			if maxThreads > 0 {
 				handler.semaphore = make(chan struct{}, maxThreads)
 			}
-			review := atypes.Request{
+			review := &atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Kind: metav1.GroupVersionKind{
 						Group:   "",
@@ -728,7 +728,7 @@ func TestValidateConfigResource(t *testing.T) {
 	for _, tt := range tc {
 		t.Run(tt.TestName, func(t *testing.T) {
 			handler := validationHandler{}
-			req := atypes.Request{
+			req := &atypes.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Name: tt.Name,
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
The admission.Request type is 400 bytes, making it huge to pass by value
to functions. Each time this is passed to another function, the runtime
fully copies this object, often many times due to the function depth. In
general, we should avoid such unnecessary struct copying.

This PR reduces this copying (for example) by limiting several functions
to only ask for the subfield of admission.Request they need - the 3 bytes
referencing the Raw object byte slice. Other changes in this PR are
analogous.

I've only done the optimization where it added no complexity to the
call sites. For example, it would be valid to pass a pointer to the
admission.Request, but this could potentially have side effects as
the function would be able to mutate the input. In other cases, the
admission.Request would need to be replaced by more than one
argument so I've not done so (I can if desired).