### PR TITLE
Use "revive" instead of "golint" linter

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -47,7 +47,7 @@ jobs:
           echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
           curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin v${GOLANGCILINT_VERSION}
         env:
-          GOLANGCILINT_VERSION: 1.37.1
+          GOLANGCILINT_VERSION: 1.40.1
 
       - name: Make lint
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,15 @@
-linter-settings:
+linters-settings:
+  gosec:
+    excludes:
+    - G108
   lll:
     line-length: 200
 
   misspell:
     locale: US
+  staticcheck:
+    # Select the Go version to target. The default is '1.13'.
+    go: "1.16"
 
 linters:
   disable-all: true
@@ -11,7 +17,7 @@ linters:
     - errcheck
     - govet
     - ineffassign
-    - golint
+    - revive # replacement for golint
     - goconst
     - gofmt
     - goimports

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ manifests: __controller-gen
 	docker run --rm -v $(shell pwd):/gatekeeper --entrypoint /usr/local/bin/kustomize line/kubectl-kustomize:${KUBECTL_KUSTOMIZE_VERSION} build /gatekeeper/cmd/build/helmify | go run cmd/build/helmify/*.go
 
 lint:
-	golangci-lint -v run --exclude G108 ./... --timeout 5m
+	golangci-lint -v run ./... --timeout 5m
 
 # Generate code
 generate: __controller-gen target-template-source

--- a/apis/status/v1beta1/constraintpodstatus_types.go
+++ b/apis/status/v1beta1/constraintpodstatus_types.go
@@ -28,9 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	ConstraintsGroup = "constraints.gatekeeper.sh"
-)
+// ConstraintsGroup is the API Group for Gatekeeper Constraints.
+const ConstraintsGroup = "constraints.gatekeeper.sh"
 
 // ConstraintPodStatusStatus defines the observed state of ConstraintPodStatus
 type ConstraintPodStatusStatus struct {

--- a/apis/status/v1beta1/labels.go
+++ b/apis/status/v1beta1/labels.go
@@ -1,5 +1,6 @@
 package v1beta1
 
+// Label keys used for internal gatekeeper operations.
 const (
 	ConstraintNameLabel         = "internal.gatekeeper.sh/constraint-name"
 	ConstraintKindLabel         = "internal.gatekeeper.sh/constraint-kind"

--- a/apis/status/v1beta1/mutatorpodstatus_types.go
+++ b/apis/status/v1beta1/mutatorpodstatus_types.go
@@ -28,9 +28,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	MutationsGroup = "mutations.gatekeeper.sh"
-)
+// MutationsGroup is the API Group for Gatekeeper Mutators.
+const MutationsGroup = "mutations.gatekeeper.sh"
 
 // MutatorPodStatusStatus defines the observed state of MutatorPodStatus
 type MutatorPodStatusStatus struct {
@@ -103,7 +102,7 @@ func NewMutatorStatusForPod(pod *corev1.Pod, mutatorID mtypes.ID, scheme *runtim
 	return obj, nil
 }
 
-// KeyForMutator returns a unique status object name given the Pod ID and
+// KeyForMutatorID returns a unique status object name given the Pod ID and
 // a mutator object
 func KeyForMutatorID(id string, mID mtypes.ID) (string, error) {
 	// This adds a requirement that the lowercase of all mutator kinds must be unique.

--- a/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
@@ -54,6 +54,7 @@ spec:
               location:
                 type: string
               match:
+                description: Match selects objects to apply mutations to.
                 properties:
                   excludedNamespaces:
                     items:

--- a/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
@@ -35,6 +35,7 @@ spec:
               location:
                 type: string
               match:
+                description: Match selects objects to apply mutations to.
                 properties:
                   excludedNamespaces:
                     items:

--- a/config/overlays/mutation_webhook/mutations.gatekeeper.sh_assign.yaml
+++ b/config/overlays/mutation_webhook/mutations.gatekeeper.sh_assign.yaml
@@ -54,6 +54,7 @@ spec:
               location:
                 type: string
               match:
+                description: Match selects objects to apply mutations to.
                 properties:
                   excludedNamespaces:
                     items:

--- a/config/overlays/mutation_webhook/mutations.gatekeeper.sh_assignmetadata.yaml
+++ b/config/overlays/mutation_webhook/mutations.gatekeeper.sh_assignmetadata.yaml
@@ -35,6 +35,7 @@ spec:
               location:
                 type: string
               match:
+                description: Match selects objects to apply mutations to.
                 properties:
                   excludedNamespaces:
                     items:

--- a/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
@@ -53,6 +53,7 @@ spec:
               location:
                 type: string
               match:
+                description: Match selects objects to apply mutations to.
                 properties:
                   excludedNamespaces:
                     items:

--- a/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
@@ -34,6 +34,7 @@ spec:
               location:
                 type: string
               match:
+                description: Match selects objects to apply mutations to.
                 properties:
                   excludedNamespaces:
                     items:

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -227,7 +227,7 @@ func TestReconcile(t *testing.T) {
 	cs.Stop()
 }
 
-// tests that expectations for sync only resource gets cancelled when it gets deleted
+// tests that expectations for sync only resource gets canceled when it gets deleted
 func TestConfig_DeleteSyncResources(t *testing.T) {
 	log.Info("Running test: Cancel the expectations when sync only resource gets deleted")
 

--- a/pkg/controller/config/process/excluder.go
+++ b/pkg/controller/config/process/excluder.go
@@ -10,8 +10,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// Process indicates the Gatekeeper component from which the resource will be excluded.
 type Process string
 
+// The set of defined Gatekeeper processes.
 const (
 	Audit    = Process("audit")
 	Sync     = Process("sync")

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -564,20 +564,14 @@ func (r *ReconcileConstraintTemplate) addWatch(kind schema.GroupVersionKind) err
 	if err := r.watcher.AddWatch(kind); err != nil {
 		return err
 	}
-	if err := r.statusWatcher.AddWatch(kind); err != nil {
-		return err
-	}
-	return nil
+	return r.statusWatcher.AddWatch(kind)
 }
 
 func (r *ReconcileConstraintTemplate) removeWatch(kind schema.GroupVersionKind) error {
 	if err := r.watcher.RemoveWatch(kind); err != nil {
 		return err
 	}
-	if err := r.statusWatcher.RemoveWatch(kind); err != nil {
-		return err
-	}
-	return nil
+	return r.statusWatcher.RemoveWatch(kind)
 }
 
 type action string

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -383,7 +383,7 @@ violation[{"msg": "denied!"}] {
 	})
 }
 
-// Tests that expectations for constraints are cancelled if the corresponding constraint is deleted.
+// Tests that expectations for constraints are canceled if the corresponding constraint is deleted.
 func TestReconcile_DeleteConstraintResources(t *testing.T) {
 	log.Info("Running test: Cancel the expectations when constraint gets deleted")
 

--- a/pkg/controller/sync/stats_reporter.go
+++ b/pkg/controller/sync/stats_reporter.go
@@ -62,7 +62,7 @@ type Reporter struct {
 	now func() float64
 }
 
-// newStatsReporter creates a reporter for sync metrics
+// NewStatsReporter creates a reporter for sync metrics
 func NewStatsReporter() (*Reporter, error) {
 	ctx, err := tag.New(
 		context.TODO(),

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,5 +1,6 @@
 package logging
 
+// Log keys.
 const (
 	Process              = "process"
 	EventType            = "event_type"

--- a/pkg/metrics/status.go
+++ b/pkg/metrics/status.go
@@ -1,12 +1,17 @@
 package metrics
 
+// Status is whether a ConstraintTemplate is functioning properly.
+// Reported in metrics.
 type Status string
 
 const (
+	// ActiveStatus indicates a ConstraintTemplate is operating normally.
 	ActiveStatus Status = "active"
-	ErrorStatus  Status = "error"
+	// ErrorStatus indicates there is a problem with a ConstraintTemplate.
+	ErrorStatus Status = "error"
 )
 
 var (
+	// AllStatuses is the set of all allowed values of Status.
 	AllStatuses = []Status{ActiveStatus, ErrorStatus}
 )

--- a/pkg/mutation/match/match.go
+++ b/pkg/mutation/match/match.go
@@ -21,6 +21,7 @@ type ApplyTo struct {
 	Versions []string `json:"versions,omitempty"`
 }
 
+// Match selects objects to apply mutations to.
 // +kubebuilder:object:generate=true
 type Match struct {
 	Kinds              []Kinds                            `json:"kinds,omitempty"`

--- a/pkg/mutation/mutators/assign_mutator.go
+++ b/pkg/mutation/mutators/assign_mutator.go
@@ -156,7 +156,7 @@ func MutatorForAssign(assign *mutationsv1alpha1.Assign) (*AssignMutator, error) 
 	}
 
 	if hasMetadataRoot(path) {
-		return nil, errors.New(fmt.Sprintf("assign %s can't change metadata", assign.GetName()))
+		return nil, fmt.Errorf("assign %s can't change metadata", assign.GetName())
 	}
 
 	err = checkKeyNotChanged(path, assign.GetName())
@@ -172,7 +172,7 @@ func MutatorForAssign(assign *mutationsv1alpha1.Assign) (*AssignMutator, error) 
 
 	value, ok := toAssign["value"]
 	if !ok {
-		return nil, errors.New(fmt.Sprintf("spec.parameters.assign for Assign %s must have a value field", assign.GetName()))
+		return nil, fmt.Errorf("spec.parameters.assign for Assign %s must have a value field", assign.GetName())
 	}
 
 	err = validateObjectAssignedToList(path, value, assign.GetName())
@@ -292,7 +292,7 @@ func checkKeyNotChanged(p *parser.Path, assignName string) error {
 		return nil
 	}
 	if lastNode.Type() != parser.ObjectNode {
-		return errors.New(fmt.Sprintf("invalid path format in Assign %s: child of a list can't be a list", assignName))
+		return fmt.Errorf("invalid path format in Assign %s: child of a list can't be a list", assignName)
 	}
 	addedObject, ok := lastNode.(*parser.Object)
 	if !ok {
@@ -304,7 +304,7 @@ func checkKeyNotChanged(p *parser.Path, assignName string) error {
 	}
 
 	if addedObject.Reference == listNode.KeyField {
-		return errors.New(fmt.Sprintf("invalid path format in Assign %s: changing the item key is not allowed", assignName))
+		return fmt.Errorf("invalid path format in Assign %s: changing the item key is not allowed", assignName)
 	}
 	return nil
 }

--- a/pkg/mutation/mutators/testhelpers/dummy_mutator.go
+++ b/pkg/mutation/mutators/testhelpers/dummy_mutator.go
@@ -15,7 +15,7 @@ import (
 
 var _ types.Mutator = &DummyMutator{}
 
-// dummyMutator is a blank mutator that makes it easier to test the core mutation function
+// DummyMutator is a blank mutator that makes it easier to test the core mutation function
 type DummyMutator struct {
 	name  string
 	value interface{}

--- a/pkg/mutation/path/parser/node.go
+++ b/pkg/mutation/path/parser/node.go
@@ -18,8 +18,11 @@ package parser
 type NodeType string
 
 const (
-	PathNode   NodeType = "Path"
-	ListNode   NodeType = "List"
+	// PathNode is a string segment of a path.
+	PathNode NodeType = "Path"
+	// ListNode is an array element of a path.
+	ListNode NodeType = "List"
+	// ObjectNode is the final Node in a path, what is being referenced.
 	ObjectNode NodeType = "Object"
 )
 

--- a/pkg/mutation/path/token/token.go
+++ b/pkg/mutation/path/token/token.go
@@ -17,6 +17,7 @@ package token
 
 import "fmt"
 
+// The set of Token types.
 const (
 	ERROR     = "ERROR"
 	EOF       = "EOF"

--- a/pkg/mutation/schema/schema_test.go
+++ b/pkg/mutation/schema/schema_test.go
@@ -1,7 +1,6 @@
 package schema
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -1235,7 +1234,7 @@ func TestErrors(t *testing.T) {
 				t.Fatal("unexpected nil error")
 			}
 			if err.Error() != test.expectedErr {
-				t.Error(fmt.Sprintf("got %v, wanted %v", err.Error(), test.expectedErr))
+				t.Errorf("got %v, wanted %v", err.Error(), test.expectedErr)
 			}
 		})
 	}

--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -12,6 +12,7 @@ import (
 
 type Operation string
 
+// All defined Operations.
 const (
 	Audit          = Operation("audit")
 	Status         = Operation("status")
@@ -20,9 +21,9 @@ const (
 )
 
 var (
-	// allOperations is a list of all possible operations that can be assigned to
-	// a pod it is NOT intended to be mutated. It should be kept in alphabetical
-	// order so that it can be readily compared to the results from AssignedOperations
+	// allOperations is a list of all possible Operations that can be assigned to
+	// a pod. It is NOT intended to be mutated. It should be kept in alphabetical
+	// order so that it can be readily compared to the results from AssignedOperations.
 	allOperations = []Operation{
 		Audit,
 		Status,

--- a/pkg/readiness/object_tracker_test.go
+++ b/pkg/readiness/object_tracker_test.go
@@ -103,8 +103,8 @@ func Test_ObjectTracker_Terminated_Expect(t *testing.T) {
 	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
 }
 
-// Verify that that expectations can be cancelled.
-func Test_ObjectTracker_Cancelled_Expectations(t *testing.T) {
+// Verify that that expectations can be canceled.
+func Test_ObjectTracker_Canceled_Expectations(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ot := newObjTracker(schema.GroupVersionKind{}, nil)
 
@@ -212,7 +212,7 @@ func Test_ObjectTracker_CircuitBreaker(t *testing.T) {
 	// Peek at internals - we should not be accruing memory from the post-circuit-breaker operations
 	ot.mu.RLock()
 	defer ot.mu.RUnlock()
-	g.Expect(ot.cancelled).To(gomega.BeEmpty())
+	g.Expect(ot.canceled).To(gomega.BeEmpty())
 	g.Expect(ot.expect).To(gomega.BeEmpty())
 	g.Expect(ot.seen).To(gomega.BeEmpty())
 	g.Expect(ot.satisfied).To(gomega.BeEmpty())
@@ -274,7 +274,7 @@ func Test_ObjectTracker_TryCancelExpect_Default(t *testing.T) {
 	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
 }
 
-// Verify that TryCancelExpect must be called multiple times before an expectation is cancelled
+// Verify that TryCancelExpect must be called multiple times before an expectation is canceled
 func Test_ObjectTracker_TryCancelExpect_WithRetries(t *testing.T) {
 	g := gomega.NewWithT(t)
 	ot := newObjTracker(schema.GroupVersionKind{}, func() objData {

--- a/pkg/readiness/ready_tracker.go
+++ b/pkg/readiness/ready_tracker.go
@@ -219,7 +219,7 @@ func (t *Tracker) Satisfied(ctx context.Context) bool {
 }
 
 // Run runs the tracker and blocks until it completes.
-// The provided context can be cancelled to signal a shutdown request.
+// The provided context can be canceled to signal a shutdown request.
 func (t *Tracker) Run(ctx context.Context) error {
 	// Any failure in the errgroup will cancel goroutines in the group using gctx.
 	// The odd one out is the statsPrinter which is meant to outlive the tracking
@@ -638,7 +638,7 @@ func (t *Tracker) DisableStats(ctx context.Context) {
 }
 
 // statsPrinter handles verbose logging of the readiness tracker outstanding expectations on a regular cadence.
-// Runs until the provided context is cancelled.
+// Runs until the provided context is canceled.
 func (t *Tracker) statsPrinter(ctx context.Context) {
 	for {
 		select {

--- a/pkg/readiness/ready_tracker_unit_test.go
+++ b/pkg/readiness/ready_tracker_unit_test.go
@@ -97,7 +97,7 @@ func Test_ReadyTracker_TryCancelTemplate_No_Retries(t *testing.T) {
 	g.Expect(rt.Satisfied(ctx)).To(gomega.BeTrue(), "tracker with 0 retries and cancellation should be satisfied")
 }
 
-// Verify that TryCancelTemplate must be called enough times to remove all retries before cancelling a template
+// Verify that TryCancelTemplate must be called enough times to remove all retries before canceling a template
 func Test_ReadyTracker_TryCancelTemplate_Retries(t *testing.T) {
 	g := gomega.NewWithT(t)
 

--- a/pkg/syncutil/context.go
+++ b/pkg/syncutil/context.go
@@ -17,7 +17,7 @@ package syncutil
 
 import "context"
 
-// contextForChannel derives a child context from a parent channel.
+// ContextForChannel derives a child context from a parent channel.
 //
 // The derived context's Done channel is closed when the returned cancel function
 // is called or when the parent channel is closed, whichever happens first.

--- a/pkg/syncutil/single_runner.go
+++ b/pkg/syncutil/single_runner.go
@@ -24,7 +24,7 @@ import (
 
 // SingleRunner wraps an errgroup to run keyed goroutines as singletons.
 // Keys are single-use and subsequent usage to schedule will be silently ignored.
-// Goroutines can be individually cancelled provided they respect the context passed to them.
+// Goroutines can be individually canceled provided they respect the context passed to them.
 type SingleRunner struct {
 	m   map[string]context.CancelFunc
 	mu  sync.Mutex

--- a/pkg/syncutil/single_runner_test.go
+++ b/pkg/syncutil/single_runner_test.go
@@ -55,7 +55,7 @@ func Test_SingleRunner(t *testing.T) {
 
 	select {
 	case <-syncTwo:
-		t.Fatalf("two should not have been cancelled yet")
+		t.Fatalf("two should not have been canceled yet")
 	case <-time.After(10 * time.Millisecond):
 	}
 
@@ -65,7 +65,7 @@ func Test_SingleRunner(t *testing.T) {
 
 	select {
 	case <-syncOne:
-		t.Fatalf("one should not have been cancelled yet")
+		t.Fatalf("one should not have been canceled yet")
 	case <-time.After(10 * time.Millisecond):
 	}
 

--- a/pkg/util/enforcement_action.go
+++ b/pkg/util/enforcement_action.go
@@ -6,8 +6,10 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+// EnforcementAction is the response we take to violations.
 type EnforcementAction string
 
+// The set of possible responses to policy violations.
 const (
 	Deny         EnforcementAction = "deny"
 	Dryrun       EnforcementAction = "dryrun"
@@ -16,6 +18,8 @@ const (
 )
 
 var supportedEnforcementActions = []EnforcementAction{Deny, Dryrun, Warn}
+
+// KnownEnforcementActions are all defined EnforcementActions.
 var KnownEnforcementActions = []EnforcementAction{Deny, Dryrun, Warn, Unrecognized}
 
 func ValidateEnforcementAction(input EnforcementAction) error {

--- a/pkg/util/pod_info.go
+++ b/pkg/util/pod_info.go
@@ -2,7 +2,7 @@ package util
 
 import "os"
 
-// PodName returns the name of the Gatekeeper pod
+// GetPodName returns the name of the Gatekeeper pod
 func GetPodName() string {
 	return os.Getenv("POD_NAME")
 }

--- a/pkg/watch/manager_integration_test.go
+++ b/pkg/watch/manager_integration_test.go
@@ -508,7 +508,7 @@ func expectedSet(objs []*unstructured.Unstructured) map[string]bool {
 
 // waitForExpected waits for reconcile requests for the specified resources to be received in a particular namespace.
 // Returns nil if expectations are satisfied.
-// Returns error if the context is cancelled before expectations are satisfied.
+// Returns error if the context is canceled before expectations are satisfied.
 func waitForExpected(ctx context.Context, objs []*unstructured.Unstructured, c <-chan reconcile.Request, namespace string) error {
 	expected := expectedSet(objs)
 	for len(expected) > 0 {

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -447,7 +447,7 @@ func TestRegistrar_Replay_Retry(t *testing.T) {
 	}
 }
 
-// Verifies that replay happens asynchronously, can be cancelled.
+// Verifies that replay happens asynchronously, can be canceled.
 func TestRegistrar_Replay_Async(t *testing.T) {
 	listCalled := make(chan struct{})
 	listDone := make(chan struct{})
@@ -455,7 +455,7 @@ func TestRegistrar_Replay_Async(t *testing.T) {
 		ListFunc: func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 			listCalled <- struct{}{}
 
-			// Block until we're cancelled.
+			// Block until we're canceled.
 			<-ctx.Done()
 			listDone <- struct{}{}
 			return nil
@@ -518,10 +518,10 @@ func TestRegistrar_Replay_Async(t *testing.T) {
 	case <-listDone:
 	// Good.
 	case <-time.After(50 * time.Millisecond):
-		t.Fatalf("replay was not cancelled")
+		t.Fatalf("replay was not canceled")
 	}
 
-	// [Scenario 2] - Verify that pending replays are cancelled during watch manager shutdown.
+	// [Scenario 2] - Verify that pending replays are canceled during watch manager shutdown.
 	if err := r2.AddWatch(gvk); err != nil {
 		t.Errorf("adding watch: %v", err)
 	}
@@ -538,7 +538,7 @@ func TestRegistrar_Replay_Async(t *testing.T) {
 	case <-listDone:
 	// Good.
 	case <-time.After(50 * time.Millisecond):
-		t.Fatalf("replay was not cancelled")
+		t.Fatalf("replay was not canceled")
 	}
 
 	_ = grp.Wait()

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -37,7 +37,9 @@ const (
 var log = logf.Log.WithName("webhook")
 
 var (
+	// VwhName is the metadata.name of the Gatekeeper ValidatingWebhookConfiguration.
 	VwhName = "gatekeeper-validating-webhook-configuration"
+	// MwhName is the metadata.name of the Gatekeeper MutatingWebhookConfiguration.
 	MwhName = "gatekeeper-mutating-webhook-configuration"
 )
 

--- a/test/clients/retry_client.go
+++ b/test/clients/retry_client.go
@@ -47,7 +47,7 @@ func NewRetryClient(c client.Client) *RetryClient {
 }
 
 // retry will run the provided function, retrying if it fails due to rate limiting.
-// If context is cancelled, it will return early.
+// If context is canceled, it will return early.
 func retry(ctx context.Context, limiter *rate.Limiter, f func() error) error {
 	for {
 		if err := ctx.Err(); err != nil {

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache_test.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache_test.go
@@ -277,11 +277,11 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(err).To(HaveOccurred())
 				})
 
-				It("should return an error when context is cancelled", func() {
-					By("cancelling the context")
+				It("should return an error when context is canceled", func() {
+					By("canceling the context")
 					informerCacheCancel()
 
-					By("listing pods in test-namespace-1 with a cancelled context")
+					By("listing pods in test-namespace-1 with a canceled context")
 					listObj := &kcorev1.PodList{}
 					err := informerCache.List(informerCacheCtx, listObj, client.InNamespace(testNamespaceOne))
 
@@ -825,11 +825,11 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(actual.Name).To(Equal("test-pod-3"))
 				})
 
-				It("should allow for get informer to be cancelled", func() {
-					By("creating a context and cancelling it")
+				It("should allow for get informer to be canceled", func() {
+					By("creating a context and canceling it")
 					informerCacheCancel()
 
-					By("getting a shared index informer for a pod with a cancelled context")
+					By("getting a shared index informer for a pod with a canceled context")
 					pod := &kcorev1.Pod{
 						ObjectMeta: kmetav1.ObjectMeta{
 							Name:      "informer-obj",
@@ -850,11 +850,11 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(errors.IsTimeout(err)).To(BeTrue())
 				})
 
-				It("should allow getting an informer by group/version/kind to be cancelled", func() {
-					By("creating a context and cancelling it")
+				It("should allow getting an informer by group/version/kind to be canceled", func() {
+					By("creating a context and canceling it")
 					informerCacheCancel()
 
-					By("getting an shared index informer for gvk = core/v1/pod with a cancelled context")
+					By("getting an shared index informer for gvk = core/v1/pod with a canceled context")
 					gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 					sii, err := informerCache.GetInformerForKind(informerCacheCtx, gvk)
 					Expect(err).To(HaveOccurred())
@@ -958,11 +958,11 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(actual.GetName()).To(Equal("test-pod-3"))
 				}, 3)
 
-				It("should allow for get informer to be cancelled", func() {
-					By("cancelling the context")
+				It("should allow for get informer to be canceled", func() {
+					By("canceling the context")
 					informerCacheCancel()
 
-					By("getting a shared index informer for a pod with a cancelled context")
+					By("getting a shared index informer for a pod with a canceled context")
 					pod := &unstructured.Unstructured{}
 					pod.SetName("informer-obj2")
 					pod.SetNamespace("default")
@@ -1077,12 +1077,12 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(actual.GetName()).To(Equal("test-pod-3"))
 				}, 3)
 
-				It("should allow for get informer to be cancelled", func() {
-					By("creating a context and cancelling it")
+				It("should allow for get informer to be canceled", func() {
+					By("creating a context and canceling it")
 					ctx, cancel := context.WithCancel(context.Background())
 					cancel()
 
-					By("getting a shared index informer for a pod with a cancelled context")
+					By("getting a shared index informer for a pod with a canceled context")
 					pod := &kmetav1.PartialObjectMetadata{}
 					pod.SetName("informer-obj2")
 					pod.SetNamespace("default")

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/informer_cache.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/informer_cache.go
@@ -171,7 +171,7 @@ func (ip *dynamicInformerCache) GetInformerNonBlocking(obj client.Object) (cache
 		return nil, err
 	}
 
-	// Use a cancelled context to signal non-blocking
+	// Use a canceled context to signal non-blocking
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Per [the golint repository](https://github.com/golang/lint), the golint linter is no longer maintained.
The recommended golangci-lint replacement is revive, so this PR switches
us to use the new linter. This commit also includes all necessary
changes to make the new linter pass.

In configuring this I noticed the that our .golangci.yaml had a typo
which caused our `misspell` and `lll` configurations to be silently
discarded - I've corrected "linter" to "linters" and resolved the
spelling mistakes it found.

Note: when running locally, you may need to upgrade to golangci-lint
1.40.1 as some previous versions did not properly configure gosec.

Signed-off-by: Will Beason <willbeason@google.com>