### PR TITLE
Preserve conflicting schemas and report conflicts

### DIFF
--- a/pkg/mutation/match/match_test.go
+++ b/pkg/mutation/match/match_test.go
@@ -23,6 +23,48 @@ func TestMatch(t *testing.T) {
 		shouldMatch bool
 	}{
 		{
+			tname:   "match empty group kinds",
+			toMatch: makeObject("kind", "group", "namespace", "name"),
+			match: Match{
+				Kinds: []Kinds{
+					{
+						Kinds:     []string{},
+						APIGroups: []string{},
+					},
+				},
+			},
+			namespace:   &corev1.Namespace{},
+			shouldMatch: true,
+		},
+		{
+			tname:   "match empty kinds",
+			toMatch: makeObject("kind", "group", "namespace", "name"),
+			match: Match{
+				Kinds: []Kinds{
+					{
+						Kinds:     []string{},
+						APIGroups: []string{"*"},
+					},
+				},
+			},
+			namespace:   &corev1.Namespace{},
+			shouldMatch: true,
+		},
+		{
+			tname:   "don't match empty kinds in other group",
+			toMatch: makeObject("kind", "group", "namespace", "name"),
+			match: Match{
+				Kinds: []Kinds{
+					{
+						Kinds:     []string{},
+						APIGroups: []string{"rbac"},
+					},
+				},
+			},
+			namespace:   &corev1.Namespace{},
+			shouldMatch: false,
+		},
+		{
 			tname:   "match kind with *",
 			toMatch: makeObject("kind", "group", "namespace", "name"),
 			match: Match{

--- a/pkg/mutation/mutators/assign_mutator.go
+++ b/pkg/mutation/mutators/assign_mutator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 
 	"github.com/google/go-cmp/cmp"
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
@@ -17,7 +18,8 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
+	runtimeschema "k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -28,10 +30,12 @@ var (
 // AssignMutator is a mutator object built out of a
 // Assign instance.
 type AssignMutator struct {
-	id        types.ID
-	assign    *mutationsv1alpha1.Assign
-	path      parser.Path
-	bindings  []schema.Binding
+	id     types.ID
+	assign *mutationsv1alpha1.Assign
+	path   parser.Path
+
+	// bindings are the set of GVKs this Mutator applies to.
+	bindings  []runtimeschema.GroupVersionKind
 	tester    *patht.Tester
 	valueTest *mutationsv1alpha1.AssignIf
 }
@@ -39,7 +43,7 @@ type AssignMutator struct {
 // AssignMutator implements mutatorWithSchema
 var _ schema.MutatorWithSchema = &AssignMutator{}
 
-func (m *AssignMutator) Matches(obj runtime.Object, ns *corev1.Namespace) bool {
+func (m *AssignMutator) Matches(obj client.Object, ns *corev1.Namespace) bool {
 	if !match.AppliesTo(m.assign.Spec.ApplyTo, obj) {
 		return false
 	}
@@ -91,7 +95,7 @@ func (m *AssignMutator) ID() types.ID {
 	return m.id
 }
 
-func (m *AssignMutator) SchemaBindings() []schema.Binding {
+func (m *AssignMutator) SchemaBindings() []runtimeschema.GroupVersionKind {
 	return m.bindings
 }
 
@@ -134,10 +138,11 @@ func (m *AssignMutator) DeepCopy() types.Mutator {
 		path: parser.Path{
 			Nodes: make([]parser.Node, len(m.path.Nodes)),
 		},
-		bindings: make([]schema.Binding, len(m.bindings)),
+		bindings: make([]runtimeschema.GroupVersionKind, len(m.bindings)),
 	}
 	copy(res.path.Nodes, m.path.Nodes)
 	copy(res.bindings, m.bindings)
+	fmt.Println(len(res.bindings))
 	res.tester = m.tester.DeepCopy()
 	res.valueTest = m.valueTest.DeepCopy()
 	return res
@@ -194,20 +199,21 @@ func MutatorForAssign(assign *mutationsv1alpha1.Assign) (*AssignMutator, error) 
 	if err != nil {
 		return nil, err
 	}
-	applyTos := applyToToBindings(assign.Spec.ApplyTo)
-	if len(applyTos) == 0 {
-		return nil, fmt.Errorf("applyTo required for Assign mutator %s", assign.GetName())
-	}
-	for _, applyTo := range applyTos {
+	for _, applyTo := range assign.Spec.ApplyTo {
 		if len(applyTo.Groups) == 0 || len(applyTo.Versions) == 0 || len(applyTo.Kinds) == 0 {
 			return nil, fmt.Errorf("invalid applyTo for Assign mutator %s, all of group, version and kind must be specified", assign.GetName())
 		}
 	}
 
+	gvks := getSortedGVKs(assign.Spec.ApplyTo)
+	if len(gvks) == 0 {
+		return nil, fmt.Errorf("applyTo required for Assign mutator %s", assign.GetName())
+	}
+
 	return &AssignMutator{
 		id:        id,
 		assign:    assign.DeepCopy(),
-		bindings:  applyTos,
+		bindings:  gvks,
 		path:      path,
 		tester:    tester,
 		valueTest: &valueTests,
@@ -225,28 +231,6 @@ func gatherPathTests(assign *mutationsv1alpha1.Assign) ([]patht.Test, error) {
 		pathTests = append(pathTests, patht.Test{SubPath: p, Condition: pt.Condition})
 	}
 	return pathTests, nil
-}
-
-func applyToToBindings(applyTos []match.ApplyTo) []schema.Binding {
-	res := []schema.Binding{}
-	for _, applyTo := range applyTos {
-		binding := schema.Binding{
-			Groups:   make([]string, len(applyTo.Groups)),
-			Kinds:    make([]string, len(applyTo.Kinds)),
-			Versions: make([]string, len(applyTo.Versions)),
-		}
-		for i, g := range applyTo.Groups {
-			binding.Groups[i] = g
-		}
-		for i, k := range applyTo.Kinds {
-			binding.Kinds[i] = k
-		}
-		for i, v := range applyTo.Versions {
-			binding.Versions[i] = v
-		}
-		res = append(res, binding)
-	}
-	return res
 }
 
 // IsValidAssign returns an error if the given assign object is not
@@ -328,4 +312,25 @@ func validateObjectAssignedToList(p parser.Path, value interface{}, assignName s
 	}
 
 	return nil
+}
+
+func getSortedGVKs(bindings []match.ApplyTo) []runtimeschema.GroupVersionKind {
+	// deduplicate GVKs
+	gvksMap := map[runtimeschema.GroupVersionKind]struct{}{}
+	for _, binding := range bindings {
+		for _, gvk := range binding.Flatten() {
+			gvksMap[gvk] = struct{}{}
+		}
+	}
+
+	var gvks []runtimeschema.GroupVersionKind
+	for gvk := range gvksMap {
+		gvks = append(gvks, gvk)
+	}
+
+	// we iterate over the map in a stable order so that
+	// unit tests won't be flaky.
+	sort.Slice(gvks, func(i, j int) bool { return gvks[i].String() < gvks[j].String() })
+
+	return gvks
 }

--- a/pkg/mutation/mutators/assignmeta_mutator.go
+++ b/pkg/mutation/mutators/assignmeta_mutator.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -49,7 +49,7 @@ type AssignMetadataMutator struct {
 // assignMetadataMutator implements mutator
 var _ types.Mutator = &AssignMetadataMutator{}
 
-func (m *AssignMetadataMutator) Matches(obj runtime.Object, ns *corev1.Namespace) bool {
+func (m *AssignMetadataMutator) Matches(obj client.Object, ns *corev1.Namespace) bool {
 	matches, err := match.Matches(&m.assignMetadata.Spec.Match, obj, ns)
 	if err != nil {
 		log.Error(err, "AssignMetadataMutator.Matches failed", "assignMeta", m.assignMetadata.Name)

--- a/pkg/mutation/mutators/conversion_test.go
+++ b/pkg/mutation/mutators/conversion_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/match"
-	mschema "github.com/open-policy-agent/gatekeeper/pkg/mutation/schema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,21 +45,23 @@ func TestAssignToMutator(t *testing.T) {
 	}
 
 	bindings := mutatorWithSchema.SchemaBindings()
-	expectedBindings := []mschema.Binding{
-		{
-			Groups:   []string{"group1", "group2"},
-			Kinds:    []string{"kind1", "kind2", "kind3"},
-			Versions: []string{"version1"},
-		},
-		{
-			Groups:   []string{"group3", "group4"},
-			Kinds:    []string{"kind4", "kind2", "kind3"},
-			Versions: []string{"version1"},
-		},
+	expectedBindings := []schema.GroupVersionKind{
+		{Group: "group1", Version: "version1", Kind: "kind1"},
+		{Group: "group1", Version: "version1", Kind: "kind2"},
+		{Group: "group1", Version: "version1", Kind: "kind3"},
+		{Group: "group2", Version: "version1", Kind: "kind1"},
+		{Group: "group2", Version: "version1", Kind: "kind2"},
+		{Group: "group2", Version: "version1", Kind: "kind3"},
+		{Group: "group3", Version: "version1", Kind: "kind2"},
+		{Group: "group3", Version: "version1", Kind: "kind3"},
+		{Group: "group3", Version: "version1", Kind: "kind4"},
+		{Group: "group4", Version: "version1", Kind: "kind2"},
+		{Group: "group4", Version: "version1", Kind: "kind3"},
+		{Group: "group4", Version: "version1", Kind: "kind4"},
 	}
 
-	if !cmp.Equal(bindings, expectedBindings) {
-		t.Errorf("Bindings are not as expected: %s", cmp.Diff(bindings, expectedBindings))
+	if diff := cmp.Diff(expectedBindings, bindings); diff != "" {
+		t.Errorf("Bindings are not as expected: %s", diff)
 	}
 }
 

--- a/pkg/mutation/mutators/testhelpers/dummy_mutator.go
+++ b/pkg/mutation/mutators/testhelpers/dummy_mutator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ types.Mutator = &DummyMutator{}
@@ -43,7 +43,7 @@ func (d *DummyMutator) Path() parser.Path {
 	return d.path
 }
 
-func (d *DummyMutator) Matches(obj runtime.Object, ns *corev1.Namespace) bool {
+func (d *DummyMutator) Matches(obj client.Object, ns *corev1.Namespace) bool {
 	matches, err := match.Matches(&d.match, obj, ns)
 	if err != nil {
 		return false

--- a/pkg/mutation/path/parser/node.go
+++ b/pkg/mutation/path/parser/node.go
@@ -23,8 +23,6 @@ import (
 type NodeType string
 
 const (
-	// PathNode is a string segment of a path.
-	PathNode NodeType = "Path"
 	// ListNode is an array element of a path.
 	ListNode NodeType = "List"
 	// ObjectNode is the final Node in a path, what is being referenced.
@@ -43,17 +41,6 @@ type Node interface {
 // Path represents an entire parsed path specification
 type Path struct {
 	Nodes []Node
-}
-
-var _ Node = Path{}
-
-func (r Path) Type() NodeType {
-	return PathNode
-}
-
-func (r Path) DeepCopyNode() Node {
-	rout := r.DeepCopy()
-	return &rout
 }
 
 func (r Path) DeepCopy() Path {

--- a/pkg/mutation/path/parser/parser_test.go
+++ b/pkg/mutation/path/parser/parser_test.go
@@ -437,21 +437,6 @@ func TestDeepCopy(t *testing.T) {
 			name:  "test list deepcopy with nil nexted pointer",
 			input: &List{KeyField: "much full", KeyValue: nil},
 		},
-		{
-			name: "test path deepcopy",
-			input: &Path{
-				Nodes: []Node{
-					&List{KeyField: "much full", KeyValue: "of everyone's"},
-					&List{KeyField: "name", KeyValue: "*", Glob: false},
-					&Object{Reference: "foo\nbar"},
-					&Path{
-						Nodes: []Node{
-							&List{KeyField: "innername", KeyValue: "*", Glob: false},
-						},
-					},
-				},
-			},
-		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/mutation/schema/errors.go
+++ b/pkg/mutation/schema/errors.go
@@ -1,0 +1,11 @@
+package schema
+
+import "github.com/open-policy-agent/gatekeeper/pkg/util"
+
+// ErrNilMutator reports that a method which expected an actual Mutator was
+// a nil pointer.
+const ErrNilMutator = util.Error("attempted to add nil mutator")
+
+// ErrConflictingSchema reports that adding a Mutator to the DB resulted in
+// conflicting implicit schemas.
+const ErrConflictingSchema = util.Error("mutator schema conflict")

--- a/pkg/mutation/schema/node.go
+++ b/pkg/mutation/schema/node.go
@@ -1,0 +1,254 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
+	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
+	"github.com/open-policy-agent/gatekeeper/pkg/util"
+)
+
+type idSet map[types.ID]bool
+
+// unknown represents a path element we do not know the type of.
+// Elements of type unknown do not conflict with path elements of known types.
+const unknown = parser.NodeType("Unknown")
+
+func (c idSet) String() string {
+	var keys []string
+	for k := range c {
+		keys = append(keys, fmt.Sprintf("%q", k.String()))
+	}
+	sort.Strings(keys)
+	return fmt.Sprintf("[%s]", strings.Join(keys, ","))
+}
+
+// node is an element of an implicit schema.
+// Allows for the definition of overlapping schemas. See Add.
+type node struct {
+	// ReferencedBy tracks the Mutations which reference this part of the schema tree.
+	ReferencedBy idSet
+
+	// Children is the set of child Nodes a this location in the schema.
+	// Each node defines a distinct child definition. If multiple Nodes are defined
+	// for the same child, then there is a schema conflict.
+	Children map[string]map[parser.NodeType]node
+}
+
+// Add inserts the provided path, linked to the given ID.
+//
+// Returns the set of conflicts detected while adding the path. Conflicts occur
+// when elements with the same path have different types, for example:
+//
+// spec.containers[name: foo].image
+// spec.containers.image
+//
+// If the returned references is non-nil it contains at least two elements, one
+// of which is the passed id.
+func (n *node) Add(id types.ID, path []parser.Node) idSet {
+	if n.ReferencedBy == nil {
+		n.ReferencedBy = make(map[types.ID]bool)
+	}
+	// This node is referenced by the passed ID.
+	n.ReferencedBy[id] = true
+
+	// Base case; there is no more path to validate.
+	if len(path) == 0 {
+		return nil
+	}
+
+	// Initialize child within n.children.
+	childNode := path[0]
+	if n.Children == nil {
+		n.Children = make(map[string]map[parser.NodeType]node)
+	}
+	childKey := key(childNode)
+	if n.Children[childKey] == nil {
+		n.Children[childKey] = make(map[parser.NodeType]node)
+	}
+	childType := headType(path)
+	if _, exists := n.Children[childKey][childType]; !exists {
+		n.Children[childKey][childType] = node{}
+	}
+
+	// Add the remaining path to the appropriate child, collecting any conflicts
+	// found when adding it.
+	child := n.Children[childKey][childType]
+	conflicts := child.Add(id, path[1:])
+	n.Children[childKey][childType] = child
+
+	// Detect conflicts at this node.
+	// We know there is a conflict if there is a child with the same Key but a
+	// different type.
+	conflicts = merge(conflicts, n.conflicts(childKey))
+	return conflicts
+}
+
+const ErrNotFound = util.Error("path not found")
+
+// Remove removes the id and path from the tree.
+// Panics if the ID is not defined or was Add()ed with a different path.
+func (n *node) Remove(id types.ID, path []parser.Node) {
+	// This ID no longer references this node.
+	if _, isReferenced := n.ReferencedBy[id]; isReferenced {
+		delete(n.ReferencedBy, id)
+	} else {
+		panic(ErrNotFound)
+	}
+
+	if len(path) == 0 {
+		// No more path to remove.
+		return
+	}
+
+	childKey := key(path[0])
+	if _, found := n.Children[childKey]; !found {
+		// The child does not exist.
+		panic(fmt.Errorf("no child for key %q: %w", childKey, ErrNotFound))
+	}
+	childType := headType(path)
+	if _, found := n.Children[childKey][childType]; !found {
+		// No child of the key and type exists.
+		// This is how we detect that the path for id is incomplete. If the path
+		// were complete, the type of the child was known when Add()ed but not when
+		// Remove()d and is files as unknown.
+		panic(fmt.Errorf("no child of type %q for key %q: %w", childType, childKey, ErrNotFound))
+	}
+
+	child := n.Children[childKey][childType]
+	child.Remove(id, path[1:])
+
+	// Delete the type from the child if it is no longer referenced.
+	if len(child.ReferencedBy) == 0 {
+		// No references to this child of this type exist.
+		delete(n.Children[childKey], childType)
+	} else {
+		n.Children[childKey][childType] = child
+	}
+
+	// Delete the child if it is no longer referenced.
+	if len(n.Children[childKey]) == 0 {
+		delete(n.Children, childKey)
+	}
+}
+
+func (n *node) conflicts(childKey string) idSet {
+	conflicts := make(idSet)
+
+	// Count the number of distinct types with this key.
+	nTypes := len(n.Children[childKey])
+	if _, hasUnknown := n.Children[childKey][unknown]; hasUnknown {
+		// Nodes whose types we are unable to determine do not count against this
+		// check.
+		nTypes--
+	}
+
+	for nodeType, child := range n.Children[childKey] {
+		if nodeType == unknown {
+			// If we don't know the type of a node, we assume it conflicts with nothing.
+			continue
+		}
+		// There are conflicts if either:
+		// 1) there are more than one non-unknown types for the Child, or
+		// 2) the Child is a List and defines multiple keys.
+		if nTypes > 1 || nodeType == parser.ListNode && len(child.Children) > 1 {
+			conflicts = merge(conflicts, child.ReferencedBy)
+		}
+	}
+
+	// If more than 1 non-unknown types are declared, this node is part of a
+	// schema conflict.
+	return conflicts
+}
+
+// HasConflicts returns true if there are any schema type conflicts along the
+// passed path.
+//
+// Returns an error if the path does not exist.
+func (n *node) HasConflicts(path []parser.Node) (bool, error) {
+	if len(path) == 0 {
+		return false, nil
+	}
+
+	childKey := key(path[0])
+	childType := headType(path)
+	if _, found := n.Children[childKey]; !found {
+		// Path has not been added, so there can be no conflicts.
+		return false, ErrNotFound
+	}
+
+	// Count the number of distinct types with this key.
+	if len(n.conflicts(childKey)) > 0 {
+		return true, nil
+	}
+
+	if _, found := n.Children[childKey][childType]; !found {
+		// Path has not been added, so there can be no conflicts.
+		return false, ErrNotFound
+	}
+	child := n.Children[childKey][childType]
+	return child.HasConflicts(path[1:])
+}
+
+// merge inserts elements from `from` into `into`. Returns `into`, or a
+// reference to a new map if `into` is nil.
+func merge(into, from idSet) idSet {
+	if len(into) == 0 && len(from) == 0 {
+		return nil
+	}
+	if into == nil {
+		into = make(idSet)
+	}
+	for k := range from {
+		into[k] = true
+	}
+	return into
+}
+
+// headType returns the type of the second Node, if it exists.
+// This is essential for determining whether the current location in a schema
+// path is a list.
+func headType(path []parser.Node) parser.NodeType {
+	if len(path) < 2 {
+		// Default unknown as we have no information either way.
+		return unknown
+	}
+	return path[1].Type()
+}
+
+func (n *node) DeepCopy() *node {
+	if n == nil {
+		return nil
+	}
+
+	result := &node{
+		ReferencedBy: make(idSet),
+		Children:     make(map[string]map[parser.NodeType]node),
+	}
+	for id := range n.ReferencedBy {
+		result.ReferencedBy[id] = true
+	}
+	for k, ts := range n.Children {
+		newChildren := make(map[parser.NodeType]node)
+		for t, child := range ts {
+			newChildren[t] = *child.DeepCopy()
+		}
+		result.Children[k] = newChildren
+	}
+	return result
+}
+
+// key extracts the unique identifier of the next element in the path from the
+// given Node for use in the node tree.
+func key(n parser.Node) string {
+	switch t := n.(type) {
+	case *parser.Object:
+		return t.Reference
+	case *parser.List:
+		return t.KeyField
+	default:
+		panic(fmt.Sprintf("unknown node type %T", n))
+	}
+}

--- a/pkg/mutation/schema/node_test.go
+++ b/pkg/mutation/schema/node_test.go
@@ -1,0 +1,509 @@
+package schema
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
+	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type idPath struct {
+	types.ID
+	path string
+}
+
+func id(name string) types.ID {
+	return types.ID{Name: name}
+}
+
+func ids(names ...string) idSet {
+	result := make(idSet)
+	for _, n := range names {
+		result[id(n)] = true
+	}
+	return result
+}
+
+func ip(name string, path string) idPath {
+	return idPath{ID: id(name), path: path}
+}
+
+func gvk(group, version, kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: group, Version: version, Kind: kind}
+}
+
+func TestNode_Add(t *testing.T) {
+	testCases := []struct {
+		name   string
+		before []idPath
+		add    idPath
+		want   idSet
+	}{
+		{
+			name:   "no conflict on first add",
+			before: []idPath{},
+			add:    ip("name", "spec.name"),
+			want:   nil,
+		},
+		{
+			name: "no conflict on different children",
+			before: []idPath{
+				ip("object", "spec.name"),
+			},
+			add:  ip("list", "spec.containers[list: foo]"),
+			want: nil,
+		},
+		{
+			name: "conflict if different key on same root",
+			before: []idPath{
+				ip("object", "spec.name"),
+			},
+			add: ip("list", "spec[list: foo]"),
+			want: map[types.ID]bool{
+				id("object"): true,
+				id("list"):   true,
+			},
+		},
+		{
+			name: "no conflict if ambiguous list",
+			before: []idPath{
+				ip("object", "spec.containers"),
+			},
+			add:  ip("list", "spec.containers[name: foo].image"),
+			want: nil,
+		},
+		{
+			name: "no conflict if ambiguous object",
+			before: []idPath{
+				ip("object", "spec.containers"),
+			},
+			add:  ip("list", "spec.containers.image"),
+			want: nil,
+		},
+		{
+			name: "list vs. object conflict",
+			before: []idPath{
+				ip("object", "spec.name"),
+			},
+			add: ip("list", "spec[name: foo]"),
+			want: map[types.ID]bool{
+				id("object"): true,
+				id("list"):   true,
+			},
+		},
+		{
+			name: "list key field conflict",
+			before: []idPath{
+				ip("list image", "spec[image: bar]"),
+			},
+			add: ip("list name", "spec[name: foo]"),
+			want: map[types.ID]bool{
+				id("list image"): true,
+				id("list name"):  true,
+			},
+		},
+		{
+			name: "multiple conflicts",
+			before: []idPath{
+				ip("object-object", "spec.container.name"),
+				ip("object-list", "spec.container[name: foo]"),
+			},
+			add: ip("list-object", "spec[container: foo].name"),
+			want: map[types.ID]bool{
+				id("object-object"): true,
+				id("object-list"):   true,
+				id("list-object"):   true,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := node{}
+			for _, p := range tc.before {
+				path, err := parser.Parse(p.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				root.Add(p.ID, path.Nodes)
+			}
+
+			path, err := parser.Parse(tc.add.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			conflicts := root.Add(tc.add.ID, path.Nodes)
+			if diff := cmp.Diff(tc.want, conflicts); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestNode_RemovePanic(t *testing.T) {
+	// Remove should panic if the expected node is not found.
+	testCases := []struct {
+		name      string
+		before    []idPath
+		toRemove  idPath
+		wantPanic bool
+	}{
+		{
+			name:      "remove from empty",
+			before:    []idPath{},
+			toRemove:  ip("name", "spec.name"),
+			wantPanic: true,
+		},
+		{
+			name: "remove if exists",
+			before: []idPath{
+				ip("name", "spec.name"),
+			},
+			toRemove:  ip("name", "spec.name"),
+			wantPanic: false,
+		},
+		{
+			name: "remove if other id exists",
+			before: []idPath{
+				ip("name", "spec.name"),
+			},
+			toRemove:  ip("name 2", "spec.name"),
+			wantPanic: true,
+		},
+		{
+			name: "panic if remove subpath",
+			before: []idPath{
+				ip("name", "spec.name"),
+			},
+			toRemove:  ip("name", "spec"),
+			wantPanic: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := node{}
+			for _, p := range tc.before {
+				path, err := parser.Parse(p.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				root.Add(p.ID, path.Nodes)
+			}
+
+			pRemove, err := parser.Parse(tc.toRemove.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				r := recover()
+				if r == nil && tc.wantPanic {
+					t.Error("expected Remove to panic but did not get panic")
+				} else if r != nil && !tc.wantPanic {
+					t.Errorf("expected Remove to succeed but panicked: %v", r)
+				}
+			}()
+			root.Remove(tc.toRemove.ID, pRemove.Nodes)
+		})
+	}
+}
+
+func TestNode_Remove(t *testing.T) {
+	testCases := []struct {
+		name               string
+		before             []idPath
+		toRemove           []idPath
+		toCheck            string
+		wantConflictBefore bool
+		wantConflictAfter  bool
+	}{
+		{
+			name: "remove object conflict same key",
+			before: []idPath{
+				ip("object", "spec.name"),
+				ip("list", "spec[name: foo]"),
+			},
+			toRemove:           []idPath{ip("object", "spec.name")},
+			toCheck:            "spec[name: foo]",
+			wantConflictBefore: true,
+			wantConflictAfter:  false,
+		},
+		{
+			name: "remove object conflict different key",
+			before: []idPath{
+				ip("object", "spec.name"),
+				ip("list", "spec[container: foo]"),
+			},
+			toRemove:           []idPath{ip("object", "spec.name")},
+			toCheck:            "spec[container: foo]",
+			wantConflictBefore: true,
+			wantConflictAfter:  false,
+		},
+		{
+			name: "remove list conflict",
+			before: []idPath{
+				ip("object", "spec.name.id"),
+				ip("list", "spec[name: foo]"),
+			},
+			toRemove:           []idPath{ip("list", "spec[name: foo]")},
+			toCheck:            "spec.name.id",
+			wantConflictBefore: true,
+			wantConflictAfter:  false,
+		},
+		{
+			name: "multiple conflicts",
+			before: []idPath{
+				ip("object-object", "spec.container.name"),
+				ip("object-list", "spec.container[name: foo]"),
+				ip("list-object", "spec[container: foo].name"),
+			},
+			toRemove:           []idPath{ip("list-object", "spec[container: foo].name")},
+			toCheck:            "spec.container[name: foo]",
+			wantConflictBefore: true,
+			wantConflictAfter:  true,
+		},
+		{
+			name: "sublist conflict with different list keys",
+			before: []idPath{
+				ip("list 1", "containers[name: foo]"),
+				ip("list 2", "containers[id: bar]"),
+			},
+			toRemove:           []idPath{ip("list 2", "containers[id: bar]")},
+			toCheck:            "containers[name: foo]",
+			wantConflictBefore: true,
+			wantConflictAfter:  false,
+		},
+		{
+			name: "preserve subpath when deleting longer schema path",
+			before: []idPath{
+				ip("short 1", "spec.containers[name: foo]"),
+				ip("long 1", "spec.containers[name: foo].image"),
+				ip("short 2", "spec.containers.name"),
+				ip("long 2", "spec.containers.name.image"),
+			},
+			toRemove: []idPath{
+				ip("long 1", "spec.containers[name: foo].image"),
+				ip("long 2", "spec.containers.name.image"),
+			},
+			toCheck:            "spec.containers[name: foo]",
+			wantConflictBefore: true,
+			wantConflictAfter:  true,
+		},
+		{
+			name: "remove identical path",
+			before: []idPath{
+				ip("path 1", "spec.containers[name: foo]"),
+				ip("path 2", "spec.containers[name: foo]"),
+			},
+			toRemove: []idPath{
+				ip("path 1", "spec.containers[name: foo]"),
+			},
+			toCheck:            "spec.containers[name: foo]",
+			wantConflictBefore: false,
+			wantConflictAfter:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := node{}
+			for _, p := range tc.before {
+				path, err := parser.Parse(p.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				root.Add(p.ID, path.Nodes)
+			}
+
+			pCheck, err := parser.Parse(tc.toCheck)
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotConflictBefore, gotConflictBeforeErr := root.HasConflicts(pCheck.Nodes)
+			if gotConflictBefore != tc.wantConflictBefore {
+				t.Errorf("before remove got HasConflicts(%q) = %t, want %t",
+					tc.toCheck, gotConflictBefore, tc.wantConflictBefore)
+			}
+			if gotConflictBeforeErr != nil {
+				t.Errorf("before remove got HasConflicts(%q) error = %v, want <nil>",
+					tc.toCheck, gotConflictBeforeErr)
+			}
+
+			for _, toRemove := range tc.toRemove {
+				pRemove, err := parser.Parse(toRemove.path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				root.Remove(toRemove.ID, pRemove.Nodes)
+			}
+
+			gotConflictAfter, gotConflictAfterErr := root.HasConflicts(pCheck.Nodes)
+			if gotConflictAfter != tc.wantConflictAfter {
+				t.Errorf("after remove got HasConflicts(%q) = %t, want %t",
+					tc.toCheck, gotConflictAfter, tc.wantConflictAfter)
+			}
+			if gotConflictAfterErr != nil {
+				t.Errorf("before remove got HasConflicts(%q) error = %v, want <nil>",
+					tc.toCheck, gotConflictAfterErr)
+			}
+		})
+	}
+}
+
+func TestNode_Add_Internals(t *testing.T) {
+	// These tests prove the internals of node are working as expected.
+	// Do not test behaviors; just validate that adding structures functions as
+	// desired.
+
+	testCases := []struct {
+		name   string
+		before []string
+		toAdd  string
+		want   node
+	}{
+		{
+			name:  "just root",
+			toAdd: "spec",
+			want: node{
+				ReferencedBy: ids("added"),
+				Children: map[string]map[parser.NodeType]node{
+					"spec": {
+						unknown: node{
+							ReferencedBy: ids("added"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "root twice",
+			before: []string{
+				"spec",
+			},
+			toAdd: "spec",
+			want: node{
+				ReferencedBy: ids("0", "added"),
+				Children: map[string]map[parser.NodeType]node{
+					"spec": {
+						unknown: node{
+							ReferencedBy: ids("0", "added"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "object node",
+			toAdd: "spec.name",
+			want: node{
+				ReferencedBy: ids("added"),
+				Children: map[string]map[parser.NodeType]node{
+					"spec": {
+						parser.ObjectNode: node{
+							ReferencedBy: ids("added"),
+							Children: map[string]map[parser.NodeType]node{
+								"name": {
+									unknown: node{
+										ReferencedBy: ids("added"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "list node",
+			toAdd: "spec[name: foo]",
+			want: node{
+				ReferencedBy: ids("added"),
+				Children: map[string]map[parser.NodeType]node{
+					"spec": {
+						parser.ListNode: node{
+							ReferencedBy: ids("added"),
+							Children: map[string]map[parser.NodeType]node{
+								"name": {
+									unknown: node{
+										ReferencedBy: ids("added"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "conflict",
+			before: []string{
+				"spec.name",
+			},
+			toAdd: "spec[name: foo]",
+			want: node{
+				ReferencedBy: ids("0", "added"),
+				Children: map[string]map[parser.NodeType]node{
+					"spec": {
+						parser.ObjectNode: node{
+							ReferencedBy: ids("0"),
+							Children: map[string]map[parser.NodeType]node{
+								"name": {
+									unknown: node{
+										ReferencedBy: ids("0"),
+									},
+								},
+							},
+						},
+						parser.ListNode: node{
+							ReferencedBy: ids("added"),
+							Children: map[string]map[parser.NodeType]node{
+								"name": {
+									unknown: node{
+										ReferencedBy: ids("added"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := node{}
+
+			for i, b := range tc.before {
+				p, err := parser.Parse(b)
+				if err != nil {
+					t.Fatal(err)
+				}
+				root.Add(id(fmt.Sprint(i)), p.Nodes)
+			}
+			rootBefore := *root.DeepCopy()
+
+			p, err := parser.Parse(tc.toAdd)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			root.Add(id("added"), p.Nodes)
+
+			if diff := cmp.Diff(tc.want, root, cmpopts.EquateEmpty()); diff != "" {
+				t.Error(diff)
+			}
+
+			root.Remove(id("added"), p.Nodes)
+
+			// We expect that adding and then removing the path causes no change.
+			if diff := cmp.Diff(rootBefore, root, cmpopts.EquateEmpty()); diff != "" {
+				t.Error("Add then Remove caused change", diff)
+			}
+		})
+	}
+}

--- a/pkg/mutation/schema/schema_test.go
+++ b/pkg/mutation/schema/schema_test.go
@@ -1,1514 +1,285 @@
 package schema
 
 import (
-	"reflect"
+	"errors"
+	"fmt"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-	"github.com/google/go-cmp/cmp"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ MutatorWithSchema = &mockMutator{}
+var _ MutatorWithSchema = &fakeMutator{}
 
-type mockMutator struct {
-	id        types.ID
-	ForceDiff bool
-	Bindings  []Binding
-	path      string
-	pathCache parser.Path
+type fakeMutator struct {
+	id       types.ID
+	bindings []schema.GroupVersionKind
+	pathStr  string
+	path     parser.Path
 }
 
-func (m *mockMutator) Matches(obj runtime.Object, ns *corev1.Namespace) bool { return false }
-
-func (m *mockMutator) Mutate(obj *unstructured.Unstructured) (bool, error) { return false, nil }
-
-func (m *mockMutator) Value() (interface{}, error) { return nil, nil }
-
-func (m *mockMutator) ID() types.ID { return m.id }
-
-func (m *mockMutator) HasDiff(other types.Mutator) bool {
-	if m.ForceDiff {
-		return true
-	}
-	return !reflect.DeepEqual(m, other)
-}
-
-func (m *mockMutator) String() string {
-	return ""
-}
-
-func deepCopyBindings(bindings []Binding) []Binding {
-	var cpy []Binding
-	for _, b := range bindings {
-		cpy = append(cpy, Binding{
-			Groups:   append([]string{}, b.Groups...),
-			Kinds:    append([]string{}, b.Kinds...),
-			Versions: append([]string{}, b.Versions...),
-		})
-	}
-	return cpy
-}
-
-func (m *mockMutator) internalDeepCopy() *mockMutator {
-	return &mockMutator{
-		id:        m.id,
-		ForceDiff: m.ForceDiff,
-		Bindings:  deepCopyBindings(m.Bindings),
-		path:      m.path,
-	}
-}
-
-func (m *mockMutator) DeepCopy() types.Mutator {
-	return m.internalDeepCopy()
-}
-
-func (m *mockMutator) SchemaBindings() []Binding { return m.Bindings }
-
-func (m *mockMutator) Path() parser.Path {
-	if len(m.pathCache.Nodes) > 0 {
-		return m.pathCache
-	}
-	out, err := parser.Parse(m.path)
+func newFakeMutator(id types.ID, pathStr string, bindings ...schema.GroupVersionKind) *fakeMutator {
+	path, err := parser.Parse(pathStr)
 	if err != nil {
 		panic(err)
 	}
-	m.pathCache = out
-	return out
-}
-
-func id(name string) types.ID {
-	return types.ID{Name: name}
-}
-
-func bindings(kinds ...string) []Binding {
-	b := []Binding{}
-	for _, kind := range kinds {
-		b = append(b, Binding{Groups: []string{""}, Versions: []string{"v1"}, Kinds: []string{kind}})
-	}
-	return b
-}
-
-func gvk(kind string) schema.GroupVersionKind {
-	return schema.GroupVersionKind{
-		Group:   "",
-		Version: "v1",
-		Kind:    kind,
-	}
-}
-
-func sp(s string) *string {
-	return &s
-}
-
-func simpleMutator(mID, kind, path string) *mockMutator {
-	return &mockMutator{
-		id:       id(mID),
-		Bindings: bindings(kind),
+	return &fakeMutator{
+		id:       id,
+		bindings: bindings,
+		pathStr:  pathStr,
 		path:     path,
 	}
 }
 
-func complexMutator(mID, path string, kinds ...string) *mockMutator {
-	return &mockMutator{
-		id:       id(mID),
-		Bindings: bindings(kinds...),
-		path:     path,
-	}
+func (m *fakeMutator) Matches(_ client.Object, _ *corev1.Namespace) bool {
+	panic("should not be called")
 }
 
-var (
-	basicCaseObjectLeaf       = simpleMutator("simple", "FooKind", "spec.someValue")
-	basicCaseObjectLeafSchema = map[schema.GroupVersionKind]*scheme{
-		gvk("FooKind"): {
-			gvk: gvk("FooKind"),
-			root: &node{
-				referenceCount: 1,
-				nodeType:       parser.ObjectNode,
-				children: map[string]*node{
-					"spec": {
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children:       map[string]*node{},
-					},
-				},
-			},
-		},
-	}
-
-	basicCaseListLeaf       = simpleMutator("simplelist", "FooListKind", "spec.someValue[hey: \"there\"]")
-	basicCaseListLeafSchema = map[schema.GroupVersionKind]*scheme{
-		gvk("FooListKind"): {
-			gvk: gvk("FooListKind"),
-			root: &node{
-				referenceCount: 1,
-				nodeType:       parser.ObjectNode,
-				children: map[string]*node{
-					"spec": {
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"someValue": {
-								referenceCount: 1,
-								nodeType:       parser.ListNode,
-								keyField:       sp("hey"),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-)
-
-func TestSchema(t *testing.T) {
-	tests := []testCase{
-		{
-			name: "Trivial",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("trivial", "FooKind", "spec"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("trivial"): simpleMutator("trivial", "FooKind", "spec"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children:       map[string]*node{},
-					},
-				},
-			},
-		},
-		{
-			name: "Trivial + delete",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("trivial", "FooKind", "spec"),
-				},
-				{
-					op: remove,
-					id: id("trivial"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{},
-			expectedSchemas:  map[schema.GroupVersionKind]*scheme{},
-		},
-		{
-			name: "Simple upsert",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: basicCaseObjectLeaf.internalDeepCopy(),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simple"): basicCaseObjectLeaf,
-			},
-			expectedSchemas: basicCaseObjectLeafSchema,
-		},
-		{
-			name: "Add and remove simple",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("simple", "FooKind", "spec.someValue"),
-				},
-				{
-					op: remove,
-					id: id("simple"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{},
-			expectedSchemas:  map[schema.GroupVersionKind]*scheme{},
-		},
-		{
-			name: "Replace",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("simple", "FooKind", "spec.someValue"),
-				},
-				{
-					op:      upsert,
-					mutator: simpleMutator("simple", "FooKind", "spec[someKey: *]"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simple"): simpleMutator("simple", "FooKind", "spec[someKey: *]"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ListNode,
-								keyField:       sp("someKey"),
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with overshadow",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: basicCaseObjectLeaf.internalDeepCopy(),
-				},
-				{
-					op:      upsert,
-					mutator: simpleMutator("complex", "FooKind", "spec.someValue.moreValues"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simple"):  basicCaseObjectLeaf,
-				id("complex"): simpleMutator("complex", "FooKind", "spec.someValue.moreValues"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"someValue": {
-										referenceCount: 1,
-										nodeType:       parser.ObjectNode,
-										children:       map[string]*node{},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with overshadow, deleted",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: basicCaseObjectLeaf.internalDeepCopy(),
-				},
-				{
-					op:      upsert,
-					mutator: simpleMutator("complex", "FooKind", "spec.someValue.moreValues"),
-				},
-				{
-					op: remove,
-					id: id("complex"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simple"): basicCaseObjectLeaf,
-			},
-			expectedSchemas: basicCaseObjectLeafSchema,
-		},
-		{
-			name: "Simple upsert with undershadow",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("complex", "FooKind", "spec.someValue.moreValues"),
-				},
-				{
-					op:      upsert,
-					mutator: basicCaseObjectLeaf.internalDeepCopy(),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simple"):  basicCaseObjectLeaf,
-				id("complex"): simpleMutator("complex", "FooKind", "spec.someValue.moreValues"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"someValue": {
-										referenceCount: 1,
-										nodeType:       parser.ObjectNode,
-										children:       map[string]*node{},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with undershadow, deleted",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("complex", "FooKind", "spec.someValue.moreValues"),
-				},
-				{
-					op:      upsert,
-					mutator: basicCaseObjectLeaf.internalDeepCopy(),
-				},
-				{
-					op: remove,
-					id: id("simple"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("complex"): simpleMutator("complex", "FooKind", "spec.someValue.moreValues"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"someValue": {
-										referenceCount: 1,
-										nodeType:       parser.ObjectNode,
-										children:       map[string]*node{},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with list",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: basicCaseListLeaf.internalDeepCopy(),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simplelist"): basicCaseListLeaf,
-			},
-			expectedSchemas: basicCaseListLeafSchema,
-		},
-		{
-			name: "Simple upsert with list and overshadow",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: basicCaseListLeaf.internalDeepCopy(),
-				},
-				{
-					op: upsert,
-					// note that we actually need to go two deep when we have a list as a terminal node
-					// because a list already implies that the immediately following node is an object
-					mutator: simpleMutator("complex", "FooListKind", "spec.someValue[hey: \"there\"].buddy.hallo"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simplelist"): basicCaseListLeaf,
-				id("complex"):    simpleMutator("complex", "FooListKind", "spec.someValue[hey: \"there\"].buddy.hallo"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooListKind"): {
-					gvk: gvk("FooListKind"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"someValue": {
-										referenceCount: 2,
-										nodeType:       parser.ListNode,
-										keyField:       sp("hey"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"buddy": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with list and overshadow, deleted",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: basicCaseListLeaf.internalDeepCopy(),
-				},
-				{
-					op: upsert,
-					// note that we actually need to go two deep when we have a list as a terminal node
-					// because a list already implies that the immediately following node is an object
-					mutator: simpleMutator("complex", "FooKind", "spec.someValue[hey: \"there\"].buddy.hallo"),
-				},
-				{
-					op: remove,
-					// note that we actually need to go two deep when we have a list as a terminal node
-					// because a list already implies that the immediately following node is an object
-					id: id("complex"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simplelist"): basicCaseListLeaf,
-			},
-			expectedSchemas: basicCaseListLeafSchema,
-		},
-		{
-			name: "Simple upsert with list and undershadow",
-			ops: []testOp{
-				{
-					op: upsert,
-					// note that we actually need to go two deep when we have a list as a terminal node
-					// because a list already implies that the immediately following node is an object
-					mutator: simpleMutator("complex", "FooListKind", "spec.someValue[hey: \"there\"].buddy.hallo"),
-				},
-				{
-					op:      upsert,
-					mutator: basicCaseListLeaf.internalDeepCopy(),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simplelist"): basicCaseListLeaf,
-				id("complex"):    simpleMutator("complex", "FooListKind", "spec.someValue[hey: \"there\"].buddy.hallo"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooListKind"): {
-					gvk: gvk("FooListKind"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"someValue": {
-										referenceCount: 2,
-										nodeType:       parser.ListNode,
-										keyField:       sp("hey"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"buddy": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with list and undershadow, deleted",
-			ops: []testOp{
-				{
-					op: upsert,
-					// note that we actually need to go two deep when we have a list as a terminal node
-					// because a list already implies that the immediately following node is an object
-					mutator: simpleMutator("complex", "FooListKind", "spec.someValue[hey: \"there\"].buddy.hallo"),
-				},
-				{
-					op:      upsert,
-					mutator: basicCaseListLeaf.internalDeepCopy(),
-				},
-				{
-					op: remove,
-					id: id("simplelist"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("complex"): simpleMutator("complex", "FooListKind", "spec.someValue[hey: \"there\"].buddy.hallo"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooListKind"): {
-					gvk: gvk("FooListKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"someValue": {
-										referenceCount: 1,
-										nodeType:       parser.ListNode,
-										keyField:       sp("hey"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"buddy": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with branch",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-a", "FooKind", "spec.common.different.more"),
-				},
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-b", "FooKind", "spec.common.food.hotdog"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("branch-a"): simpleMutator("branch-a", "FooKind", "spec.common.different.more"),
-				id("branch-b"): simpleMutator("branch-b", "FooKind", "spec.common.food.hotdog"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"common": {
-										referenceCount: 2,
-										nodeType:       parser.ObjectNode,
-										children: map[string]*node{
-											"different": {
-												referenceCount: 1,
-												nodeType:       parser.ObjectNode,
-												children:       map[string]*node{},
-											},
-											"food": {
-												referenceCount: 1,
-												nodeType:       parser.ObjectNode,
-												children:       map[string]*node{},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with branch and delete",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-a", "FooKind", "spec.common.different.more"),
-				},
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-b", "FooKind", "spec.common.food.hotdog"),
-				},
-				{
-					op: remove,
-					id: id("branch-a"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("branch-b"): simpleMutator("branch-b", "FooKind", "spec.common.food.hotdog"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"common": {
-										referenceCount: 1,
-										nodeType:       parser.ObjectNode,
-										children: map[string]*node{
-											"food": {
-												referenceCount: 1,
-												nodeType:       parser.ObjectNode,
-												children:       map[string]*node{},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with branch -- list",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-a", "FooKind", "spec.common.different.more"),
-				},
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-b", "FooKind", "spec.common.food[kind: hotdog]"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("branch-a"): simpleMutator("branch-a", "FooKind", "spec.common.different.more"),
-				id("branch-b"): simpleMutator("branch-b", "FooKind", "spec.common.food[kind: hotdog]"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"common": {
-										referenceCount: 2,
-										nodeType:       parser.ObjectNode,
-										children: map[string]*node{
-											"different": {
-												referenceCount: 1,
-												nodeType:       parser.ObjectNode,
-												children:       map[string]*node{},
-											},
-											"food": {
-												referenceCount: 1,
-												keyField:       sp("kind"),
-												nodeType:       parser.ListNode,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with branch -- list, deleted list",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-a", "FooKind", "spec.common.different.more"),
-				},
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-b", "FooKind", "spec.common.food[kind: hotdog]"),
-				},
-				{
-					op: remove,
-					id: id("branch-b"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("branch-a"): simpleMutator("branch-a", "FooKind", "spec.common.different.more"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"common": {
-										referenceCount: 1,
-										nodeType:       parser.ObjectNode,
-										children: map[string]*node{
-											"different": {
-												referenceCount: 1,
-												nodeType:       parser.ObjectNode,
-												children:       map[string]*node{},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Simple upsert with branch -- list, deleted object",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-a", "FooKind", "spec.common.different.more"),
-				},
-				{
-					op:      upsert,
-					mutator: simpleMutator("branch-b", "FooKind", "spec.common.food[kind: hotdog]"),
-				},
-				{
-					op: remove,
-					id: id("branch-a"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("branch-b"): simpleMutator("branch-b", "FooKind", "spec.common.food[kind: hotdog]"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"common": {
-										referenceCount: 1,
-										nodeType:       parser.ObjectNode,
-										children: map[string]*node{
-											"food": {
-												referenceCount: 1,
-												keyField:       sp("kind"),
-												nodeType:       parser.ListNode,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Multi kind, multi mutator",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: basicCaseListLeaf.internalDeepCopy(),
-				},
-				{
-					op:      upsert,
-					mutator: basicCaseObjectLeaf.internalDeepCopy(),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simplelist"): basicCaseListLeaf,
-				id("simple"):     basicCaseObjectLeaf,
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooListKind"): basicCaseListLeafSchema[gvk("FooListKind")],
-				gvk("FooKind"):     basicCaseObjectLeafSchema[gvk("FooKind")],
-			},
-		},
-		{
-			name: "Multi kind, multi mutator + delete",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: basicCaseListLeaf.internalDeepCopy(),
-				},
-				{
-					op:      upsert,
-					mutator: basicCaseObjectLeaf.internalDeepCopy(),
-				},
-				{
-					op: remove,
-					id: id("simple"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("simplelist"): basicCaseListLeaf,
-			},
-			expectedSchemas: basicCaseListLeafSchema,
-		},
-		{
-			name: "Multi kind",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("many", "spec.containers[name: sidecar].property.yep", "FooKind", "BarKind"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("many"): complexMutator("many", "spec.containers[name: sidecar].property.yep", "FooKind", "BarKind"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"containers": {
-										referenceCount: 1,
-										nodeType:       parser.ListNode,
-										keyField:       sp("name"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"property": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				gvk("BarKind"): {
-					gvk: gvk("BarKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"containers": {
-										referenceCount: 1,
-										nodeType:       parser.ListNode,
-										keyField:       sp("name"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"property": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Multi kind + delete",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("many", "spec.containers[name: sidecar].property.yep", "FooKind", "BarKind"),
-				},
-				{
-					op: remove,
-					id: id("many"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{},
-			expectedSchemas:  map[schema.GroupVersionKind]*scheme{},
-		},
-		{
-			name: "Multi kind + overlap",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("many", "spec.containers[name: sidecar].property.yep", "FooKind", "BarKind"),
-				},
-				{
-					op:      upsert,
-					mutator: complexMutator("one", "spec.trusted", "FooKind"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("many"): complexMutator("many", "spec.containers[name: sidecar].property.yep", "FooKind", "BarKind"),
-				id("one"):  complexMutator("one", "spec.trusted", "FooKind"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"containers": {
-										referenceCount: 1,
-										nodeType:       parser.ListNode,
-										keyField:       sp("name"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"property": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				gvk("BarKind"): {
-					gvk: gvk("BarKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"containers": {
-										referenceCount: 1,
-										nodeType:       parser.ListNode,
-										keyField:       sp("name"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"property": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Multi kind + overlap, delete simple",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("many", "spec.containers[name: sidecar].property.yep", "FooKind", "BarKind"),
-				},
-				{
-					op:      upsert,
-					mutator: complexMutator("one", "spec.trusted", "FooKind"),
-				},
-				{
-					op: remove,
-					id: id("one"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("many"): complexMutator("many", "spec.containers[name: sidecar].property.yep", "FooKind", "BarKind"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"containers": {
-										referenceCount: 1,
-										nodeType:       parser.ListNode,
-										keyField:       sp("name"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"property": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				gvk("BarKind"): {
-					gvk: gvk("BarKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"containers": {
-										referenceCount: 1,
-										nodeType:       parser.ListNode,
-										keyField:       sp("name"),
-										child: &node{
-											referenceCount: 1,
-											nodeType:       parser.ObjectNode,
-											children: map[string]*node{
-												"property": {
-													referenceCount: 1,
-													nodeType:       parser.ObjectNode,
-													children:       map[string]*node{},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "Multi kind + overlap, delete complex",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("many", "spec.containers[name: sidecar].property.yep", "FooKind", "BarKind"),
-				},
-				{
-					op:      upsert,
-					mutator: complexMutator("one", "spec.trusted", "FooKind"),
-				},
-				{
-					op: remove,
-					id: id("many"),
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("one"): complexMutator("one", "spec.trusted", "FooKind"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("FooKind"): {
-					gvk: gvk("FooKind"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children:       map[string]*node{},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-	for _, test := range tests {
-		tester := func(t *testing.T) {
-			db := New()
-			testFn(test, db, t)
-		}
-		t.Run(test.name, tester)
-	}
+func (m *fakeMutator) Mutate(_ *unstructured.Unstructured) (bool, error) {
+	panic("should not be called")
 }
 
-func TestErrors(t *testing.T) {
-	tests := []struct {
-		name        string
-		first       string
-		second      string
-		expectedErr string
+func (m *fakeMutator) Value() (interface{}, error) {
+	panic("should not be called")
+}
+
+func (m *fakeMutator) ID() types.ID { return m.id }
+
+func (m *fakeMutator) HasDiff(other types.Mutator) bool {
+	if m == other {
+		return true
+	}
+	if other == nil {
+		return false
+	}
+
+	o, ok := other.(*fakeMutator)
+	if !ok {
+		err := fmt.Errorf("unexpected mutator type %T, want %T", other, &fakeMutator{})
+		panic(err)
+	}
+	return m.id == o.id && m.pathStr == o.pathStr
+}
+
+func (m *fakeMutator) String() string {
+	return ""
+}
+
+func (m *fakeMutator) DeepCopy() types.Mutator {
+	result := &fakeMutator{
+		id:       m.id,
+		pathStr:  m.pathStr,
+		bindings: make([]schema.GroupVersionKind, len(m.bindings)),
+		path:     m.path.DeepCopy(),
+	}
+	copy(result.bindings, m.bindings)
+	return result
+}
+
+func (m *fakeMutator) SchemaBindings() []schema.GroupVersionKind {
+	return m.bindings
+}
+
+func (m *fakeMutator) Path() parser.Path {
+	return m.path
+}
+
+func TestDB_Upsert(t *testing.T) {
+	testCases := []struct {
+		name    string
+		before  []MutatorWithSchema
+		toAdd   MutatorWithSchema
+		wantErr error
 	}{
 		{
-			name:        "Long path with conflict at end",
-			first:       "spec.intermediate.someValue[hey: \"there\"].buddy.hallo",
-			second:      "spec.intermediate.someValue[hey: again].buddy[key: *]",
-			expectedErr: `spec.intermediate.someValue[hey: again].buddy: node type conflict: Object vs List`,
+			name:    "add nil mutator",
+			before:  []MutatorWithSchema{},
+			toAdd:   nil,
+			wantErr: ErrNilMutator,
 		},
 		{
-			name:        "Long path with conflict at end, globbed",
-			first:       "spec.intermediate.someValue[hey: \"there\"].buddy.hallo",
-			second:      "spec.intermediate.someValue[hey: *].buddy[key: *]",
-			expectedErr: `spec.intermediate.someValue[hey: *].buddy: node type conflict: Object vs List`,
+			name:   "add mutator",
+			before: []MutatorWithSchema{},
+			toAdd: newFakeMutator(id("bar"), "spec.containers[name: foo].image",
+				gvk("", "v1", "Pod")),
+			wantErr: nil,
 		},
 		{
-			name:        "Long path with conflict at beginning",
-			first:       "spec.intermediate.someValue[hey: \"there\"].buddy.hallo",
-			second:      "spec.intermediate[hey: again].buddy[key: *]",
-			expectedErr: `spec.intermediate: node type conflict: Object vs List`,
+			name: "overwrite identical mutator",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("bar"), "spec.containers[name: foo].image",
+					gvk("", "v1", "Pod")),
+			},
+			toAdd: newFakeMutator(id("bar"), "spec.containers[name: foo].image",
+				gvk("", "v1", "Pod")),
+			wantErr: nil,
 		},
 		{
-			name:        "Originally list, try to add object",
-			first:       "spec.containers[name: foo]",
-			second:      "spec.containers.wrong",
-			expectedErr: "spec.containers: node type conflict: List vs Object",
+			name: "add conflicting mutator",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("foo"), "spec.containers.image",
+					gvk("", "v1", "Pod")),
+			},
+			toAdd: newFakeMutator(id("bar"), "spec.containers[name: foo].image",
+				gvk("", "v1", "Pod")),
+			wantErr: ErrConflictingSchema,
+		},
+		{
+			name: "add conflicting mutator of different type",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("foo"), "spec.containers.image",
+					gvk("", "v1", "Pod")),
+			},
+			toAdd: newFakeMutator(id("bar"), "spec.containers[name: foo].image",
+				gvk("", "v2", "Pod")),
+			wantErr: nil,
+		},
+		{
+			name: "overwrite mutator with conflicting one",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("foo"), "spec.containers.image",
+					gvk("", "v1", "Pod")),
+			},
+			toAdd: newFakeMutator(id("foo"), "spec.containers[name: foo].image",
+				gvk("", "v1", "Pod")),
+			wantErr: nil,
+		},
+		{
+			name: "globbed list does not conflict with non-globbed list",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("foo"), "spec.containers[name: foo].image",
+					gvk("", "v1", "Pod")),
+			},
+			toAdd: newFakeMutator(id("bar"), "spec.containers[name: *].image",
+				gvk("", "v1", "Pod")),
+			wantErr: nil,
 		},
 	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			db := New()
-			if err := db.Upsert(simpleMutator("complex", "FooKind", test.first)); err != nil {
-				t.Fatal(err)
+
+			for _, m := range tc.before {
+				// Intentionally ignore errors here as in many cases previous Upserts
+				// would have returned errors, and that behavior is not under test.
+				_ = db.Upsert(m)
 			}
-			err := db.Upsert(simpleMutator("conflict", "FooKind", test.second))
-			if err == nil {
-				t.Fatal("unexpected nil error")
-			}
-			if err.Error() != test.expectedErr {
-				t.Errorf("got %v, wanted %v", err.Error(), test.expectedErr)
+
+			err := db.Upsert(tc.toAdd)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("got Upsert() error = %v, want %v", err, tc.wantErr)
 			}
 		})
 	}
 }
 
-func TestUnwinding(t *testing.T) {
-	tests := []struct {
-		name             string
-		ops              []testOp
-		expectedMutators map[types.ID]MutatorWithSchema
-		expectedSchemas  map[schema.GroupVersionKind]*scheme
+func TestDB_Remove(t *testing.T) {
+	testCases := []struct {
+		name               string
+		before             []MutatorWithSchema
+		toRemove           types.ID
+		toCheck            types.ID
+		wantConflictBefore bool
+		wantConflictAfter  bool
 	}{
 		{
-			name: "Initial Overlap",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("one", "spec.trusted", "A"),
-				},
-				{
-					op:            upsert,
-					mutator:       complexMutator("many", "spec[trusted: nope]", "A", "B"),
-					errorExpected: true,
-					expectedError: "spec: node type conflict: Object vs List",
-				},
-			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("one"): complexMutator("one", "spec.trusted", "A"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("A"): {
-					gvk: gvk("A"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children:       map[string]*node{},
-							},
-						},
-					},
-				},
-			},
+			name:               "remove from empty has no conflict",
+			before:             []MutatorWithSchema{},
+			toRemove:           id("foo"),
+			toCheck:            id("bar"),
+			wantConflictBefore: false,
+			wantConflictAfter:  false,
 		},
 		{
-			name: "Second Overlap",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("one", "spec.trusted", "B"),
-				},
-				{
-					op:            upsert,
-					mutator:       complexMutator("many", "spec[trusted: nope]", "A", "B"),
-					errorExpected: true,
-					expectedError: "spec: node type conflict: Object vs List",
-				},
+			name: "no conflict after removing",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("foo"), "spec.name.image",
+					gvk("", "v1", "Role")),
+				newFakeMutator(id("bar"), "spec[name: foo].image",
+					gvk("", "v1", "Role")),
 			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("one"): complexMutator("one", "spec.trusted", "B"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("B"): {
-					gvk: gvk("B"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children:       map[string]*node{},
-							},
-						},
-					},
-				},
-			},
+			toRemove:           id("bar"),
+			toCheck:            id("foo"),
+			wantConflictBefore: true,
+			wantConflictAfter:  false,
 		},
 		{
-			name: "Revert bad replace",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("one", "spec.trusted", "B"),
-				},
-				{
-					op:            upsert,
-					mutator:       complexMutator("many", "spec.trusted.yep", "A", "B"),
-					errorExpected: false,
-				},
-				{
-					op:            upsert,
-					mutator:       complexMutator("many", "spec[trusted: nope]", "A", "B"),
-					errorExpected: true,
-					expectedError: "spec: node type conflict: Object vs List",
-				},
+			name: "still conflict after removing",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("foo"), "spec.name.image",
+					gvk("", "v1", "Role")),
+				newFakeMutator(id("bar"), "spec[name: foo].image",
+					gvk("", "v1", "Role")),
+				newFakeMutator(id("qux"), "spec[name: foo].tag",
+					gvk("", "v1", "Role")),
 			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("one"):  complexMutator("one", "spec.trusted", "B"),
-				id("many"): complexMutator("many", "spec.trusted.yep", "A", "B"),
-			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("A"): {
-					gvk: gvk("A"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"trusted": {
-										referenceCount: 1,
-										nodeType:       parser.ObjectNode,
-										children:       map[string]*node{},
-									},
-								},
-							},
-						},
-					},
-				},
-				gvk("B"): {
-					gvk: gvk("B"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ObjectNode,
-								children: map[string]*node{
-									"trusted": {
-										referenceCount: 1,
-										nodeType:       parser.ObjectNode,
-										children:       map[string]*node{},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
+			toRemove:           id("bar"),
+			toCheck:            id("foo"),
+			wantConflictBefore: true,
+			wantConflictAfter:  true,
 		},
 		{
-			name: "Revert bad replace -- map",
-			ops: []testOp{
-				{
-					op:      upsert,
-					mutator: complexMutator("one", "spec[trusted: *]", "B"),
-				},
-				{
-					op:            upsert,
-					mutator:       complexMutator("many", "spec[trusted: thing].yep", "A", "B"),
-					errorExpected: false,
-				},
-				{
-					op:            upsert,
-					mutator:       complexMutator("many", "spec.trusted", "A", "B"),
-					errorExpected: true,
-					expectedError: "spec: node type conflict: List vs Object",
-				},
+			name: "conflicts are not transitive",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("foo"), "spec.name.image",
+					gvk("", "v1", "Role")),
+				newFakeMutator(id("bar"), "spec[name: foo].image",
+					gvk("", "v1", "Role"),
+					gvk("", "v2", "Role")),
+				newFakeMutator(id("qux"), "spec[name: foo].tag",
+					gvk("", "v2", "Role")),
 			},
-			expectedMutators: map[types.ID]MutatorWithSchema{
-				id("one"):  complexMutator("one", "spec[trusted: *]", "B"),
-				id("many"): complexMutator("many", "spec[trusted: thing].yep", "A", "B"),
+			toRemove: id("bar"),
+			// foo and bar are in conflict, but not qux.
+			toCheck:            id("qux"),
+			wantConflictBefore: false,
+			wantConflictAfter:  false,
+		},
+		{
+			name: "multiple conflicts are preserved",
+			before: []MutatorWithSchema{
+				newFakeMutator(id("foo"), "spec.name.image",
+					gvk("", "v1", "Role")),
+				newFakeMutator(id("bar"), "spec[name: rxc].image[tag: v1].id",
+					gvk("", "v1", "Role"),
+					gvk("", "v2", "Role")),
+				newFakeMutator(id("qux"), "spec[name: rxc].image.tag.id",
+					gvk("", "v2", "Role")),
 			},
-			expectedSchemas: map[schema.GroupVersionKind]*scheme{
-				gvk("A"): {
-					gvk: gvk("A"),
-					root: &node{
-						referenceCount: 1,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 1,
-								nodeType:       parser.ListNode,
-								keyField:       sp("trusted"),
-								child: &node{
-									referenceCount: 1,
-									nodeType:       parser.ObjectNode,
-									children:       map[string]*node{},
-								},
-							},
-						},
-					},
-				},
-				gvk("B"): {
-					gvk: gvk("B"),
-					root: &node{
-						referenceCount: 2,
-						nodeType:       parser.ObjectNode,
-						children: map[string]*node{
-							"spec": {
-								referenceCount: 2,
-								nodeType:       parser.ListNode,
-								keyField:       sp("trusted"),
-								child: &node{
-									referenceCount: 1,
-									nodeType:       parser.ObjectNode,
-									children:       map[string]*node{},
-								},
-							},
-						},
-					},
-				},
-			},
+			toRemove:           id("foo"),
+			toCheck:            id("qux"),
+			wantConflictBefore: true,
+			wantConflictAfter:  true,
 		},
 	}
-	for _, test := range tests {
-		tester := func(t *testing.T) {
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 			db := New()
-			testFn(test, db, t)
-		}
-		t.Run(test.name, tester)
-	}
-}
 
-const (
-	upsert = "upsert"
-	remove = "remove"
-)
-
-type testOp struct {
-	op            string
-	errorExpected bool
-	expectedError string
-	id            types.ID
-	mutator       *mockMutator
-}
-
-type testCase struct {
-	name             string
-	ops              []testOp
-	expectedMutators map[types.ID]MutatorWithSchema
-	expectedSchemas  map[schema.GroupVersionKind]*scheme
-}
-
-func testFn(test testCase, db *DB, t *testing.T) {
-	for _, op := range test.ops {
-		switch op.op {
-		case upsert:
-			err := db.Upsert(op.mutator)
-			if op.errorExpected != (err != nil) {
-				t.Errorf("error = %v, which is unexpected", err)
+			for _, m := range tc.before {
+				// Intentionally ignore errors here as in many cases previous Upserts
+				// would have returned errors, and that behavior is not under test.
+				_ = db.Upsert(m)
 			}
-			if op.expectedError != "" && err != nil && err.Error() != op.expectedError {
-				t.Errorf("error = %s, expected %s", err.Error(), op.expectedError)
+
+			gotConflictBefore := db.HasConflicts(tc.toCheck)
+			if gotConflictBefore != tc.wantConflictBefore {
+				t.Errorf("before Remove got HasConflicts(%v) = %t, want %t",
+					tc.toCheck, gotConflictBefore, tc.wantConflictBefore)
 			}
-		case remove:
-			db.Remove(op.id)
-		default:
-			t.Error("malformed test: unrecognized op")
-		}
-	}
-	if test.expectedSchemas != nil {
-		if !reflect.DeepEqual(db.schemas, test.expectedSchemas) {
-			t.Errorf("Difference in schemas: %v\n\n%s\n\n%s",
-				cmp.Diff(db.schemas, test.expectedSchemas, cmp.AllowUnexported(
-					scheme{},
-					node{},
-				)),
-				spew.Sdump(db.schemas),
-				spew.Sdump(test.expectedSchemas),
-			)
-		}
-	}
-	if test.expectedMutators != nil {
-		if !reflect.DeepEqual(db.mutators, test.expectedMutators) {
-			t.Errorf("Difference in mutators: %v", cmp.Diff(db.mutators, test.expectedMutators, cmp.AllowUnexported(
-				mockMutator{},
-			)))
-		}
+
+			db.Remove(tc.toRemove)
+			gotConflictAfter := db.HasConflicts(tc.toCheck)
+			if gotConflictAfter != tc.wantConflictAfter {
+				t.Errorf("after Remove got HasConflicts(%v) = %t, want %t",
+					tc.toCheck, gotConflictAfter, tc.wantConflictAfter)
+			}
+		})
 	}
 }

--- a/pkg/mutation/system.go
+++ b/pkg/mutation/system.go
@@ -48,10 +48,12 @@ func (s *System) Upsert(m types.Mutator) error {
 	toAdd := m.DeepCopy()
 
 	// Checking schema consistency only if the mutator has schema
+	var err error
 	if withSchema, ok := toAdd.(schema.MutatorWithSchema); ok {
 		err := s.schemaDB.Upsert(withSchema)
 		if err != nil {
-			return errors.Wrapf(err, "Schema upsert failed for %v", m.ID())
+			s.schemaDB.Remove(withSchema.ID())
+			return errors.Wrapf(err, "Schema upsert caused conflict for %v", m.ID())
 		}
 	}
 
@@ -63,19 +65,19 @@ func (s *System) Upsert(m types.Mutator) error {
 
 	if i == len(s.orderedMutators) { // Adding to the bottom of the list
 		s.orderedMutators = append(s.orderedMutators, toAdd)
-		return nil
+		return err
 	}
 
 	found := equal(s.orderedMutators[i].ID(), toAdd.ID())
 	if found {
 		s.orderedMutators[i] = toAdd
-		return nil
+		return err
 	}
 
 	s.orderedMutators = append(s.orderedMutators, nil)
 	copy(s.orderedMutators[i+1:], s.orderedMutators[i:])
 	s.orderedMutators[i] = toAdd
-	return nil
+	return err
 }
 
 // Mutate applies the mutation in place to the given object. Returns
@@ -89,15 +91,18 @@ func (s *System) Mutate(obj *unstructured.Unstructured, ns *corev1.Namespace) (b
 
 	var allAppliedMutations [][]types.Mutator
 	if *MutationLoggingEnabled || *MutationAnnotationsEnabled {
-		if allAppliedMutations == nil {
-			allAppliedMutations = [][]types.Mutator{}
-		}
+		allAppliedMutations = [][]types.Mutator{}
 	}
 
 	for i := 0; i < maxIterations; i++ {
-		appliedMutations := []types.Mutator{}
+		var appliedMutations []types.Mutator
 		old := obj.DeepCopy()
 		for _, m := range s.orderedMutators {
+			if s.schemaDB.HasConflicts(m.ID()) {
+				// Don't try to apply Mutators which have conflicts.
+				continue
+			}
+
 			if m.Matches(obj, ns) {
 				mutated, err := m.Mutate(obj)
 				if mutated && (*MutationLoggingEnabled || *MutationAnnotationsEnabled) {
@@ -228,7 +233,11 @@ func (s *System) Remove(id types.ID) error {
 
 // Get mutator for given id
 func (s *System) Get(id types.ID) types.Mutator {
-	return s.mutatorsMap[id].DeepCopy()
+	mutator, found := s.mutatorsMap[id]
+	if !found {
+		return nil
+	}
+	return mutator.DeepCopy()
 }
 
 func greaterOrEqual(id1, id2 types.ID) bool {

--- a/pkg/mutation/system_test.go
+++ b/pkg/mutation/system_test.go
@@ -5,41 +5,39 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Leveraging existing resource types to create custom mutators in order to validate
 // the cache.
-type MockMutator struct {
-	Mocked           types.ID
-	RelevantField    string // relevant for comparison
-	NotRelevantField string // not relevant for comparison
-	Labels           map[string]string
-	MutationCount    int
-	UnstableFor      int // makes the mutation unstable for the first n mutations
+type fakeMutator struct {
+	MID           types.ID
+	MPath         parser.Path // relevant for comparison
+	GVKs          []schema.GroupVersionKind
+	Labels        map[string]string
+	MutationCount int
+	UnstableFor   int // makes the mutation unstable for the first n mutations
 }
 
-func (m *MockMutator) Matches(obj runtime.Object, ns *corev1.Namespace) bool {
+func (m *fakeMutator) Matches(obj client.Object, ns *corev1.Namespace) bool {
 	return true // always matches
 }
 
-func (m *MockMutator) Mutate(obj *unstructured.Unstructured) (bool, error) {
-	m.MutationCount++
+func (m *fakeMutator) Mutate(obj *unstructured.Unstructured) (bool, error) {
 	if m.Labels == nil {
 		return false, nil
 	}
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return false, err
-	}
+	m.MutationCount++
 
-	current := accessor.GetLabels()
+	current := obj.GetLabels()
 	if current == nil {
 		current = make(map[string]string)
 	}
@@ -50,39 +48,37 @@ func (m *MockMutator) Mutate(obj *unstructured.Unstructured) (bool, error) {
 		}
 		current[k] = v
 	}
-	accessor.SetLabels(current)
+	obj.SetLabels(current)
 
 	return true, nil
 }
 
-func (m *MockMutator) ID() types.ID {
-	return m.Mocked
+func (m *fakeMutator) ID() types.ID {
+	return m.MID
 }
 
-func (m *MockMutator) Path() parser.Path {
-	return parser.Path{}
+func (m *fakeMutator) Path() parser.Path {
+	return m.MPath
 }
 
-func (m *MockMutator) Value() (interface{}, error) {
+func (m *fakeMutator) Value() (interface{}, error) {
 	return nil, nil
 }
 
-func (m *MockMutator) HasDiff(mutator types.Mutator) bool {
-	mock, ok := mutator.(*MockMutator)
-	if !ok {
-		return false
-	}
-	return m.RelevantField != mock.RelevantField
+func (m *fakeMutator) HasDiff(mutator types.Mutator) bool {
+	return !cmp.Equal(m, mutator, cmpopts.EquateEmpty())
 }
 
-func (m *MockMutator) DeepCopy() types.Mutator {
-	res := &MockMutator{
-		Mocked:           m.Mocked,
-		RelevantField:    m.RelevantField,
-		NotRelevantField: m.NotRelevantField,
-		MutationCount:    m.MutationCount,
-		UnstableFor:      m.UnstableFor,
+func (m *fakeMutator) DeepCopy() types.Mutator {
+	res := &fakeMutator{
+		MID:           m.MID,
+		MPath:         m.MPath.DeepCopy(),
+		GVKs:          make([]schema.GroupVersionKind, len(m.GVKs)),
+		MutationCount: m.MutationCount,
+		UnstableFor:   m.UnstableFor,
 	}
+	copy(res.GVKs, m.GVKs)
+
 	if m.Labels != nil {
 		if res.Labels == nil {
 			res.Labels = make(map[string]string)
@@ -94,17 +90,21 @@ func (m *MockMutator) DeepCopy() types.Mutator {
 	return res
 }
 
-func (m *MockMutator) String() string {
+func (m *fakeMutator) String() string {
 	return ""
 }
 
+func (m *fakeMutator) SchemaBindings() []schema.GroupVersionKind {
+	return m.GVKs
+}
+
 var mutators = []types.Mutator{
-	&MockMutator{Mocked: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
-	&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
-	&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
-	&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
-	&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
-	&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}},
+	&fakeMutator{MID: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+	&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
+	&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
+	&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
+	&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+	&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}},
 }
 
 func TestSorting(t *testing.T) {
@@ -118,12 +118,12 @@ func TestSorting(t *testing.T) {
 			tname:   "testsort",
 			initial: mutators,
 			expected: []types.Mutator{
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
-				&MockMutator{Mocked: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
+				&fakeMutator{MID: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 			},
 			action: func(s *System) error { return nil },
 		},
@@ -131,11 +131,11 @@ func TestSorting(t *testing.T) {
 			tname:   "testremove",
 			initial: mutators,
 			expected: []types.Mutator{
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
-				&MockMutator{Mocked: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
+				&fakeMutator{MID: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 			},
 			action: func(s *System) error {
 				return s.Remove(types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"})
@@ -145,32 +145,32 @@ func TestSorting(t *testing.T) {
 			tname:   "testaddingsame",
 			initial: mutators,
 			expected: []types.Mutator{
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
-				&MockMutator{Mocked: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
+				&fakeMutator{MID: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 			},
 			action: func(s *System) error {
-				return s.Upsert(&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"},
-					NotRelevantField: "notrelevantvalue"})
+				return s.Upsert(&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}})
 			},
 		},
 		{
 			tname:   "testaddingdifferent",
 			initial: mutators,
 			expected: []types.Mutator{
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"}, RelevantField: "relevantvalue"},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
-				&MockMutator{Mocked: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"},
+					MPath: mustParse("relevantvalue"), GVKs: []schema.GroupVersionKind{{Kind: "foo"}}},
+				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
+				&fakeMutator{MID: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 			},
 			action: func(s *System) error {
-				return s.Upsert(&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"},
-					RelevantField: "relevantvalue"})
+				return s.Upsert(&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "aaa"},
+					MPath: mustParse("relevantvalue"), GVKs: []schema.GroupVersionKind{{Kind: "foo"}}})
 			},
 		},
 	}
@@ -192,16 +192,16 @@ func TestSorting(t *testing.T) {
 				t.Errorf("%s: Expected %d object from the operator, found %d", tc.tname, len(c.orderedMutators), len(tc.expected))
 			}
 
-			if !cmp.Equal(c.orderedMutators, tc.expected) {
-				t.Errorf("%s: Cache content is not consistent: %s", tc.tname, cmp.Diff(c.orderedMutators, tc.expected))
+			if diff := cmp.Diff(tc.expected, c.orderedMutators, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("%s: Cache content is not consistent: %s", tc.tname, diff)
 			}
 
 			expectedMap := make(map[types.ID]types.Mutator)
 			for _, m := range tc.expected {
 				expectedMap[m.ID()] = m
 			}
-			if !cmp.Equal(c.mutatorsMap, expectedMap) {
-				t.Errorf("%s: Cache content (map) is not consistent: %s", tc.tname, cmp.Diff(c.mutatorsMap, expectedMap))
+			if diff := cmp.Diff(expectedMap, c.mutatorsMap, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("%s: Cache content (map) is not consistent: %s", tc.tname, diff)
 			}
 		})
 	}
@@ -210,18 +210,18 @@ func TestSorting(t *testing.T) {
 func TestMutation(t *testing.T) {
 	table := []struct {
 		tname              string
-		mutations          [](*MockMutator)
+		mutations          []*fakeMutator
 		expectedLabels     map[string]string
 		expectedIterations int
 		expectError        bool
 	}{
 		{
 			tname: "mutate",
-			mutations: [](*MockMutator){
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}, Labels: map[string]string{
+			mutations: []*fakeMutator{
+				{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}, Labels: map[string]string{
 					"ka": "va",
 				}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "bbb"}, Labels: map[string]string{
+				{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "bbb"}, Labels: map[string]string{
 					"kb": "vb",
 				}},
 			},
@@ -233,11 +233,11 @@ func TestMutation(t *testing.T) {
 		},
 		{
 			tname: "neverconverge",
-			mutations: [](*MockMutator){
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}, Labels: map[string]string{
+			mutations: []*fakeMutator{
+				{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}, Labels: map[string]string{
 					"ka": "va",
 				}, UnstableFor: 5},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "bbb"}, Labels: map[string]string{
+				{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "bbb"}, Labels: map[string]string{
 					"kb": "vb",
 				}},
 			},
@@ -245,17 +245,17 @@ func TestMutation(t *testing.T) {
 		},
 		{
 			tname: "convergeafter3",
-			mutations: [](*MockMutator){
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}, Labels: map[string]string{
+			mutations: []*fakeMutator{
+				{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}, Labels: map[string]string{
 					"ka": "va",
 				}, UnstableFor: 3},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "bbb"}, Labels: map[string]string{
+				{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "bbb"}, Labels: map[string]string{
 					"kb": "vb",
 				}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "ccc"}, Labels: map[string]string{
+				{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "ccc"}, Labels: map[string]string{
 					"kb": "vb",
 				}},
-				&MockMutator{Mocked: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "ddd"}, Labels: map[string]string{
+				{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "ddd"}, Labels: map[string]string{
 					"kb": "vb",
 				}},
 			},
@@ -301,25 +301,203 @@ func TestMutation(t *testing.T) {
 				t.Fatal(tc.tname, "Mutate failed unexpectedly", err)
 			}
 
-			accessor, err := meta.Accessor(toMutate)
-			if err != nil {
-				t.Fatal("Failed to get unstruct accessor", err)
-			}
-
-			newLabels := accessor.GetLabels()
+			newLabels := toMutate.GetLabels()
 
 			if !mutated {
-				t.Error(tc.tname, "Mutation not as expected", cmp.Diff(newLabels, tc.expectedLabels))
+				t.Error(tc.tname, "Mutation not as expected", cmp.Diff(tc.expectedLabels, newLabels))
 			}
 
-			if !cmp.Equal(newLabels, tc.expectedLabels) {
-				t.Error(tc.tname, "Mutation not as expected", cmp.Diff(newLabels, tc.expectedLabels))
+			if diff := cmp.Diff(tc.expectedLabels, newLabels); diff != "" {
+				t.Error(tc.tname, "Mutation not as expected", diff)
 			}
 
-			probe := c.orderedMutators[0].(*MockMutator) // fetching a mock mutator to check the number of iterations
+			probe := c.orderedMutators[0].(*fakeMutator) // fetching a mock mutator to check the number of iterations
 			if probe.MutationCount != tc.expectedIterations {
 				t.Error(tc.tname, "Expected %d  mutation iterations, got", tc.expectedIterations, tc.mutations[0].MutationCount)
 			}
 		})
+	}
+}
+
+func mustParse(s string) parser.Path {
+	p, err := parser.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func TestSystem_DontApplyConflictingMutations(t *testing.T) {
+	// Two conflicting mutators.
+	foo := &fakeMutator{
+		MID:    types.ID{Name: "foo"},
+		MPath:  mustParse("spec.containers[name: foo].image"),
+		GVKs:   []schema.GroupVersionKind{{Version: "v1", Kind: "Pod"}},
+		Labels: map[string]string{"active": "true"},
+	}
+	fooConflict := &fakeMutator{
+		MID:    types.ID{Name: "foo-conflict"},
+		MPath:  mustParse("spec.containers.image"),
+		GVKs:   []schema.GroupVersionKind{{Version: "v1", Kind: "Pod"}},
+		Labels: map[string]string{"active": "true"},
+	}
+
+	s := NewSystem()
+	err := s.Upsert(foo)
+	if err != nil {
+		t.Fatalf("got Upsert() error = %v, want <nil>", err)
+	}
+
+	// We can mutate objects before System is put in an inconsistent state.
+	t.Run("mutate works on consistent state", func(t *testing.T) {
+		u := &unstructured.Unstructured{}
+		gotMutated, gotErr := s.Mutate(u, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "billing"}})
+		if !gotMutated {
+			t.Errorf("got Mutate() = %t, want true", gotMutated)
+		}
+		if gotErr != nil {
+			t.Fatalf("got Mutate() error = %v, want <nil>", gotErr)
+		}
+	})
+
+	// Put System in an inconsistent state.
+	err = s.Upsert(fooConflict)
+	if err == nil {
+		t.Fatalf("got Upsert() error = %v, want error", err)
+	}
+
+	// Since foo and foo-conflict define conflicting schemas, neither is executed.
+	// TODO(willbeason): Fix once System is updated to properly report conflicts (#1216).
+	//  Should be "no mutation on inconsistent state".
+	t.Run("mutation on inconsistent state", func(t *testing.T) {
+		u2 := &unstructured.Unstructured{}
+		gotMutated, gotErr := s.Mutate(u2, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "billing"}})
+		if !gotMutated {
+			t.Errorf("got Mutate() = %t, want true", gotMutated)
+		}
+		// if gotMutated {
+		// 	t.Errorf("got Mutate() = %t, want false", gotMutated)
+		// }
+		if gotErr != nil {
+			t.Fatalf("got Mutate() error = %v, want <nil>", gotErr)
+		}
+	})
+
+	// Get the system back to a consistent state.
+	err = s.Remove(types.ID{Name: "foo-conflict"})
+	if err != nil {
+		t.Fatalf("got Remove() error = %v, want <nil>", err)
+	}
+
+	// Mutations are performed again.
+	t.Run("mutations performed after conflict removed", func(t *testing.T) {
+		u3 := &unstructured.Unstructured{}
+		gotMutated, gotErr := s.Mutate(u3, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "billing"}})
+		if !gotMutated {
+			t.Errorf("got Mutate() = %t, want true", gotMutated)
+		}
+		if gotErr != nil {
+			t.Fatalf("got Mutate() error = %v, want <nil>", gotErr)
+		}
+	})
+}
+
+func TestSystem_DontApplyConflictingMutationsRemoveOriginal(t *testing.T) {
+	// Two conflicting mutators.
+	foo := &fakeMutator{
+		MID:    types.ID{Name: "foo"},
+		MPath:  mustParse("spec.containers[name: foo].image"),
+		GVKs:   []schema.GroupVersionKind{{Version: "v1", Kind: "Pod"}},
+		Labels: map[string]string{"active": "true"},
+	}
+	fooConflict := &fakeMutator{
+		MID:    types.ID{Name: "foo-conflict"},
+		MPath:  mustParse("spec.containers.image"),
+		GVKs:   []schema.GroupVersionKind{{Version: "v1", Kind: "Pod"}},
+		Labels: map[string]string{"active": "true"},
+	}
+
+	// Put System in an inconsistent state.
+	s := NewSystem()
+	err := s.Upsert(foo)
+	if err != nil {
+		t.Fatalf("got Upsert() error = %v, want <nil>", err)
+	}
+	err = s.Upsert(fooConflict)
+	if err == nil {
+		t.Fatalf("got Upsert() error = %v, want error", err)
+	}
+	gotErr := s.Remove(types.ID{Name: "foo"})
+	if gotErr != nil {
+		t.Fatalf("got Remove() error = %v, want <nil>", gotErr)
+	}
+
+	u := &unstructured.Unstructured{}
+	gotMutated, gotErr := s.Mutate(u, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "billing"}})
+	if gotMutated {
+		t.Errorf("got Mutate() = %t, want false", gotMutated)
+	}
+	if gotErr != nil {
+		t.Fatalf("got Mutate() error = %v, want <nil>", gotErr)
+	}
+}
+
+func id(name string) types.ID {
+	return types.ID{Name: name}
+}
+
+func TestSystem_EarliestConflictingMutatorWins(t *testing.T) {
+	// Two conflicting mutators.
+	foo := &fakeMutator{
+		MID:    id("foo"),
+		MPath:  mustParse("spec.containers[name: foo].image"),
+		GVKs:   []schema.GroupVersionKind{{Version: "v1", Kind: "Pod"}},
+		Labels: map[string]string{"active": "true"},
+	}
+	fooConflict := &fakeMutator{
+		MID:    id("foo-conflict"),
+		MPath:  mustParse("spec.containers.image"),
+		GVKs:   []schema.GroupVersionKind{{Version: "v1", Kind: "Pod"}},
+		Labels: map[string]string{"active": "true"},
+	}
+	// A non-conflicting mutator on the same type.
+	bar := &fakeMutator{
+		MID:    id("bar"),
+		MPath:  mustParse("spec.images[name: nginx].tag"),
+		GVKs:   []schema.GroupVersionKind{{Version: "v1", Kind: "Pod"}},
+		Labels: map[string]string{"active": "true"},
+	}
+
+	// Put System in an inconsistent state.
+	s := NewSystem()
+	err := s.Upsert(foo)
+	if err != nil {
+		t.Fatalf("got Upsert() error = %v, want <nil>", err)
+	}
+	err = s.Upsert(fooConflict)
+	if err == nil {
+		t.Fatalf("got Upsert() error = %v, want error", err)
+	}
+	err = s.Upsert(bar)
+	if err != nil {
+		t.Fatalf("got Upsert() error = %v, want <nil>", err)
+	}
+
+	u := &unstructured.Unstructured{}
+	gotMutated, gotErr := s.Mutate(u, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "billing"}})
+	if !gotMutated {
+		t.Errorf("got Mutate() = %t, want true", gotMutated)
+	}
+	if gotErr != nil {
+		t.Fatalf("got Mutate() error = %v, want <nil>", gotErr)
+	}
+	if s.Get(id("foo")).(*fakeMutator).MutationCount != 2 {
+		t.Errorf("got foo.MutationCount == %d, want 2", foo.MutationCount)
+	}
+	if s.Get(id("foo-conflict")) != nil {
+		t.Errorf("got fooConflict.MutationCount == %d, want 0", fooConflict.MutationCount)
+	}
+	if s.Get(id("bar")).(*fakeMutator).MutationCount != 2 {
+		t.Errorf("got bar.MutationCount == %d, want 2", bar.MutationCount)
 	}
 }

--- a/pkg/mutation/types/mutator.go
+++ b/pkg/mutation/types/mutator.go
@@ -2,12 +2,13 @@ package types
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -19,10 +20,16 @@ type ID struct {
 	Name      string
 }
 
+func (id ID) String() string {
+	return fmt.Sprintf("%v %v",
+		schema.GroupKind{Group: id.Group, Kind: id.Kind},
+		client.ObjectKey{Namespace: id.Namespace, Name: id.Name})
+}
+
 // Mutator represent a mutation object.
 type Mutator interface {
 	// Matches tells if the given object is eligible for this mutation.
-	Matches(obj runtime.Object, ns *corev1.Namespace) bool
+	Matches(obj client.Object, ns *corev1.Namespace) bool
 	// Mutate applies the mutation to the given object
 	Mutate(obj *unstructured.Unstructured) (bool, error)
 	// ID returns the id of the current mutator.

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -1,0 +1,7 @@
+package util
+
+type Error string
+
+func (e Error) Error() string {
+	return string(e)
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
@@ -1,0 +1,156 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cmpopts provides common options for the cmp package.
+package cmpopts
+
+import (
+	"math"
+	"reflect"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"golang.org/x/xerrors"
+)
+
+func equateAlways(_, _ interface{}) bool { return true }
+
+// EquateEmpty returns a Comparer option that determines all maps and slices
+// with a length of zero to be equal, regardless of whether they are nil.
+//
+// EquateEmpty can be used in conjunction with SortSlices and SortMaps.
+func EquateEmpty() cmp.Option {
+	return cmp.FilterValues(isEmpty, cmp.Comparer(equateAlways))
+}
+
+func isEmpty(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Slice || vx.Kind() == reflect.Map) &&
+		(vx.Len() == 0 && vy.Len() == 0)
+}
+
+// EquateApprox returns a Comparer option that determines float32 or float64
+// values to be equal if they are within a relative fraction or absolute margin.
+// This option is not used when either x or y is NaN or infinite.
+//
+// The fraction determines that the difference of two values must be within the
+// smaller fraction of the two values, while the margin determines that the two
+// values must be within some absolute margin.
+// To express only a fraction or only a margin, use 0 for the other parameter.
+// The fraction and margin must be non-negative.
+//
+// The mathematical expression used is equivalent to:
+//	|x-y| ≤ max(fraction*min(|x|, |y|), margin)
+//
+// EquateApprox can be used in conjunction with EquateNaNs.
+func EquateApprox(fraction, margin float64) cmp.Option {
+	if margin < 0 || fraction < 0 || math.IsNaN(margin) || math.IsNaN(fraction) {
+		panic("margin or fraction must be a non-negative number")
+	}
+	a := approximator{fraction, margin}
+	return cmp.Options{
+		cmp.FilterValues(areRealF64s, cmp.Comparer(a.compareF64)),
+		cmp.FilterValues(areRealF32s, cmp.Comparer(a.compareF32)),
+	}
+}
+
+type approximator struct{ frac, marg float64 }
+
+func areRealF64s(x, y float64) bool {
+	return !math.IsNaN(x) && !math.IsNaN(y) && !math.IsInf(x, 0) && !math.IsInf(y, 0)
+}
+func areRealF32s(x, y float32) bool {
+	return areRealF64s(float64(x), float64(y))
+}
+func (a approximator) compareF64(x, y float64) bool {
+	relMarg := a.frac * math.Min(math.Abs(x), math.Abs(y))
+	return math.Abs(x-y) <= math.Max(a.marg, relMarg)
+}
+func (a approximator) compareF32(x, y float32) bool {
+	return a.compareF64(float64(x), float64(y))
+}
+
+// EquateNaNs returns a Comparer option that determines float32 and float64
+// NaN values to be equal.
+//
+// EquateNaNs can be used in conjunction with EquateApprox.
+func EquateNaNs() cmp.Option {
+	return cmp.Options{
+		cmp.FilterValues(areNaNsF64s, cmp.Comparer(equateAlways)),
+		cmp.FilterValues(areNaNsF32s, cmp.Comparer(equateAlways)),
+	}
+}
+
+func areNaNsF64s(x, y float64) bool {
+	return math.IsNaN(x) && math.IsNaN(y)
+}
+func areNaNsF32s(x, y float32) bool {
+	return areNaNsF64s(float64(x), float64(y))
+}
+
+// EquateApproxTime returns a Comparer option that determines two non-zero
+// time.Time values to be equal if they are within some margin of one another.
+// If both times have a monotonic clock reading, then the monotonic time
+// difference will be used. The margin must be non-negative.
+func EquateApproxTime(margin time.Duration) cmp.Option {
+	if margin < 0 {
+		panic("margin must be a non-negative number")
+	}
+	a := timeApproximator{margin}
+	return cmp.FilterValues(areNonZeroTimes, cmp.Comparer(a.compare))
+}
+
+func areNonZeroTimes(x, y time.Time) bool {
+	return !x.IsZero() && !y.IsZero()
+}
+
+type timeApproximator struct {
+	margin time.Duration
+}
+
+func (a timeApproximator) compare(x, y time.Time) bool {
+	// Avoid subtracting times to avoid overflow when the
+	// difference is larger than the largest representible duration.
+	if x.After(y) {
+		// Ensure x is always before y
+		x, y = y, x
+	}
+	// We're within the margin if x+margin >= y.
+	// Note: time.Time doesn't have AfterOrEqual method hence the negation.
+	return !x.Add(a.margin).Before(y)
+}
+
+// AnyError is an error that matches any non-nil error.
+var AnyError anyError
+
+type anyError struct{}
+
+func (anyError) Error() string     { return "any error" }
+func (anyError) Is(err error) bool { return err != nil }
+
+// EquateErrors returns a Comparer option that determines errors to be equal
+// if errors.Is reports them to match. The AnyError error can be used to
+// match any non-nil error.
+func EquateErrors() cmp.Option {
+	return cmp.FilterValues(areConcreteErrors, cmp.Comparer(compareErrors))
+}
+
+// areConcreteErrors reports whether x and y are types that implement error.
+// The input types are deliberately of the interface{} type rather than the
+// error type so that we can handle situations where the current type is an
+// interface{}, but the underlying concrete types both happen to implement
+// the error interface.
+func areConcreteErrors(x, y interface{}) bool {
+	_, ok1 := x.(error)
+	_, ok2 := y.(error)
+	return ok1 && ok2
+}
+
+func compareErrors(x, y interface{}) bool {
+	xe := x.(error)
+	ye := y.(error)
+	// TODO(≥go1.13): Use standard definition of errors.Is.
+	return xerrors.Is(xe, ye) || xerrors.Is(ye, xe)
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
@@ -1,0 +1,206 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// IgnoreFields returns an Option that ignores fields of the
+// given names on a single struct type. It respects the names of exported fields
+// that are forwarded due to struct embedding.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to ignore a
+// specific sub-field that is embedded or nested within the parent struct.
+func IgnoreFields(typ interface{}, names ...string) cmp.Option {
+	sf := newStructFilter(typ, names...)
+	return cmp.FilterPath(sf.filter, cmp.Ignore())
+}
+
+// IgnoreTypes returns an Option that ignores all values assignable to
+// certain types, which are specified by passing in a value of each type.
+func IgnoreTypes(typs ...interface{}) cmp.Option {
+	tf := newTypeFilter(typs...)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type typeFilter []reflect.Type
+
+func newTypeFilter(typs ...interface{}) (tf typeFilter) {
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil {
+			// This occurs if someone tries to pass in sync.Locker(nil)
+			panic("cannot determine type; consider using IgnoreInterfaces")
+		}
+		tf = append(tf, t)
+	}
+	return tf
+}
+func (tf typeFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreInterfaces returns an Option that ignores all values or references of
+// values assignable to certain interface types. These interfaces are specified
+// by passing in an anonymous struct with the interface types embedded in it.
+// For example, to ignore sync.Locker, pass in struct{sync.Locker}{}.
+func IgnoreInterfaces(ifaces interface{}) cmp.Option {
+	tf := newIfaceFilter(ifaces)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type ifaceFilter []reflect.Type
+
+func newIfaceFilter(ifaces interface{}) (tf ifaceFilter) {
+	t := reflect.TypeOf(ifaces)
+	if ifaces == nil || t.Name() != "" || t.Kind() != reflect.Struct {
+		panic("input must be an anonymous struct")
+	}
+	for i := 0; i < t.NumField(); i++ {
+		fi := t.Field(i)
+		switch {
+		case !fi.Anonymous:
+			panic("struct cannot have named fields")
+		case fi.Type.Kind() != reflect.Interface:
+			panic("embedded field must be an interface type")
+		case fi.Type.NumMethod() == 0:
+			// This matches everything; why would you ever want this?
+			panic("cannot ignore empty interface")
+		default:
+			tf = append(tf, fi.Type)
+		}
+	}
+	return tf
+}
+func (tf ifaceFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p.Last().Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+		if t.Kind() != reflect.Ptr && reflect.PtrTo(t).AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreUnexported returns an Option that only ignores the immediate unexported
+// fields of a struct, including anonymous fields of unexported types.
+// In particular, unexported fields within the struct's exported fields
+// of struct types, including anonymous fields, will not be ignored unless the
+// type of the field itself is also passed to IgnoreUnexported.
+//
+// Avoid ignoring unexported fields of a type which you do not control (i.e. a
+// type from another repository), as changes to the implementation of such types
+// may change how the comparison behaves. Prefer a custom Comparer instead.
+func IgnoreUnexported(typs ...interface{}) cmp.Option {
+	ux := newUnexportedFilter(typs...)
+	return cmp.FilterPath(ux.filter, cmp.Ignore())
+}
+
+type unexportedFilter struct{ m map[reflect.Type]bool }
+
+func newUnexportedFilter(typs ...interface{}) unexportedFilter {
+	ux := unexportedFilter{m: make(map[reflect.Type]bool)}
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil || t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
+		}
+		ux.m[t] = true
+	}
+	return ux
+}
+func (xf unexportedFilter) filter(p cmp.Path) bool {
+	sf, ok := p.Index(-1).(cmp.StructField)
+	if !ok {
+		return false
+	}
+	return xf.m[p.Index(-2).Type()] && !isExported(sf.Name())
+}
+
+// isExported reports whether the identifier is exported.
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}
+
+// IgnoreSliceElements returns an Option that ignores elements of []V.
+// The discard function must be of the form "func(T) bool" which is used to
+// ignore slice elements of type V, where V is assignable to T.
+// Elements are ignored if the function reports true.
+func IgnoreSliceElements(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.ValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		si, ok := p.Index(-1).(cmp.SliceIndex)
+		if !ok {
+			return false
+		}
+		if !si.Type().AssignableTo(vf.Type().In(0)) {
+			return false
+		}
+		vx, vy := si.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}
+
+// IgnoreMapEntries returns an Option that ignores entries of map[K]V.
+// The discard function must be of the form "func(T, R) bool" which is used to
+// ignore map entries of type K and V, where K and V are assignable to T and R.
+// Entries are ignored if the function reports true.
+func IgnoreMapEntries(discardFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(discardFunc)
+	if !function.IsType(vf.Type(), function.KeyValuePredicate) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid discard function: %T", discardFunc))
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		mi, ok := p.Index(-1).(cmp.MapIndex)
+		if !ok {
+			return false
+		}
+		if !mi.Key().Type().AssignableTo(vf.Type().In(0)) || !mi.Type().AssignableTo(vf.Type().In(1)) {
+			return false
+		}
+		k := mi.Key()
+		vx, vy := mi.Values()
+		if vx.IsValid() && vf.Call([]reflect.Value{k, vx})[0].Bool() {
+			return true
+		}
+		if vy.IsValid() && vf.Call([]reflect.Value{k, vy})[0].Bool() {
+			return true
+		}
+		return false
+	}, cmp.Ignore())
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
@@ -1,0 +1,147 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/internal/function"
+)
+
+// SortSlices returns a Transformer option that sorts all []V.
+// The less function must be of the form "func(T, T) bool" which is used to
+// sort any slice with element type V that is assignable to T.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//
+// The less function does not have to be "total". That is, if !less(x, y) and
+// !less(y, x) for two elements x and y, their relative order is maintained.
+//
+// SortSlices can be used in conjunction with EquateEmpty.
+func SortSlices(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ss := sliceSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ss.filter, cmp.Transformer("cmpopts.SortSlices", ss.sort))
+}
+
+type sliceSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ss sliceSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	if !(x != nil && y != nil && vx.Type() == vy.Type()) ||
+		!(vx.Kind() == reflect.Slice && vx.Type().Elem().AssignableTo(ss.in)) ||
+		(vx.Len() <= 1 && vy.Len() <= 1) {
+		return false
+	}
+	// Check whether the slices are already sorted to avoid an infinite
+	// recursion cycle applying the same transform to itself.
+	ok1 := sort.SliceIsSorted(x, func(i, j int) bool { return ss.less(vx, i, j) })
+	ok2 := sort.SliceIsSorted(y, func(i, j int) bool { return ss.less(vy, i, j) })
+	return !ok1 || !ok2
+}
+func (ss sliceSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	dst := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+	for i := 0; i < src.Len(); i++ {
+		dst.Index(i).Set(src.Index(i))
+	}
+	sort.SliceStable(dst.Interface(), func(i, j int) bool { return ss.less(dst, i, j) })
+	ss.checkSort(dst)
+	return dst.Interface()
+}
+func (ss sliceSorter) checkSort(v reflect.Value) {
+	start := -1 // Start of a sequence of equal elements.
+	for i := 1; i < v.Len(); i++ {
+		if ss.less(v, i-1, i) {
+			// Check that first and last elements in v[start:i] are equal.
+			if start >= 0 && (ss.less(v, start, i-1) || ss.less(v, i-1, start)) {
+				panic(fmt.Sprintf("incomparable values detected: want equal elements: %v", v.Slice(start, i)))
+			}
+			start = -1
+		} else if start == -1 {
+			start = i
+		}
+	}
+}
+func (ss sliceSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i), v.Index(j)
+	return ss.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}
+
+// SortMaps returns a Transformer option that flattens map[K]V types to be a
+// sorted []struct{K, V}. The less function must be of the form
+// "func(T, T) bool" which is used to sort any map with key K that is
+// assignable to T.
+//
+// Flattening the map into a slice has the property that cmp.Equal is able to
+// use Comparers on K or the K.Equal method if it exists.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//	• Total: if x != y, then either less(x, y) or less(y, x)
+//
+// SortMaps can be used in conjunction with EquateEmpty.
+func SortMaps(lessFunc interface{}) cmp.Option {
+	vf := reflect.ValueOf(lessFunc)
+	if !function.IsType(vf.Type(), function.Less) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", lessFunc))
+	}
+	ms := mapSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ms.filter, cmp.Transformer("cmpopts.SortMaps", ms.sort))
+}
+
+type mapSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ms mapSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Map && vx.Type().Key().AssignableTo(ms.in)) &&
+		(vx.Len() != 0 || vy.Len() != 0)
+}
+func (ms mapSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	outType := reflect.StructOf([]reflect.StructField{
+		{Name: "K", Type: src.Type().Key()},
+		{Name: "V", Type: src.Type().Elem()},
+	})
+	dst := reflect.MakeSlice(reflect.SliceOf(outType), src.Len(), src.Len())
+	for i, k := range src.MapKeys() {
+		v := reflect.New(outType).Elem()
+		v.Field(0).Set(k)
+		v.Field(1).Set(src.MapIndex(k))
+		dst.Index(i).Set(v)
+	}
+	sort.Slice(dst.Interface(), func(i, j int) bool { return ms.less(dst, i, j) })
+	ms.checkSort(dst)
+	return dst.Interface()
+}
+func (ms mapSorter) checkSort(v reflect.Value) {
+	for i := 1; i < v.Len(); i++ {
+		if !ms.less(v, i-1, i) {
+			panic(fmt.Sprintf("partial order detected: want %v < %v", v.Index(i-1), v.Index(i)))
+		}
+	}
+}
+func (ms mapSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i).Field(0), v.Index(j).Field(0)
+	return ms.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
@@ -1,0 +1,187 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// filterField returns a new Option where opt is only evaluated on paths that
+// include a specific exported field on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to select a
+// specific sub-field that is embedded or nested within the parent struct.
+func filterField(typ interface{}, name string, opt cmp.Option) cmp.Option {
+	// TODO: This is currently unexported over concerns of how helper filters
+	// can be composed together easily.
+	// TODO: Add tests for FilterField.
+
+	sf := newStructFilter(typ, name)
+	return cmp.FilterPath(sf.filter, opt)
+}
+
+type structFilter struct {
+	t  reflect.Type // The root struct type to match on
+	ft fieldTree    // Tree of fields to match on
+}
+
+func newStructFilter(typ interface{}, names ...string) structFilter {
+	// TODO: Perhaps allow * as a special identifier to allow ignoring any
+	// number of path steps until the next field match?
+	// This could be useful when a concrete struct gets transformed into
+	// an anonymous struct where it is not possible to specify that by type,
+	// but the transformer happens to provide guarantees about the names of
+	// the transformed fields.
+
+	t := reflect.TypeOf(typ)
+	if t == nil || t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("%T must be a non-pointer struct", typ))
+	}
+	var ft fieldTree
+	for _, name := range names {
+		cname, err := canonicalName(t, name)
+		if err != nil {
+			panic(fmt.Sprintf("%s: %v", strings.Join(cname, "."), err))
+		}
+		ft.insert(cname)
+	}
+	return structFilter{t, ft}
+}
+
+func (sf structFilter) filter(p cmp.Path) bool {
+	for i, ps := range p {
+		if ps.Type().AssignableTo(sf.t) && sf.ft.matchPrefix(p[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldTree represents a set of dot-separated identifiers.
+//
+// For example, inserting the following selectors:
+//	Foo
+//	Foo.Bar.Baz
+//	Foo.Buzz
+//	Nuka.Cola.Quantum
+//
+// Results in a tree of the form:
+//	{sub: {
+//		"Foo": {ok: true, sub: {
+//			"Bar": {sub: {
+//				"Baz": {ok: true},
+//			}},
+//			"Buzz": {ok: true},
+//		}},
+//		"Nuka": {sub: {
+//			"Cola": {sub: {
+//				"Quantum": {ok: true},
+//			}},
+//		}},
+//	}}
+type fieldTree struct {
+	ok  bool                 // Whether this is a specified node
+	sub map[string]fieldTree // The sub-tree of fields under this node
+}
+
+// insert inserts a sequence of field accesses into the tree.
+func (ft *fieldTree) insert(cname []string) {
+	if ft.sub == nil {
+		ft.sub = make(map[string]fieldTree)
+	}
+	if len(cname) == 0 {
+		ft.ok = true
+		return
+	}
+	sub := ft.sub[cname[0]]
+	sub.insert(cname[1:])
+	ft.sub[cname[0]] = sub
+}
+
+// matchPrefix reports whether any selector in the fieldTree matches
+// the start of path p.
+func (ft fieldTree) matchPrefix(p cmp.Path) bool {
+	for _, ps := range p {
+		switch ps := ps.(type) {
+		case cmp.StructField:
+			ft = ft.sub[ps.Name()]
+			if ft.ok {
+				return true
+			}
+			if len(ft.sub) == 0 {
+				return false
+			}
+		case cmp.Indirect:
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// canonicalName returns a list of identifiers where any struct field access
+// through an embedded field is expanded to include the names of the embedded
+// types themselves.
+//
+// For example, suppose field "Foo" is not directly in the parent struct,
+// but actually from an embedded struct of type "Bar". Then, the canonical name
+// of "Foo" is actually "Bar.Foo".
+//
+// Suppose field "Foo" is not directly in the parent struct, but actually
+// a field in two different embedded structs of types "Bar" and "Baz".
+// Then the selector "Foo" causes a panic since it is ambiguous which one it
+// refers to. The user must specify either "Bar.Foo" or "Baz.Foo".
+func canonicalName(t reflect.Type, sel string) ([]string, error) {
+	var name string
+	sel = strings.TrimPrefix(sel, ".")
+	if sel == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if i := strings.IndexByte(sel, '.'); i < 0 {
+		name, sel = sel, ""
+	} else {
+		name, sel = sel[:i], sel[i:]
+	}
+
+	// Type must be a struct or pointer to struct.
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%v must be a struct", t)
+	}
+
+	// Find the canonical name for this current field name.
+	// If the field exists in an embedded struct, then it will be expanded.
+	sf, _ := t.FieldByName(name)
+	if !isExported(name) {
+		// Avoid using reflect.Type.FieldByName for unexported fields due to
+		// buggy behavior with regard to embeddeding and unexported fields.
+		// See https://golang.org/issue/4876 for details.
+		sf = reflect.StructField{}
+		for i := 0; i < t.NumField() && sf.Name == ""; i++ {
+			if t.Field(i).Name == name {
+				sf = t.Field(i)
+			}
+		}
+	}
+	if sf.Name == "" {
+		return []string{name}, fmt.Errorf("does not exist")
+	}
+	var ss []string
+	for i := range sf.Index {
+		ss = append(ss, t.FieldByIndex(sf.Index[:i+1]).Name)
+	}
+	if sel == "" {
+		return ss, nil
+	}
+	ssPost, err := canonicalName(sf.Type, sel)
+	return append(ss, ssPost...), err
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/xform.go
@@ -1,0 +1,35 @@
+// Copyright 2018, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmpopts
+
+import (
+	"github.com/google/go-cmp/cmp"
+)
+
+type xformFilter struct{ xform cmp.Option }
+
+func (xf xformFilter) filter(p cmp.Path) bool {
+	for _, ps := range p {
+		if t, ok := ps.(cmp.Transform); ok && t.Option() == xf.xform {
+			return false
+		}
+	}
+	return true
+}
+
+// AcyclicTransformer returns a Transformer with a filter applied that ensures
+// that the transformer cannot be recursively applied upon its own output.
+//
+// An example use case is a transformer that splits a string by lines:
+//	AcyclicTransformer("SplitLines", func(s string) []string{
+//		return strings.Split(s, "\n")
+//	})
+//
+// Had this been an unfiltered Transformer instead, this would result in an
+// infinite cycle converting a string to []string to [][]string and so on.
+func AcyclicTransformer(name string, xformFunc interface{}) cmp.Option {
+	xf := xformFilter{cmp.Transformer(name, xformFunc)}
+	return cmp.FilterPath(xf.filter, xf.xform)
+}

--- a/vendor/golang.org/x/xerrors/LICENSE
+++ b/vendor/golang.org/x/xerrors/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2019 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/xerrors/PATENTS
+++ b/vendor/golang.org/x/xerrors/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/xerrors/README
+++ b/vendor/golang.org/x/xerrors/README
@@ -1,0 +1,2 @@
+This repository holds the transition packages for the new Go 1.13 error values.
+See golang.org/design/29934-error-values.

--- a/vendor/golang.org/x/xerrors/adaptor.go
+++ b/vendor/golang.org/x/xerrors/adaptor.go
@@ -1,0 +1,193 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"strconv"
+)
+
+// FormatError calls the FormatError method of f with an errors.Printer
+// configured according to s and verb, and writes the result to s.
+func FormatError(f Formatter, s fmt.State, verb rune) {
+	// Assuming this function is only called from the Format method, and given
+	// that FormatError takes precedence over Format, it cannot be called from
+	// any package that supports errors.Formatter. It is therefore safe to
+	// disregard that State may be a specific printer implementation and use one
+	// of our choice instead.
+
+	// limitations: does not support printing error as Go struct.
+
+	var (
+		sep    = " " // separator before next error
+		p      = &state{State: s}
+		direct = true
+	)
+
+	var err error = f
+
+	switch verb {
+	// Note that this switch must match the preference order
+	// for ordinary string printing (%#v before %+v, and so on).
+
+	case 'v':
+		if s.Flag('#') {
+			if stringer, ok := err.(fmt.GoStringer); ok {
+				io.WriteString(&p.buf, stringer.GoString())
+				goto exit
+			}
+			// proceed as if it were %v
+		} else if s.Flag('+') {
+			p.printDetail = true
+			sep = "\n  - "
+		}
+	case 's':
+	case 'q', 'x', 'X':
+		// Use an intermediate buffer in the rare cases that precision,
+		// truncation, or one of the alternative verbs (q, x, and X) are
+		// specified.
+		direct = false
+
+	default:
+		p.buf.WriteString("%!")
+		p.buf.WriteRune(verb)
+		p.buf.WriteByte('(')
+		switch {
+		case err != nil:
+			p.buf.WriteString(reflect.TypeOf(f).String())
+		default:
+			p.buf.WriteString("<nil>")
+		}
+		p.buf.WriteByte(')')
+		io.Copy(s, &p.buf)
+		return
+	}
+
+loop:
+	for {
+		switch v := err.(type) {
+		case Formatter:
+			err = v.FormatError((*printer)(p))
+		case fmt.Formatter:
+			v.Format(p, 'v')
+			break loop
+		default:
+			io.WriteString(&p.buf, v.Error())
+			break loop
+		}
+		if err == nil {
+			break
+		}
+		if p.needColon || !p.printDetail {
+			p.buf.WriteByte(':')
+			p.needColon = false
+		}
+		p.buf.WriteString(sep)
+		p.inDetail = false
+		p.needNewline = false
+	}
+
+exit:
+	width, okW := s.Width()
+	prec, okP := s.Precision()
+
+	if !direct || (okW && width > 0) || okP {
+		// Construct format string from State s.
+		format := []byte{'%'}
+		if s.Flag('-') {
+			format = append(format, '-')
+		}
+		if s.Flag('+') {
+			format = append(format, '+')
+		}
+		if s.Flag(' ') {
+			format = append(format, ' ')
+		}
+		if okW {
+			format = strconv.AppendInt(format, int64(width), 10)
+		}
+		if okP {
+			format = append(format, '.')
+			format = strconv.AppendInt(format, int64(prec), 10)
+		}
+		format = append(format, string(verb)...)
+		fmt.Fprintf(s, string(format), p.buf.String())
+	} else {
+		io.Copy(s, &p.buf)
+	}
+}
+
+var detailSep = []byte("\n    ")
+
+// state tracks error printing state. It implements fmt.State.
+type state struct {
+	fmt.State
+	buf bytes.Buffer
+
+	printDetail bool
+	inDetail    bool
+	needColon   bool
+	needNewline bool
+}
+
+func (s *state) Write(b []byte) (n int, err error) {
+	if s.printDetail {
+		if len(b) == 0 {
+			return 0, nil
+		}
+		if s.inDetail && s.needColon {
+			s.needNewline = true
+			if b[0] == '\n' {
+				b = b[1:]
+			}
+		}
+		k := 0
+		for i, c := range b {
+			if s.needNewline {
+				if s.inDetail && s.needColon {
+					s.buf.WriteByte(':')
+					s.needColon = false
+				}
+				s.buf.Write(detailSep)
+				s.needNewline = false
+			}
+			if c == '\n' {
+				s.buf.Write(b[k:i])
+				k = i + 1
+				s.needNewline = true
+			}
+		}
+		s.buf.Write(b[k:])
+		if !s.inDetail {
+			s.needColon = true
+		}
+	} else if !s.inDetail {
+		s.buf.Write(b)
+	}
+	return len(b), nil
+}
+
+// printer wraps a state to implement an xerrors.Printer.
+type printer state
+
+func (s *printer) Print(args ...interface{}) {
+	if !s.inDetail || s.printDetail {
+		fmt.Fprint((*state)(s), args...)
+	}
+}
+
+func (s *printer) Printf(format string, args ...interface{}) {
+	if !s.inDetail || s.printDetail {
+		fmt.Fprintf((*state)(s), format, args...)
+	}
+}
+
+func (s *printer) Detail() bool {
+	s.inDetail = true
+	return s.printDetail
+}

--- a/vendor/golang.org/x/xerrors/codereview.cfg
+++ b/vendor/golang.org/x/xerrors/codereview.cfg
@@ -1,0 +1,1 @@
+issuerepo: golang/go

--- a/vendor/golang.org/x/xerrors/doc.go
+++ b/vendor/golang.org/x/xerrors/doc.go
@@ -1,0 +1,22 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package xerrors implements functions to manipulate errors.
+//
+// This package is based on the Go 2 proposal for error values:
+//   https://golang.org/design/29934-error-values
+//
+// These functions were incorporated into the standard library's errors package
+// in Go 1.13:
+// - Is
+// - As
+// - Unwrap
+//
+// Also, Errorf's %w verb was incorporated into fmt.Errorf.
+//
+// Use this package to get equivalent behavior in all supported Go versions.
+//
+// No other features of this package were included in Go 1.13, and at present
+// there are no plans to include any of them.
+package xerrors // import "golang.org/x/xerrors"

--- a/vendor/golang.org/x/xerrors/errors.go
+++ b/vendor/golang.org/x/xerrors/errors.go
@@ -1,0 +1,33 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import "fmt"
+
+// errorString is a trivial implementation of error.
+type errorString struct {
+	s     string
+	frame Frame
+}
+
+// New returns an error that formats as the given text.
+//
+// The returned error contains a Frame set to the caller's location and
+// implements Formatter to show this information when printed with details.
+func New(text string) error {
+	return &errorString{text, Caller(1)}
+}
+
+func (e *errorString) Error() string {
+	return e.s
+}
+
+func (e *errorString) Format(s fmt.State, v rune) { FormatError(e, s, v) }
+
+func (e *errorString) FormatError(p Printer) (next error) {
+	p.Print(e.s)
+	e.frame.Format(p)
+	return nil
+}

--- a/vendor/golang.org/x/xerrors/fmt.go
+++ b/vendor/golang.org/x/xerrors/fmt.go
@@ -1,0 +1,187 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"golang.org/x/xerrors/internal"
+)
+
+const percentBangString = "%!"
+
+// Errorf formats according to a format specifier and returns the string as a
+// value that satisfies error.
+//
+// The returned error includes the file and line number of the caller when
+// formatted with additional detail enabled. If the last argument is an error
+// the returned error's Format method will return it if the format string ends
+// with ": %s", ": %v", or ": %w". If the last argument is an error and the
+// format string ends with ": %w", the returned error implements an Unwrap
+// method returning it.
+//
+// If the format specifier includes a %w verb with an error operand in a
+// position other than at the end, the returned error will still implement an
+// Unwrap method returning the operand, but the error's Format method will not
+// return the wrapped error.
+//
+// It is invalid to include more than one %w verb or to supply it with an
+// operand that does not implement the error interface. The %w verb is otherwise
+// a synonym for %v.
+func Errorf(format string, a ...interface{}) error {
+	format = formatPlusW(format)
+	// Support a ": %[wsv]" suffix, which works well with xerrors.Formatter.
+	wrap := strings.HasSuffix(format, ": %w")
+	idx, format2, ok := parsePercentW(format)
+	percentWElsewhere := !wrap && idx >= 0
+	if !percentWElsewhere && (wrap || strings.HasSuffix(format, ": %s") || strings.HasSuffix(format, ": %v")) {
+		err := errorAt(a, len(a)-1)
+		if err == nil {
+			return &noWrapError{fmt.Sprintf(format, a...), nil, Caller(1)}
+		}
+		// TODO: this is not entirely correct. The error value could be
+		// printed elsewhere in format if it mixes numbered with unnumbered
+		// substitutions. With relatively small changes to doPrintf we can
+		// have it optionally ignore extra arguments and pass the argument
+		// list in its entirety.
+		msg := fmt.Sprintf(format[:len(format)-len(": %s")], a[:len(a)-1]...)
+		frame := Frame{}
+		if internal.EnableTrace {
+			frame = Caller(1)
+		}
+		if wrap {
+			return &wrapError{msg, err, frame}
+		}
+		return &noWrapError{msg, err, frame}
+	}
+	// Support %w anywhere.
+	// TODO: don't repeat the wrapped error's message when %w occurs in the middle.
+	msg := fmt.Sprintf(format2, a...)
+	if idx < 0 {
+		return &noWrapError{msg, nil, Caller(1)}
+	}
+	err := errorAt(a, idx)
+	if !ok || err == nil {
+		// Too many %ws or argument of %w is not an error. Approximate the Go
+		// 1.13 fmt.Errorf message.
+		return &noWrapError{fmt.Sprintf("%sw(%s)", percentBangString, msg), nil, Caller(1)}
+	}
+	frame := Frame{}
+	if internal.EnableTrace {
+		frame = Caller(1)
+	}
+	return &wrapError{msg, err, frame}
+}
+
+func errorAt(args []interface{}, i int) error {
+	if i < 0 || i >= len(args) {
+		return nil
+	}
+	err, ok := args[i].(error)
+	if !ok {
+		return nil
+	}
+	return err
+}
+
+// formatPlusW is used to avoid the vet check that will barf at %w.
+func formatPlusW(s string) string {
+	return s
+}
+
+// Return the index of the only %w in format, or -1 if none.
+// Also return a rewritten format string with %w replaced by %v, and
+// false if there is more than one %w.
+// TODO: handle "%[N]w".
+func parsePercentW(format string) (idx int, newFormat string, ok bool) {
+	// Loosely copied from golang.org/x/tools/go/analysis/passes/printf/printf.go.
+	idx = -1
+	ok = true
+	n := 0
+	sz := 0
+	var isW bool
+	for i := 0; i < len(format); i += sz {
+		if format[i] != '%' {
+			sz = 1
+			continue
+		}
+		// "%%" is not a format directive.
+		if i+1 < len(format) && format[i+1] == '%' {
+			sz = 2
+			continue
+		}
+		sz, isW = parsePrintfVerb(format[i:])
+		if isW {
+			if idx >= 0 {
+				ok = false
+			} else {
+				idx = n
+			}
+			// "Replace" the last character, the 'w', with a 'v'.
+			p := i + sz - 1
+			format = format[:p] + "v" + format[p+1:]
+		}
+		n++
+	}
+	return idx, format, ok
+}
+
+// Parse the printf verb starting with a % at s[0].
+// Return how many bytes it occupies and whether the verb is 'w'.
+func parsePrintfVerb(s string) (int, bool) {
+	// Assume only that the directive is a sequence of non-letters followed by a single letter.
+	sz := 0
+	var r rune
+	for i := 1; i < len(s); i += sz {
+		r, sz = utf8.DecodeRuneInString(s[i:])
+		if unicode.IsLetter(r) {
+			return i + sz, r == 'w'
+		}
+	}
+	return len(s), false
+}
+
+type noWrapError struct {
+	msg   string
+	err   error
+	frame Frame
+}
+
+func (e *noWrapError) Error() string {
+	return fmt.Sprint(e)
+}
+
+func (e *noWrapError) Format(s fmt.State, v rune) { FormatError(e, s, v) }
+
+func (e *noWrapError) FormatError(p Printer) (next error) {
+	p.Print(e.msg)
+	e.frame.Format(p)
+	return e.err
+}
+
+type wrapError struct {
+	msg   string
+	err   error
+	frame Frame
+}
+
+func (e *wrapError) Error() string {
+	return fmt.Sprint(e)
+}
+
+func (e *wrapError) Format(s fmt.State, v rune) { FormatError(e, s, v) }
+
+func (e *wrapError) FormatError(p Printer) (next error) {
+	p.Print(e.msg)
+	e.frame.Format(p)
+	return e.err
+}
+
+func (e *wrapError) Unwrap() error {
+	return e.err
+}

--- a/vendor/golang.org/x/xerrors/format.go
+++ b/vendor/golang.org/x/xerrors/format.go
@@ -1,0 +1,34 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+// A Formatter formats error messages.
+type Formatter interface {
+	error
+
+	// FormatError prints the receiver's first error and returns the next error in
+	// the error chain, if any.
+	FormatError(p Printer) (next error)
+}
+
+// A Printer formats error messages.
+//
+// The most common implementation of Printer is the one provided by package fmt
+// during Printf (as of Go 1.13). Localization packages such as golang.org/x/text/message
+// typically provide their own implementations.
+type Printer interface {
+	// Print appends args to the message output.
+	Print(args ...interface{})
+
+	// Printf writes a formatted string.
+	Printf(format string, args ...interface{})
+
+	// Detail reports whether error detail is requested.
+	// After the first call to Detail, all text written to the Printer
+	// is formatted as additional detail, or ignored when
+	// detail has not been requested.
+	// If Detail returns false, the caller can avoid printing the detail at all.
+	Detail() bool
+}

--- a/vendor/golang.org/x/xerrors/frame.go
+++ b/vendor/golang.org/x/xerrors/frame.go
@@ -1,0 +1,56 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"runtime"
+)
+
+// A Frame contains part of a call stack.
+type Frame struct {
+	// Make room for three PCs: the one we were asked for, what it called,
+	// and possibly a PC for skipPleaseUseCallersFrames. See:
+	// https://go.googlesource.com/go/+/032678e0fb/src/runtime/extern.go#169
+	frames [3]uintptr
+}
+
+// Caller returns a Frame that describes a frame on the caller's stack.
+// The argument skip is the number of frames to skip over.
+// Caller(0) returns the frame for the caller of Caller.
+func Caller(skip int) Frame {
+	var s Frame
+	runtime.Callers(skip+1, s.frames[:])
+	return s
+}
+
+// location reports the file, line, and function of a frame.
+//
+// The returned function may be "" even if file and line are not.
+func (f Frame) location() (function, file string, line int) {
+	frames := runtime.CallersFrames(f.frames[:])
+	if _, ok := frames.Next(); !ok {
+		return "", "", 0
+	}
+	fr, ok := frames.Next()
+	if !ok {
+		return "", "", 0
+	}
+	return fr.Function, fr.File, fr.Line
+}
+
+// Format prints the stack as error detail.
+// It should be called from an error's Format implementation
+// after printing any other error detail.
+func (f Frame) Format(p Printer) {
+	if p.Detail() {
+		function, file, line := f.location()
+		if function != "" {
+			p.Printf("%s\n    ", function)
+		}
+		if file != "" {
+			p.Printf("%s:%d\n", file, line)
+		}
+	}
+}

--- a/vendor/golang.org/x/xerrors/go.mod
+++ b/vendor/golang.org/x/xerrors/go.mod
@@ -1,0 +1,3 @@
+module golang.org/x/xerrors
+
+go 1.11

--- a/vendor/golang.org/x/xerrors/internal/internal.go
+++ b/vendor/golang.org/x/xerrors/internal/internal.go
@@ -1,0 +1,8 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+// EnableTrace indicates whether stack information should be recorded in errors.
+var EnableTrace = true

--- a/vendor/golang.org/x/xerrors/wrap.go
+++ b/vendor/golang.org/x/xerrors/wrap.go
@@ -1,0 +1,106 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package xerrors
+
+import (
+	"reflect"
+)
+
+// A Wrapper provides context around another error.
+type Wrapper interface {
+	// Unwrap returns the next error in the error chain.
+	// If there is no next error, Unwrap returns nil.
+	Unwrap() error
+}
+
+// Opaque returns an error with the same error formatting as err
+// but that does not match err and cannot be unwrapped.
+func Opaque(err error) error {
+	return noWrapper{err}
+}
+
+type noWrapper struct {
+	error
+}
+
+func (e noWrapper) FormatError(p Printer) (next error) {
+	if f, ok := e.error.(Formatter); ok {
+		return f.FormatError(p)
+	}
+	p.Print(e.error)
+	return nil
+}
+
+// Unwrap returns the result of calling the Unwrap method on err, if err implements
+// Unwrap. Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	u, ok := err.(Wrapper)
+	if !ok {
+		return nil
+	}
+	return u.Unwrap()
+}
+
+// Is reports whether any error in err's chain matches target.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool {
+	if target == nil {
+		return err == target
+	}
+
+	isComparable := reflect.TypeOf(target).Comparable()
+	for {
+		if isComparable && err == target {
+			return true
+		}
+		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
+			return true
+		}
+		// TODO: consider supporing target.Is(err). This would allow
+		// user-definable predicates, but also may allow for coping with sloppy
+		// APIs, thereby making it easier to get away with them.
+		if err = Unwrap(err); err == nil {
+			return false
+		}
+	}
+}
+
+// As finds the first error in err's chain that matches the type to which target
+// points, and if so, sets the target to its value and returns true. An error
+// matches a type if it is assignable to the target type, or if it has a method
+// As(interface{}) bool such that As(target) returns true. As will panic if target
+// is not a non-nil pointer to a type which implements error or is of interface type.
+//
+// The As method should set the target to its value and return true if err
+// matches the type to which target points.
+func As(err error, target interface{}) bool {
+	if target == nil {
+		panic("errors: target cannot be nil")
+	}
+	val := reflect.ValueOf(target)
+	typ := val.Type()
+	if typ.Kind() != reflect.Ptr || val.IsNil() {
+		panic("errors: target must be a non-nil pointer")
+	}
+	if e := typ.Elem(); e.Kind() != reflect.Interface && !e.Implements(errorType) {
+		panic("errors: *target must be interface or implement error")
+	}
+	targetType := typ.Elem()
+	for err != nil {
+		if reflect.TypeOf(err).AssignableTo(targetType) {
+			val.Elem().Set(reflect.ValueOf(err))
+			return true
+		}
+		if x, ok := err.(interface{ As(interface{}) bool }); ok && x.As(target) {
+			return true
+		}
+		err = Unwrap(err)
+	}
+	return false
+}
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -74,6 +74,7 @@ github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/go-cmp v0.5.4
 ## explicit
 github.com/google/go-cmp/cmp
+github.com/google/go-cmp/cmp/cmpopts
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
@@ -344,6 +345,9 @@ golang.org/x/text/width
 # golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 ## explicit
 golang.org/x/time/rate
+# golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+golang.org/x/xerrors
+golang.org/x/xerrors/internal
 # gomodules.xyz/jsonpatch/v2 v2.1.0
 gomodules.xyz/jsonpatch/v2
 # google.golang.org/appengine v1.6.6


### PR DESCRIPTION
**Pre-warning: Some of the changes in this PR can be split off into
other PRs and others cannot. Many of the changes discussed
which can be split off won't make sense without this PR (e.g. the
changes to parser.Node), but I can put those in their own PR.**

When multiple Pods are running mutators, it is possible that they will
ingest mutators in different orders. Before this PR, we would
essentially randomly pick which mutator to honor and discard future
mutators which conflicted.

AssignMutators now directly store []schema.GroupVersionKind
representing the types they match for schema bookkeeping. In the
future we may replace this with a map if we decide to use that
instead of iterating over the ApplyTos. ApplyTos thus have a
convenience method for flattening to the list of GVKs they match.

Various uses of meta.Accessor() have been removed as they are
no longer needed with the relatively new client.Client interface
update. Respective interfaces have been changed to accept
client.Object instead of runtime.Object as in all cases where
this change has been made, we have a client.Object.

Added degenerate cases to unit testing for Match to document
that it is intentional that empty Match fields implicitly match
everything.

Remove Bindings type (which just replicated the ApplyTo struct)
as we just use []schema.GroupVersionKind instead.

Replace combined cmp.Equal+cmp.Diff calls with single call to
cmp.Diff since this is more idiomatic.

Add Key() to Node interface so callers can access the key field
without needing to do type introspection.

Make Path no longer match the Node interface. We never use
a Path as a Node, so this has no functional impact. It does
make code checking for Nodes cleaner as we don't need to
check to see if a Node is of type Path (which in all cases is an error).

Split implicit schema conflict checking into its own type, schema.node.
Large changes to schema.DB to account for that we allow the implicit
schema to be in an inconsistent state, but can be healed by removing
the offending mutators.

As a side effect, this greatly reduced the complexity of DB and makes
testing simpler than it was before. I've completely rewritten the test
cases. It's possible I've missed edge cases - please suggest more.

Modify mutation.System to properly account for that schemas may
enter inconsistent states. Before calling mutate, System now
checks the DB to see if the mutator has conflicts in any of the
types it declares. Note that this means that if mutators Foo and Bar
have a conflict on the v1/Role type, but only Foo modifies the
v1beta1/Role type, then Foo will not perform mutations on
v1beta1/Role objects.

Define Error string type alias in util/ for use throughout the repository
per comment on previous PR.

Fixes: #1216

Signed-off-by: Will Beason <willbeason@google.com>