### PR TITLE
Resolve rangeValCopy lint suggestions

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -270,10 +270,10 @@ func (am *Manager) auditResources(
 		if _, ok := clusterAPIResources[gv]; !ok {
 			clusterAPIResources[gv] = make(map[string]bool)
 		}
-		for _, resource := range rl.APIResources {
-			for _, verb := range resource.Verbs {
+		for i := range rl.APIResources {
+			for _, verb := range rl.APIResources[i].Verbs {
 				if verb == "list" {
-					clusterAPIResources[gv][resource.Kind] = true
+					clusterAPIResources[gv][rl.APIResources[i].Kind] = true
 					break
 				}
 			}
@@ -457,8 +457,8 @@ func (am *Manager) getAllConstraintKinds() ([]schema.GroupVersionKind, error) {
 	version := resourceGV[1]
 	// We have seen duplicate GVK entries on shifting to status client, remove them
 	unique := make(map[schema.GroupVersionKind]bool)
-	for _, i := range l.APIResources {
-		unique[schema.GroupVersionKind{Group: group, Version: version, Kind: i.Kind}] = true
+	for i := range l.APIResources {
+		unique[schema.GroupVersionKind{Group: group, Version: version, Kind: l.APIResources[i].Kind}] = true
 	}
 	var ret []schema.GroupVersionKind
 	for gvk := range unique {
@@ -557,7 +557,8 @@ func (ucloop *updateConstraintLoop) updateConstraintStatus(ctx context.Context, 
 	ucloop.log.Info("updating constraint status", "constraintName", constraintName)
 	// create constraint status violations
 	var statusViolations []interface{}
-	for _, ar := range auditResults {
+	for i := range auditResults {
+		ar := &auditResults[i] // avoid large shallow copy in range loop
 		// append statusViolations for this constraint until constraintViolationsLimit has reached
 		if uint(len(statusViolations)) < *constraintViolationsLimit {
 			msg := ar.message

--- a/pkg/controller/constraintstatus/constraintstatus_controller.go
+++ b/pkg/controller/constraintstatus/constraintstatus_controller.go
@@ -207,14 +207,14 @@ func (r *ReconcileConstraintStatus) Reconcile(ctx context.Context, request recon
 	sort.Sort(statusObjs)
 
 	var s []interface{}
-	for _, v := range statusObjs {
+	for i := range statusObjs {
 		// Don't report status if it's not for the correct object. This can happen
 		// if a watch gets interrupted, causing the constraint status to be deleted
 		// out from underneath it
-		if v.Status.ConstraintUID != instance.GetUID() {
+		if statusObjs[i].Status.ConstraintUID != instance.GetUID() {
 			continue
 		}
-		j, err := json.Marshal(v.Status)
+		j, err := json.Marshal(statusObjs[i].Status)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller.go
@@ -178,14 +178,14 @@ func (r *ReconcileConstraintStatus) Reconcile(ctx context.Context, request recon
 	sort.Sort(statusObjs)
 
 	var s []interface{}
-	for _, v := range statusObjs {
+	for i := range statusObjs {
 		// Don't report status if it's not for the correct object. This can happen
 		// if a watch gets interrupted, causing the constraint status to be deleted
 		// out from underneath it
-		if v.Status.TemplateUID != template.GetUID() {
+		if statusObjs[i].Status.TemplateUID != template.GetUID() {
 			continue
 		}
-		j, err := json.Marshal(v.Status)
+		j, err := json.Marshal(statusObjs[i].Status)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/mutatorstatus/mutatorstatus_controller.go
+++ b/pkg/controller/mutatorstatus/mutatorstatus_controller.go
@@ -228,14 +228,14 @@ func (r *ReconcileMutatorStatus) Reconcile(ctx context.Context, request reconcil
 	sort.Sort(statusObjs)
 
 	var s []interface{}
-	for _, v := range statusObjs {
+	for i := range statusObjs {
 		// Don't report status if it's not for the correct object. This can happen
 		// if a watch gets interrupted, causing the mutator status to be deleted
 		// out from underneath it
-		if v.Status.MutatorUID != instance.GetUID() {
+		if statusObjs[i].Status.MutatorUID != instance.GetUID() {
 			continue
 		}
-		j, err := json.Marshal(v.Status)
+		j, err := json.Marshal(statusObjs[i].Status)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/readiness/ready_tracker.go
+++ b/pkg/readiness/ready_tracker.go
@@ -466,9 +466,12 @@ func (t *Tracker) trackConstraintTemplates(ctx context.Context) error {
 
 	handled := make(map[schema.GroupVersionKind]bool, len(templates.Items))
 	for i := range templates.Items {
-		ct := templates.Items[i]
+		// We don't need to shallow-copy the ConstraintTemplate here. The templates
+		// list is used for nothing else, so there is no danger of the object we
+		// pass to templates.Expect() changing from underneath us.
+		ct := &templates.Items[i]
 		log.V(1).Info("expecting template", "name", ct.GetName())
-		t.templates.Expect(&ct)
+		t.templates.Expect(ct)
 
 		gvk := schema.GroupVersionKind{
 			Group:   constraintGroup,

--- a/pkg/readiness/ready_tracker.go
+++ b/pkg/readiness/ready_tracker.go
@@ -465,8 +465,8 @@ func (t *Tracker) trackConstraintTemplates(ctx context.Context) error {
 	log.V(1).Info("setting expectations for templates", "templateCount", len(templates.Items))
 
 	handled := make(map[schema.GroupVersionKind]bool, len(templates.Items))
-	for _, ct := range templates.Items {
-		ct := ct
+	for i := range templates.Items {
+		ct := templates.Items[i]
 		log.V(1).Info("expecting template", "name", ct.GetName())
 		t.templates.Expect(&ct)
 
@@ -555,12 +555,13 @@ func (t *Tracker) getConfigResource(ctx context.Context) (*configv1alpha1.Config
 		return nil, fmt.Errorf("listing config: %w", err)
 	}
 
-	for _, c := range lst.Items {
+	for i := range lst.Items {
+		c := &lst.Items[i]
 		if c.GetName() != keys.Config.Name || c.GetNamespace() != keys.Config.Namespace {
 			log.Info("ignoring unsupported config name", "namespace", c.GetNamespace(), "name", c.GetName())
 			continue
 		}
-		return &c, nil
+		return c, nil
 	}
 
 	// Not found.

--- a/pkg/upgrade/manager.go
+++ b/pkg/upgrade/manager.go
@@ -117,8 +117,8 @@ func (um *Manager) upgradeGroupVersion(ctx context.Context, groupVersion string)
 
 	// For some reason we have seen duplicate kinds, suppress that
 	uniqueKinds := make(map[string]bool)
-	for _, r := range resourceList.APIResources {
-		uniqueKinds[r.Kind] = true
+	for i := range resourceList.APIResources {
+		uniqueKinds[resourceList.APIResources[i].Kind] = true
 	}
 
 	// get resource for each Kind

--- a/pkg/watch/manager_integration_test.go
+++ b/pkg/watch/manager_integration_test.go
@@ -449,8 +449,8 @@ loop:
 			return fmt.Errorf("getting resources for group: %+v: %w", gvk.GroupVersion(), err)
 		}
 
-		for _, r := range resourceList.APIResources {
-			if r.Name == plural {
+		for i := range resourceList.APIResources {
+			if resourceList.APIResources[i].Name == plural {
 				select {
 				case <-time.After(100 * time.Millisecond):
 				case <-ctx.Done():


### PR DESCRIPTION
**What this PR does / why we need it**:
While range loops are convenient ways of accessing each element in a
list, they can lead to immensely wasteful copying if not handled
carefully. In some cases, we're copying ~400 bytes just to access a
single field!

This PR fixes the issues found by the rangeValCopy linter. Usually, this
is resolved by indexing the list inline. In cases where the entire entry
is required, or many fields are accessed, I've created a variable which
creates a reference to the item in the list without copying it.

In one case, after the implicit shallow copy of the list, we then
explicitly create another shallow copy. I've made it so we only perform
a single shallow copy, as the code seems to intend.

Full list of fixes below. Each line includes how large the copied object
was. I've only done this change for objects larger than 128 bytes.

./pkg/audit/manager.go:273:3: rangeValCopy: each iteration copies 176 bytes (consider pointers or indexing)
./pkg/audit/manager.go:460:2: rangeValCopy: each iteration copies 176 bytes (consider pointers or indexing)
./pkg/audit/manager.go:560:2: rangeValCopy: each iteration copies 184 bytes (consider pointers or indexing)
./pkg/controller/constraintstatus/constraintstatus_controller.go:210:2: rangeValCopy: each iteration copies 376 bytes (consider pointers or indexing)
./pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller.go:181:2: rangeValCopy: each iteration copies 368 bytes (consider pointers or indexing)
./pkg/controller/mutatorstatus/mutatorstatus_controller.go:231:2: rangeValCopy: each iteration copies 376 bytes (consider pointers or indexing)
./pkg/readiness/ready_tracker.go:468:2: rangeValCopy: each iteration copies 384 bytes (consider pointers or indexing)
./pkg/readiness/ready_tracker.go:558:2: rangeValCopy: each iteration copies 353 bytes (consider pointers or indexing)
./pkg/upgrade/manager.go:120:2: rangeValCopy: each iteration copies 176 bytes (consider pointers or indexing)
./pkg/watch/manager_integration_test.go:452:3: rangeValCopy: each iteration copies 176 bytes (consider pointers or indexing)