### PR TITLE
Use MaxInt32 instead of MaxInt64

### DIFF
--- a/pkg/mutation/path/tester/tester.go
+++ b/pkg/mutation/path/tester/tester.go
@@ -86,7 +86,7 @@ func New(location parser.Path, tests []Test) (*Tester, error) {
 	}
 
 	// Read in all tests before checking for conflicts.
-	idxLowestMustNot := math.MaxInt64
+	idxLowestMustNot := math.MaxInt32
 	idxHighestMust := 0
 	for _, test := range tests {
 		i := len(test.SubPath.Nodes) - 1


### PR DESCRIPTION
MaxInt64 breaks on 32-bit systems unless explicitly typecast to an
int64.

In this case, we do not expect users will ever need to reference nodes
more than 2 billion layers deep with gatekeeper. Thus, it feels safe to
make this assumption and use MaxInt32 as the starting value for the
minimum. We will encounter other problems long before this gives us
problems.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: