### PR TITLE
Lint code using dockerized golangci-lint

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -33,25 +33,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
-
-      - name: Install golangci-lint
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/bin
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $GITHUB_WORKSPACE/bin v${GOLANGCILINT_VERSION}
-        env:
-          GOLANGCILINT_VERSION: 1.40.1
-
-      - name: Make lint
-        run: |
-          make lint
+    - uses: actions/checkout@v2
+      # source: https://github.com/golangci/golangci-lint-action
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with:
+        # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+        version: v1.40.1
 
   test:
     name: "Unit test"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Staging dirs
+# Staging and temporary dirs
 .staging/
+/.tmp
 
 # Binaries for programs and plugins
 *.exe

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,6 @@
+run:
+  timeout: 5m
+
 linters-settings:
   gosec:
     excludes:


### PR DESCRIPTION
This means we don't need to manually install golangci-lint every time we
run our git workflow - we just use a generally-available one that
already has it installed.

It also means that "make lint" will work the same for everyone and the
workflow without additional coordination. Before this PR, it was
possible for maintainers to be on a different version of golangci-lint
than the one used by the GitHub workflow and so "make lint" would
provide inconsistent results.