### PR TITLE
Add kind 1.22 Github Workflow

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -118,6 +118,48 @@ jobs:
           path: |
             logs-*.json
 
+  # This action is separate because it loads a k8s 1.22 from a separate source.  This isn't the
+  # pattern we want going forward, so keeping this separate makes it easy to delete in the future.
+  build_test_122:
+    name: "Build and Test - k8s 1.22"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Bootstrap e2e
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/bin
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+          make e2e-bootstrap KUBERNETES_VERSION="1.21.1" KIND_NODE_VERSION="openpolicyagent/kind-node-image:v1.22.0-alpha.2"
+
+      - name: Run e2e
+        run: |
+          make e2e-build-load-image IMG=gatekeeper-e2e:latest
+          make deploy IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
+          # there should be no additional manifest changes
+          git diff --exit-code
+          make test-e2e
+
+      - name: Save logs
+        run: |
+          kubectl logs -n gatekeeper-system -l control-plane=controller-manager --tail=-1 > logs-controller.json
+          kubectl logs -n gatekeeper-system -l control-plane=audit-controller --tail=-1 > logs-audit.json
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: logs
+          path: |
+            logs-*.json
+
   helm_build_test:
     name: "[Helm] Build and Test"
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ test:
 test-e2e:
 	bats -t ${BATS_TESTS_FILE}
 
+KIND_NODE_VERSION := kindest/node:v$(KUBERNETES_VERSION)
 e2e-bootstrap:
 	# Download and install kind
 	curl -L https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-amd64 --output ${GITHUB_WORKSPACE}/bin/kind && chmod +x ${GITHUB_WORKSPACE}/bin/kind
@@ -112,7 +113,7 @@ e2e-bootstrap:
 	# Check for existing kind cluster
 	if [ $$(${GITHUB_WORKSPACE}/bin/kind get clusters) ]; then ${GITHUB_WORKSPACE}/bin/kind delete cluster; fi
 	# Create a new kind cluster
-	TERM=dumb ${GITHUB_WORKSPACE}/bin/kind create cluster --image kindest/node:v${KUBERNETES_VERSION} --wait 5m
+	TERM=dumb ${GITHUB_WORKSPACE}/bin/kind create cluster --image $(KIND_NODE_VERSION) --wait 5m
 
 e2e-build-load-image: docker-buildx
 	kind load docker-image --name kind ${IMG}


### PR DESCRIPTION
This PR adds a separate github workflow for testing k8s 1.22 via a
custom-built k8s 1.22 node image.  1.22 isn't currently available under
kindest/node on docker hub, as 1.22 hasn't been officially released.

sozercan built and pushed this image from the k8s GitHub repo.  Once k8s
1.22 is available via the typical kindest/node pathway, the changes in
this PR should be removed.

Signed-off-by: juliankatz <juliankatz@google.com>

