### PR TITLE
Cherry pick of #1360: Add default configs to mutatingwebhookconfig

### DIFF
--- a/config/overlays/mutation_webhook/webhook.yaml
+++ b/config/overlays/mutation_webhook/webhook.yaml
@@ -30,3 +30,8 @@ webhooks:
     resources:
     - '*'
   sideEffects: None
+  timeoutSeconds: 3
+  namespaceSelector:
+    matchExpressions:
+      - key: admission.gatekeeper.sh/ignore
+        operator: DoesNotExist

--- a/deploy/experimental/gatekeeper-mutation.yaml
+++ b/deploy/experimental/gatekeeper-mutation.yaml
@@ -830,6 +830,12 @@ webhooks:
     - UPDATE
     resources:
     - '*'
+  sideEffects: None
+  timeoutSeconds: 3
+  namespaceSelector:
+    matchExpressions:
+      - key: admission.gatekeeper.sh/ignore
+        operator: DoesNotExist
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -21,6 +21,10 @@ webhooks:
   failurePolicy: Ignore
   matchPolicy: Exact
   name: mutation.gatekeeper.sh
+  namespaceSelector:
+    matchExpressions:
+    - key: admission.gatekeeper.sh/ignore
+      operator: DoesNotExist
   rules:
   - apiGroups:
     - '*'
@@ -32,4 +36,5 @@ webhooks:
     resources:
     - '*'
   sideEffects: None
+  timeoutSeconds: 3
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: