### PR TITLE
Add mutatorpodstatus to helm chart

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -182,53 +182,12 @@ jobs:
         run: |
           make e2e-build-load-image IMG=gatekeeper-e2e-helm:latest
           make e2e-helm-deploy HELM_REPO=gatekeeper-e2e-helm HELM_RELEASE=latest HELM_VERSION=${{ matrix.HELM_VERSION }} GATEKEEPER_NAMESPACE=${{ matrix.GATEKEEPER_NAMESPACE }}
-          make test-e2e GATEKEEPER_NAMESPACE=${{ matrix.GATEKEEPER_NAMESPACE }}
+          make test-e2e GATEKEEPER_NAMESPACE=${{ matrix.GATEKEEPER_NAMESPACE }} ENABLE_MUTATION_TESTS=1
 
       - name: Save logs
         run: |
           kubectl logs -n ${{ matrix.GATEKEEPER_NAMESPACE }} -l control-plane=controller-manager --tail=-1 > logs-helm-${{ matrix.HELM_VERSION }}-${{ matrix.GATEKEEPER_NAMESPACE }}-controller.json
           kubectl logs -n ${{ matrix.GATEKEEPER_NAMESPACE }} -l control-plane=audit-controller --tail=-1 > logs-helm-${{ matrix.HELM_VERSION }}-${{ matrix.GATEKEEPER_NAMESPACE }}-audit.json
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v2
-        if: ${{ always() }}
-        with:
-          name: logs
-          path: |
-            logs-*.json
-
-  build_mutation_test:
-    name: "Build and Test Mutation"
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      matrix:
-        KUBERNETES_VERSION: ["1.19.11", "1.20.7", "1.21.1"]
-    steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
-      - name: Set up Go 1.16
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16
-
-      - name: Bootstrap e2e
-        run: |
-          mkdir -p $GITHUB_WORKSPACE/bin
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-          make e2e-bootstrap KUBERNETES_VERSION=${{ matrix.KUBERNETES_VERSION }}
-
-      - name: Run e2e mutation
-        run: |
-          make e2e-build-load-image IMG=gatekeeper-e2e:latest
-          make deploy-mutation IMG=gatekeeper-e2e:latest USE_LOCAL_IMG=true
-          make test-e2e ENABLE_MUTATION_TESTS=1
-
-      - name: Save logs
-        run: |
-          kubectl logs -n gatekeeper-system -l control-plane=controller-manager --tail=-1 > logs-controller-mutation.json
-          kubectl logs -n gatekeeper-system -l control-plane=audit-controller --tail=-1 > logs-audit-mutation.json
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ e2e-helm-deploy: e2e-helm-install
 		--set emitAdmissionEvents=true \
 		--set emitAuditEvents=true \
 		--set postInstall.labelNamespace.enabled=true \
+		--set experimentalEnableMutation=true \
 		--set disabledBuiltins={http.send};\
 
 e2e-helm-upgrade-init: e2e-helm-install
@@ -198,7 +199,7 @@ manifests: __controller-gen
 	# As mutation CRDs are not ready to be included in our final gatekeeper.yaml, we leave them out of config/crd/kustomization.yaml.
 	# This makes these files unavailable to the helmify step below.  The solve for this was to copy the mutation CRDs into
 	# config/overlays/mutation_webhook/.  To maintain the generation pipeline, we do that copy step here.
-	cp config/crd/bases/mutations* config/overlays/mutation_webhook/
+	cp config/crd/bases/*mutat* config/overlays/mutation_webhook/
 	rm -rf manifest_staging
 	mkdir -p manifest_staging/deploy
 	mkdir -p manifest_staging/charts/gatekeeper

--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -33,6 +33,12 @@ status: null
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: mutatorpodstatuses.status.gatekeeper.sh
+status: null
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
   name: assignmetadata.mutations.gatekeeper.sh
 status: null
 ---

--- a/config/overlays/mutation_webhook/kustomization.yaml
+++ b/config/overlays/mutation_webhook/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - webhook.yaml
   - mutations.gatekeeper.sh_assign.yaml
   - mutations.gatekeeper.sh_assignmetadata.yaml
+  - status.gatekeeper.sh_mutatorpodstatuses.yaml
 
 
 patchesJson6902:

--- a/config/overlays/mutation_webhook/status.gatekeeper.sh_mutatorpodstatuses.yaml
+++ b/config/overlays/mutation_webhook/status.gatekeeper.sh_mutatorpodstatuses.yaml
@@ -1,0 +1,68 @@
+
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  creationTimestamp: null
+  name: mutatorpodstatuses.status.gatekeeper.sh
+spec:
+  group: status.gatekeeper.sh
+  names:
+    kind: MutatorPodStatus
+    listKind: MutatorPodStatusList
+    plural: mutatorpodstatuses
+    singular: mutatorpodstatus
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MutatorPodStatus is the Schema for the mutationpodstatuses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus
+            properties:
+              enforced:
+                type: boolean
+              errors:
+                items:
+                  description: MutatorError represents a single error caught while adding a mutator to a system
+                  properties:
+                    message:
+                      type: string
+                  required:
+                  - message
+                  type: object
+                type: array
+              id:
+                type: string
+              mutatorUID:
+                description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              operations:
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
@@ -1,0 +1,61 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: mutatorpodstatuses.status.gatekeeper.sh
+spec:
+  group: status.gatekeeper.sh
+  names:
+    kind: MutatorPodStatus
+    listKind: MutatorPodStatusList
+    plural: mutatorpodstatuses
+    singular: mutatorpodstatus
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MutatorPodStatus is the Schema for the mutationpodstatuses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          status:
+            description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus
+            properties:
+              enforced:
+                type: boolean
+              errors:
+                items:
+                  description: MutatorError represents a single error caught while adding a mutator to a system
+                  properties:
+                    message:
+                      type: string
+                  required:
+                  - message
+                  type: object
+                type: array
+              id:
+                type: string
+              mutatorUID:
+                description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                type: string
+              observedGeneration:
+                format: int64
+                type: integer
+              operations:
+                items:
+                  type: string
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

**What this PR does / why we need it**:
Ensure mutatorpodstatus crd is included in the helm chart.
*NOTE*: removing `build_mutation_test` job from github workflow. Enabling and running mutation tests by default. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1387 

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: