### PR TITLE
Fix manager image patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ bin
 *.out
 
 # Manager image patch file
-config/overlays/dev/manager_image_patch.yaml
-config/overlays/dev_mutation/manager_image_patch.yaml
+config/overlays/dev/image_patch*
+config/overlays/dev_mutation/image_patch*
 
 # Kubernetes Generated files - skip generated files, except for vendored files
 

--- a/config/overlays/dev/kustomization.yaml
+++ b/config/overlays/dev/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ../../default
 
 patchesStrategicMerge:
-- manager_image_patch.yaml
+- image_patch_audit_manager.yaml
+- image_patch_controller_manager.yaml

--- a/config/overlays/dev_mutation/kustomization.yaml
+++ b/config/overlays/dev_mutation/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
   - ../mutation_webhook
 
 patchesStrategicMerge:
-- manager_image_patch.yaml
+- image_patch_audit_manager.yaml
+- image_patch_controller_manager.yaml

--- a/hack/image_patch_audit_manager.yaml
+++ b/hack/image_patch_audit_manager.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audit
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - image: <your image file>
+        name: manager
+        args:
+        - --port=8443
+        - --logtostderr
+        - --emit-admission-events
+        - --exempt-namespace=gatekeeper-system
+        - --operation=webhook
+        - --disable-opa-builtin=http.send

--- a/hack/image_patch_controller_manager.yaml
+++ b/hack/image_patch_controller_manager.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - image: <your image file>
+        name: manager
+        args:
+        - --emit-audit-events
+        - --operation=audit
+        - --operation=status
+        - --logtostderr


### PR DESCRIPTION
The MANAGER_IMAGE_PATCH used to substitute a test image in the
gatekeeper.yaml was broken.  Only the first of the two patches was
applied, leaving one of the deployments un-patched.

This is likely related to a change in kustomize (my machine is running
v4.1.2).  Figuring out which version broke this change is less important
than fixing the problem, so I've gone ahead and done that.

Signed-off-by: juliankatz <juliankatz@google.com>