### PR TITLE
[mutation] validate parent and children Conditions

### DIFF
--- a/pkg/controller/assign/assign_controller.go
+++ b/pkg/controller/assign/assign_controller.go
@@ -169,12 +169,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	deleted = deleted || !assign.GetDeletionTimestamp().IsZero()
 	tracker := r.tracker.For(gvkAssign)
 
-	mID, err := types.MakeID(assign)
-	if err != nil {
-		tracker.TryCancelExpect(assign)
-		log.Error(err, "Failed to get id out of assign")
-		return reconcile.Result{}, err
-	}
+	mID := types.MakeID(assign)
 
 	if deleted {
 		tracker.CancelExpect(assign)

--- a/pkg/controller/assignmetadata/assignmetadata_controller.go
+++ b/pkg/controller/assignmetadata/assignmetadata_controller.go
@@ -171,12 +171,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	deleted = deleted || !assignMetadata.GetDeletionTimestamp().IsZero()
 	tracker := r.tracker.For(gvkAssignMetadata)
 
-	mID, err := types.MakeID(assignMetadata)
-	if err != nil {
-		tracker.TryCancelExpect(assignMetadata)
-		log.Error(err, "Failed to get id out of assign")
-		return reconcile.Result{}, err
-	}
+	mID := types.MakeID(assignMetadata)
 
 	if deleted {
 		tracker.CancelExpect(assignMetadata)

--- a/pkg/mutation/mutators/assignmeta_mutator.go
+++ b/pkg/mutation/mutators/assignmeta_mutator.go
@@ -43,7 +43,7 @@ var (
 type AssignMetadataMutator struct {
 	id             types.ID
 	assignMetadata *mutationsv1alpha1.AssignMetadata
-	path           *parser.Path
+	path           parser.Path
 }
 
 // assignMetadataMutator implements mutator
@@ -59,7 +59,7 @@ func (m *AssignMetadataMutator) Matches(obj runtime.Object, ns *corev1.Namespace
 }
 
 func (m *AssignMetadataMutator) Mutate(obj *unstructured.Unstructured) (bool, error) {
-	t, err := tester.New([]tester.Test{
+	t, err := tester.New(m.Path(), []tester.Test{
 		{SubPath: m.Path(), Condition: tester.MustNotExist},
 	})
 	if err != nil {
@@ -71,7 +71,7 @@ func (m *AssignMetadataMutator) ID() types.ID {
 	return m.id
 }
 
-func (m *AssignMetadataMutator) Path() *parser.Path {
+func (m *AssignMetadataMutator) Path() parser.Path {
 	return m.path
 }
 
@@ -93,11 +93,10 @@ func (m *AssignMetadataMutator) HasDiff(mutator types.Mutator) bool {
 }
 
 func (m *AssignMetadataMutator) DeepCopy() types.Mutator {
-	p := m.path.DeepCopy()
 	res := &AssignMetadataMutator{
 		id:             m.id,
 		assignMetadata: m.assignMetadata.DeepCopy(),
-		path:           &p,
+		path:           m.path.DeepCopy(),
 	}
 	return res
 }
@@ -141,20 +140,16 @@ func MutatorForAssignMetadata(assignMeta *mutationsv1alpha1.AssignMetadata) (*As
 	if _, ok := value.(string); !ok {
 		return nil, errors.New("spec.parameters.assign.value field must be a string for AssignMetadata " + assignMeta.GetName())
 	}
-	id, err := types.MakeID(assignMeta)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to retrieve id for assignMetadata type")
-	}
 
 	return &AssignMetadataMutator{
-		id:             id,
+		id:             types.MakeID(assignMeta),
 		assignMetadata: assignMeta.DeepCopy(),
 		path:           path,
 	}, nil
 }
 
 // Verifies that the given path is valid for metadata
-func isValidMetadataPath(path *parser.Path) bool {
+func isValidMetadataPath(path parser.Path) bool {
 	// Path must be metadata.annotations.something or metadata.labels.something
 	if len(path.Nodes) != 3 ||
 		path.Nodes[0].Type() != parser.ObjectNode ||

--- a/pkg/mutation/mutators/conversion_test.go
+++ b/pkg/mutation/mutators/conversion_test.go
@@ -84,7 +84,7 @@ func TestAssignMetadataToMutator(t *testing.T) {
 		t.Fatalf("MutatorForAssignMetadata for failed, %v", err)
 	}
 	path := mutator.Path()
-	if path == nil {
+	if len(path.Nodes) == 0 {
 		t.Fatalf("Got empty path")
 	}
 }

--- a/pkg/mutation/mutators/testhelpers/dummy_mutator.go
+++ b/pkg/mutation/mutators/testhelpers/dummy_mutator.go
@@ -19,7 +19,7 @@ var _ types.Mutator = &DummyMutator{}
 type DummyMutator struct {
 	name  string
 	value interface{}
-	path  *parser.Path
+	path  parser.Path
 	match match.Match
 }
 
@@ -39,7 +39,7 @@ func (d *DummyMutator) Value() (interface{}, error) {
 	return d.value, nil
 }
 
-func (d *DummyMutator) Path() *parser.Path {
+func (d *DummyMutator) Path() parser.Path {
 	return d.path
 }
 
@@ -52,7 +52,7 @@ func (d *DummyMutator) Matches(obj runtime.Object, ns *corev1.Namespace) bool {
 }
 
 func (d *DummyMutator) Mutate(obj *unstructured.Unstructured) (bool, error) {
-	t, _ := path.New(nil)
+	t, _ := path.New(parser.Path{}, nil)
 	return core.Mutate(d, t, func(_ interface{}, _ bool) bool { return true }, obj)
 }
 

--- a/pkg/mutation/path/parser/node.go
+++ b/pkg/mutation/path/parser/node.go
@@ -70,7 +70,7 @@ func (r Path) String() string {
 	result := strings.Builder{}
 	for i, n := range r.Nodes {
 		nStr := n.String()
-		if _, isObject := n.(*Object); i > 0 && isObject {
+		if n.Type() == ObjectNode && i > 0 {
 			// No leading separator, and no separators before List Nodes.
 			result.WriteString(".")
 		}

--- a/pkg/mutation/path/parser/parser.go
+++ b/pkg/mutation/path/parser/parser.go
@@ -37,7 +37,7 @@ type parser struct {
 }
 
 // Parse parses the provided input and returns an abstract representation if successful.
-func Parse(input string) (*Path, error) {
+func Parse(input string) (Path, error) {
 	p := newParser(input)
 	return p.Parse()
 }
@@ -76,8 +76,8 @@ func (p *parser) expectPeek(t token.Type) bool {
 	return p.peekToken.Type == t
 }
 
-func (p *parser) Parse() (*Path, error) {
-	root := &Path{}
+func (p *parser) Parse() (Path, error) {
+	root := Path{}
 	for p.curToken.Type == token.IDENT && p.err == nil {
 		if node := p.parseObject(); node != nil {
 			root.Nodes = append(root.Nodes, node)
@@ -97,7 +97,7 @@ func (p *parser) Parse() (*Path, error) {
 			if p.expectPeek(token.EOF) {
 				// block trailing separators
 				p.setError(ErrTrailingSeparator)
-				return nil, p.err
+				return Path{}, p.err
 			}
 			// Skip past the separator
 			p.next()
@@ -105,7 +105,7 @@ func (p *parser) Parse() (*Path, error) {
 			// Allowed. Loop will exit.
 		default:
 			p.setError(fmt.Errorf("%w: expected '.' or eof, got: %s", ErrUnexpectedToken, p.peekToken.String()))
-			return nil, p.err
+			return Path{}, p.err
 		}
 	}
 
@@ -113,7 +113,7 @@ func (p *parser) Parse() (*Path, error) {
 		p.setError(fmt.Errorf("%w: expected field name or eof, got: %s", ErrUnexpectedToken, p.curToken.String()))
 	}
 	if p.err != nil {
-		return nil, p.err
+		return Path{}, p.err
 	}
 
 	return root, nil

--- a/pkg/mutation/path/parser/parser_test.go
+++ b/pkg/mutation/path/parser/parser_test.go
@@ -287,7 +287,7 @@ func TestParser(t *testing.T) {
 				t.Fatalf("for input: %s\ngot error: %v, want: %v", tc.input, err, tc.wantErr)
 			}
 			var nodes []Node
-			if root != nil {
+			if len(root.Nodes) != 0 {
 				nodes = root.Nodes
 			}
 			diff := cmp.Diff(tc.expected, nodes)
@@ -297,7 +297,7 @@ func TestParser(t *testing.T) {
 
 			// Ensure that converting a parsed Path into a String and back again
 			// produces an identical Path.
-			if root != nil && tc.wantErr == nil {
+			if len(root.Nodes) != 0 && tc.wantErr == nil {
 				asString := root.String()
 
 				reparsedRoot, err := Parse(asString)

--- a/pkg/mutation/schema/schema_test.go
+++ b/pkg/mutation/schema/schema_test.go
@@ -21,7 +21,7 @@ type mockMutator struct {
 	ForceDiff bool
 	Bindings  []Binding
 	path      string
-	pathCache *parser.Path
+	pathCache parser.Path
 }
 
 func (m *mockMutator) Matches(obj runtime.Object, ns *corev1.Namespace) bool { return false }
@@ -44,7 +44,7 @@ func (m *mockMutator) String() string {
 }
 
 func deepCopyBindings(bindings []Binding) []Binding {
-	cpy := []Binding{}
+	var cpy []Binding
 	for _, b := range bindings {
 		cpy = append(cpy, Binding{
 			Groups:   append([]string{}, b.Groups...),
@@ -70,8 +70,8 @@ func (m *mockMutator) DeepCopy() types.Mutator {
 
 func (m *mockMutator) SchemaBindings() []Binding { return m.Bindings }
 
-func (m *mockMutator) Path() *parser.Path {
-	if m.pathCache != nil {
+func (m *mockMutator) Path() parser.Path {
+	if len(m.pathCache.Nodes) > 0 {
 		return m.pathCache
 	}
 	out, err := parser.Parse(m.path)

--- a/pkg/mutation/system_test.go
+++ b/pkg/mutation/system_test.go
@@ -59,8 +59,8 @@ func (m *MockMutator) ID() types.ID {
 	return m.Mocked
 }
 
-func (m *MockMutator) Path() *parser.Path {
-	return nil
+func (m *MockMutator) Path() parser.Path {
+	return parser.Path{}
 }
 
 func (m *MockMutator) Value() (interface{}, error) {

--- a/pkg/mutation/types/mutator.go
+++ b/pkg/mutation/types/mutator.go
@@ -6,9 +6,9 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ID represent the identifier of a mutation object.
@@ -33,22 +33,18 @@ type Mutator interface {
 	// DeepCopy returns a copy of the current object
 	DeepCopy() Mutator
 	Value() (interface{}, error)
-	Path() *parser.Path
+	Path() parser.Path
 	String() string
 }
 
 // MakeID builds an ID object for the given object
-func MakeID(obj runtime.Object) (ID, error) {
-	meta, err := meta.Accessor(obj)
-	if err != nil {
-		return ID{}, errors.Wrapf(err, "Failed to get accessor for %s %s", obj.GetObjectKind().GroupVersionKind().Group, obj.GetObjectKind().GroupVersionKind().Kind)
-	}
+func MakeID(obj client.Object) ID {
 	return ID{
 		Group:     obj.GetObjectKind().GroupVersionKind().Group,
 		Kind:      obj.GetObjectKind().GroupVersionKind().Kind,
-		Name:      meta.GetName(),
-		Namespace: meta.GetNamespace(),
-	}, nil
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
+	}
 }
 
 // UnmarshalValue unmarshals the value a mutation is meant to assign

--- a/pkg/mutation/types/mutator_test.go
+++ b/pkg/mutation/types/mutator_test.go
@@ -27,11 +27,7 @@ func TestMakeID(t *testing.T) {
 	}
 	config.APIVersion, config.Kind = gvk.ToAPIVersionAndKind()
 
-	ID, err := types.MakeID(config)
-
-	if err != nil {
-		t.Errorf("MakeID failed %v", err)
-	}
+	ID := types.MakeID(config)
 
 	expectedID := types.ID{
 		Group:     "groupname",

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -167,8 +167,7 @@ func Test_AssignMetadata(t *testing.T) {
 
 	// Verify that the AssignMetadata is present in the cache
 	for _, am := range testAssignMetadata {
-		id, err := mutationtypes.MakeID(am)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "can not create AssignMetadata id")
+		id := mutationtypes.MakeID(am)
 		exptectedMutator := mutationCache.Get(id)
 		g.Expect(exptectedMutator).NotTo(gomega.BeNil(), "expected mutator was not found")
 	}
@@ -215,8 +214,7 @@ func Test_Assign(t *testing.T) {
 
 	// Verify that the Assign is present in the cache
 	for _, am := range testAssign {
-		id, err := mutationtypes.MakeID(am)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "can not create Assign id")
+		id := mutationtypes.MakeID(am)
 		exptectedMutator := mutationCache.Get(id)
 		g.Expect(exptectedMutator).NotTo(gomega.BeNil(), "expected mutator was not found")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
*Forbid creating mutations which require specific paths but forbid their parents.* For example, requiring `spec.foo` does not exist but also requiring that `spec.foo.bar` must exist.

*Improve error handling and validation in pkg/mutations/path.* Use new Go 1.13-style base and wrapped errors, which allows us to directly check for specific errors in tests using `errors.Is`. In the future, we may also use errors.Is for control flow as we can handle errors safely while still annotating them as needed.

*Make mutation path error messages more explicit.* Define `Node.String()` for printing out specific paths in error messages, helping users debug offending path tests. Additionally, test that `Parse(node.String())` yields an equivalent structure.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1289