### PR TITLE
Add integer keyValue support to mutation path parser / mutators

### DIFF
--- a/pkg/mutation/mutators/assign_mutator.go
+++ b/pkg/mutation/mutators/assign_mutator.go
@@ -323,8 +323,8 @@ func validateObjectAssignedToList(p parser.Path, value interface{}, assignName s
 	if !ok {
 		return errors.New("only full objects can be appended to lists, Assign: " + assignName)
 	}
-	if *listNode.KeyValue != valueMap[listNode.KeyField] {
-		return fmt.Errorf("adding object to list with different key %s: list key %s, object key %s, assign: %s", listNode.KeyField, *listNode.KeyValue, valueMap[listNode.KeyField], assignName)
+	if listNode.KeyValue != valueMap[listNode.KeyField] {
+		return fmt.Errorf("adding object to list with different key %s: list key %v, object key %v, assign: %s", listNode.KeyField, listNode.KeyValue, valueMap[listNode.KeyField], assignName)
 	}
 
 	return nil

--- a/pkg/mutation/mutators/assign_mutator_test.go
+++ b/pkg/mutation/mutators/assign_mutator_test.go
@@ -2,6 +2,7 @@ package mutators
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"testing"
@@ -1509,6 +1510,41 @@ func TestApplyTo(t *testing.T) {
 	}
 }
 
+var testPod = &v1.Pod{
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: "v1",
+		Kind:       "Pod",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "opa",
+		Namespace: "production",
+		Labels:    map[string]string{"owner": "me.agilebank.demo"},
+	},
+	Spec: v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Name:  "opa",
+				Image: "openpolicyagent/opa:0.9.2",
+				Args: []string{
+					"run",
+					"--server",
+					"--addr=localhost:8080",
+				},
+				Ports: []v1.ContainerPort{
+					{
+						ContainerPort: 8080,
+						Name:          "out-of-scope",
+					},
+					{
+						ContainerPort: 8888,
+						Name:          "unchanged",
+					},
+				},
+			},
+		},
+	},
+}
+
 func TestAssign(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1523,40 +1559,7 @@ func TestAssign(t *testing.T) {
 				path:    `spec.containers[name: opa].ports[containerPort: 8888].name`,
 				value:   makeValue("modified"),
 			},
-			obj: newPod(&v1.Pod{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "Pod",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "opa",
-					Namespace: "production",
-					Labels:    map[string]string{"owner": "me.agilebank.demo"},
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:  "opa",
-							Image: "openpolicyagent/opa:0.9.2",
-							Args: []string{
-								"run",
-								"--server",
-								"--addr=localhost:8080",
-							},
-							Ports: []v1.ContainerPort{
-								{
-									ContainerPort: 8080,
-									Name:          "out-of-scope",
-								},
-								{
-									ContainerPort: 8888,
-									Name:          "unchanged",
-								},
-							},
-						},
-					},
-				},
-			}),
+			obj: newPod(testPod),
 			fn: func(u *unstructured.Unstructured) error {
 				var pod v1.Pod
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
@@ -1581,6 +1584,111 @@ func TestAssign(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "new integer key value",
+			cfg: &assignTestCfg{
+				applyTo: []match.ApplyTo{{Groups: []string{""}, Versions: []string{"v1"}, Kinds: []string{"Pod"}}},
+				path:    `spec.containers[name: opa].ports[containerPort: 2001].name`,
+				value:   makeValue("added"),
+			},
+			obj: newPod(testPod),
+			fn: func(u *unstructured.Unstructured) error {
+				var pod v1.Pod
+				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
+				if err != nil {
+					return err
+				}
+
+				if len(pod.Spec.Containers) != 1 {
+					return fmt.Errorf("incorrect number of containers: %d", len(pod.Spec.Containers))
+				}
+				c := pod.Spec.Containers[0]
+				if len(c.Ports) != 3 {
+					return fmt.Errorf("incorrect number of ports: %d", len(c.Ports))
+				}
+				p := c.Ports[2]
+				if p.ContainerPort != int32(2001) {
+					return fmt.Errorf("incorrect containerPort: %d", p.ContainerPort)
+				}
+				if p.Name != "added" {
+					return fmt.Errorf("incorrect port name: %s", p.Name)
+				}
+				return nil
+			},
+		},
+		{
+			name: "truncated integer key value",
+			cfg: &assignTestCfg{
+				applyTo: []match.ApplyTo{{Groups: []string{""}, Versions: []string{"v1"}, Kinds: []string{"Pod"}}},
+				path:    `spec.containers[name: opa].ports[containerPort: 4294967297].name`,
+				value:   makeValue("added"),
+			},
+			obj: newPod(testPod),
+			fn: func(u *unstructured.Unstructured) error {
+				var pod v1.Pod
+				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
+				if err != nil {
+					return err
+				}
+
+				if len(pod.Spec.Containers) != 1 {
+					return fmt.Errorf("incorrect number of containers: %d", len(pod.Spec.Containers))
+				}
+				c := pod.Spec.Containers[0]
+				if len(c.Ports) != 3 {
+					return fmt.Errorf("incorrect number of ports: %d", len(c.Ports))
+				}
+				p := c.Ports[2]
+				// Note in this test case, the UnstructuredConverter truncates our 64bit containerPort down to 32bit.
+				// The actual mutation was done in 64bit.
+				if p.ContainerPort != int32(1) {
+					return fmt.Errorf("incorrect containerPort: %d", p.ContainerPort)
+				}
+				if p.Name != "added" {
+					return fmt.Errorf("incorrect port name: %s", p.Name)
+				}
+				return nil
+			},
+		},
+		{
+			name: "type mismatch for key value",
+			cfg: &assignTestCfg{
+				applyTo: []match.ApplyTo{{Groups: []string{""}, Versions: []string{"v1"}, Kinds: []string{"Pod"}}},
+				path:    `spec.containers[name: opa].ports[containerPort: "8888"].name`,
+				value:   makeValue("modified"),
+			},
+			obj: newPod(testPod),
+			fn: func(u *unstructured.Unstructured) error {
+				var pod v1.Pod
+				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
+				if err == nil {
+					return errors.New("expected type mismatch when deserializing mutated pod")
+				}
+
+				containers, err := nestedMapSlice(u.Object, "spec", "containers")
+				if err != nil {
+					return fmt.Errorf("fetching containers: %w", err)
+				}
+				if len(containers) != 1 {
+					return fmt.Errorf("incorrect number of containers: %d", len(containers))
+				}
+				ports, err := nestedMapSlice(containers[0], "ports")
+				if err != nil {
+					return fmt.Errorf("fetching ports: %w", err)
+				}
+				if len(ports) != 3 {
+					return fmt.Errorf("incorrect number of ports: %d", len(containers))
+				}
+				if ports[1]["containerPort"] != 8888 && ports[1]["name"] != "unchanged" {
+					return fmt.Errorf("port was incorrectly modified: %v", ports[1])
+				}
+				if ports[2]["containerPort"] != "8888" && ports[1]["name"] != "modified" {
+					return fmt.Errorf("type mismatched port was not added as expected: %v", ports[1])
+				}
+
+				return nil
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -1596,4 +1704,24 @@ func TestAssign(t *testing.T) {
 			}
 		})
 	}
+}
+
+func nestedMapSlice(u map[string]interface{}, fields ...string) ([]map[string]interface{}, error) {
+	lst, ok, err := unstructured.NestedSlice(u, fields...)
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]map[string]interface{}, len(lst))
+	for i := range lst {
+		v, ok := lst[i].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected type: %T, expected map[string]interface{}", lst[i])
+		}
+		out[i] = v
+	}
+	return out, nil
 }

--- a/pkg/mutation/mutators/core/mutation_function.go
+++ b/pkg/mutation/mutators/core/mutation_function.go
@@ -112,7 +112,7 @@ func (s *mutatorState) mutateInternal(current interface{}, depth int) (bool, int
 				elementFound = true
 			} else if listElementAsObject, ok := listElement.(map[string]interface{}); ok {
 				if elementValue, ok := listElementAsObject[key]; ok {
-					if *castPathEntry.KeyValue == elementValue {
+					if castPathEntry.KeyValue == elementValue {
 						if !s.tester.ExistsOkay(depth) {
 							return false, nil, nil
 						}
@@ -166,10 +166,10 @@ func (s *mutatorState) setListElementToValue(currentAsList []interface{}, listPa
 	if listPathEntry.KeyValue == nil {
 		return false, nil, errors.New("encountered nil key value when setting a new list element")
 	}
-	keyValue := *listPathEntry.KeyValue
+	keyValue := listPathEntry.KeyValue
 
 	for i, listElement := range currentAsList {
-		if elementValue, found, err := nestedString(listElement, key); err != nil {
+		if elementValue, found, err := nestedFieldNoCopy(listElement, key); err != nil {
 			return false, nil, err
 		} else if found && keyValue == elementValue {
 			newKeyValue, ok := newValueAsObject[key]
@@ -211,15 +211,15 @@ func (s *mutatorState) createMissingElement(depth int) (interface{}, error) {
 		if castPathEntry.KeyValue == nil {
 			return nil, fmt.Errorf("list entry has no key value")
 		}
-		nextAsObject[castPathEntry.KeyField] = *castPathEntry.KeyValue
+		nextAsObject[castPathEntry.KeyField] = castPathEntry.KeyValue
 	}
 	return next, nil
 }
 
-func nestedString(current interface{}, key string) (string, bool, error) {
+func nestedFieldNoCopy(current interface{}, key string) (interface{}, bool, error) {
 	currentAsMap, ok := current.(map[string]interface{})
 	if !ok {
 		return "", false, fmt.Errorf("cast error, unable to case %T to map[string]interface{}", current)
 	}
-	return unstructured.NestedString(currentAsMap, key)
+	return unstructured.NestedFieldNoCopy(currentAsMap, key)
 }

--- a/pkg/mutation/path/parser/errors.go
+++ b/pkg/mutation/path/parser/errors.go
@@ -13,29 +13,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package token
+package parser
 
-import "fmt"
-
-// The set of Token types.
-const (
-	ERROR     = "ERROR"
-	EOF       = "EOF"
-	IDENT     = "IDENT"
-	INT       = "INT"
-	LBRACKET  = "LBRACKET"
-	RBRACKET  = "RBRACKET"
-	SEPARATOR = "SEPARATOR"
-	GLOB      = "GLOB"
-	COLON     = "COLON"
+import (
+	"errors"
+	"fmt"
 )
 
-type Type string
-type Token struct {
-	Type    Type
-	Literal string
+var (
+	ErrTrailingSeparator = errors.New("trailing separators are forbidden")
+	ErrUnexpectedToken   = errors.New("unexpected token")
+	ErrInvalidInteger    = invalidIntegerError{}
+)
+
+type invalidIntegerError struct {
+	s string
 }
 
-func (t Token) String() string {
-	return fmt.Sprintf("%s: %q", t.Type, t.Literal)
+func (e invalidIntegerError) Error() string {
+	return fmt.Sprintf("invalid integer: %s", e.s)
+}
+func (e invalidIntegerError) Is(target error) bool {
+	_, ok := target.(invalidIntegerError)
+	return ok
 }

--- a/pkg/mutation/path/parser/errors.go
+++ b/pkg/mutation/path/parser/errors.go
@@ -21,9 +21,12 @@ import (
 )
 
 var (
+	// ErrTrailingSeparator indicates a parsing error due to an illegal trailing separator.
 	ErrTrailingSeparator = errors.New("trailing separators are forbidden")
-	ErrUnexpectedToken   = errors.New("unexpected token")
-	ErrInvalidInteger    = invalidIntegerError{}
+	// ErrUnexpectedToken indicates a parsing error due to an unexpected token.
+	ErrUnexpectedToken = errors.New("unexpected token")
+	// ErrInvalidInteger indicates a parsing error due to an invalid integer, such as integer overflow.
+	ErrInvalidInteger = invalidIntegerError{}
 )
 
 type invalidIntegerError struct {

--- a/pkg/mutation/path/parser/node.go
+++ b/pkg/mutation/path/parser/node.go
@@ -152,18 +152,17 @@ func (l List) String() string {
 
 // quote optionally adds double quotes around the passed string if needed.
 // Quotes are needed for:
-//  * Strings containing whitespace, quotes, or other characters that need escaping.
-//  * Strings starting with "ambiguous" characters that will be tokenized as non-strings,
-//    including digits, *, [, ], . etc.
+//  * Strings containing whitespace, quotes, or other "ambiguous" characters that will
+//    be tokenized as non-strings and need escaping.
+//  * Strings starting digits, that would otherwise be tokenized as an integer
 //  * Empty strings
 func quote(s string) string {
 	if len(s) == 0 {
 		return `""`
 	}
 	switch {
-	case strings.ContainsAny(s, "'\"\t\n \\"),
-		strings.ContainsAny(s[0:1], "0123456789"),
-		strings.ContainsAny(s[0:1], "*[]:."):
+	case strings.ContainsAny(s, "'\"\t\n \\*[]:."),
+		strings.ContainsAny(s[0:1], "0123456789"):
 		// Using fmt.Sprintf with %q converts whitespace to escape sequences, and we
 		// don't want that.
 		s = strings.ReplaceAll(s, `\`, `\\`)

--- a/pkg/mutation/path/parser/node.go
+++ b/pkg/mutation/path/parser/node.go
@@ -155,6 +155,7 @@ func (l List) String() string {
 //  * Strings containing whitespace, quotes, or other characters that need escaping.
 //  * Strings starting with "ambiguous" characters that will be tokenized as non-strings,
 //    including digits, *, [, ], . etc.
+//  * Empty strings
 func quote(s string) string {
 	if len(s) == 0 {
 		return `""`
@@ -169,22 +170,6 @@ func quote(s string) string {
 		s = strings.ReplaceAll(s, `"`, `\"`)
 		return `"` + s + `"`
 	}
-	//if strings.ContainsAny(s, "'\"\t\n \\") || startsWithDigit(s) {
-	//	// Using fmt.Sprintf with %q converts whitespace to escape sequences, and we
-	//	// don't want that.
-	//	s = strings.ReplaceAll(s, `\`, `\\`)
-	//	s = strings.ReplaceAll(s, `"`, `\"`)
-	//	return `"` + s + `"`
-	//}
 
 	return s
-}
-
-func startsWithDigit(s string) bool {
-	return len(s) > 0 && isDigit(s[0])
-
-}
-
-func isDigit(r uint8) bool {
-	return '0' <= r && r <= '9'
 }

--- a/pkg/mutation/path/parser/parser_test.go
+++ b/pkg/mutation/path/parser/parser_test.go
@@ -360,6 +360,31 @@ func TestParser(t *testing.T) {
 				&Object{Reference: `token-with-\embedded-backslash`},
 			},
 		},
+		// Verify round-tripping on strings-that-look-like-other-tokens
+		{
+			input: `'foo[bar: baz]'`,
+			expected: []Node{
+				&Object{Reference: `foo[bar: baz]`},
+			},
+		},
+		{
+			input: `'foo[bar:baz]'`,
+			expected: []Node{
+				&Object{Reference: `foo[bar:baz]`},
+			},
+		},
+		{
+			input: `'foo[bar:*]'`,
+			expected: []Node{
+				&Object{Reference: `foo[bar:*]`},
+			},
+		},
+		{
+			input: `'dot..dot'`,
+			expected: []Node{
+				&Object{Reference: `dot..dot`},
+			},
+		},
 	}
 
 	for i, tc := range tests {

--- a/pkg/mutation/path/parser/parser_test.go
+++ b/pkg/mutation/path/parser/parser_test.go
@@ -74,7 +74,7 @@ func TestParser(t *testing.T) {
 			expected: []Node{
 				&Object{Reference: "spec"},
 				&Object{Reference: "containers"},
-				&List{KeyField: "name", KeyValue: strPtr("*"), Glob: false},
+				&List{KeyField: "name", KeyValue: "*", Glob: false},
 				&Object{Reference: "securityContext"},
 			},
 		},
@@ -83,7 +83,7 @@ func TestParser(t *testing.T) {
 			expected: []Node{
 				&Object{Reference: "spec"},
 				&Object{Reference: "containers"},
-				&List{KeyField: "name", KeyValue: strPtr("foo")},
+				&List{KeyField: "name", KeyValue: "foo"},
 				&Object{Reference: "securityContext"},
 			},
 		},
@@ -92,7 +92,7 @@ func TestParser(t *testing.T) {
 			expected: []Node{
 				&Object{Reference: "spec"},
 				&Object{Reference: "containers"},
-				&List{KeyField: "my key", KeyValue: strPtr("foo bar")},
+				&List{KeyField: "my key", KeyValue: "foo bar"},
 			},
 		},
 		{
@@ -110,7 +110,7 @@ func TestParser(t *testing.T) {
 			expected: []Node{
 				&Object{Reference: "spec"},
 				&Object{Reference: "containers"},
-				&List{KeyField: "name", KeyValue: strPtr("")},
+				&List{KeyField: "name", KeyValue: ""},
 				&Object{Reference: "securityContext"},
 			},
 		},
@@ -119,7 +119,7 @@ func TestParser(t *testing.T) {
 			expected: []Node{
 				&Object{Reference: "spec"},
 				&Object{Reference: "containers"},
-				&List{KeyField: "", KeyValue: strPtr("someValue")},
+				&List{KeyField: "", KeyValue: "someValue"},
 				&Object{Reference: "securityContext"},
 			},
 		},
@@ -200,6 +200,44 @@ func TestParser(t *testing.T) {
 			wantErr: ErrUnexpectedToken,
 		},
 		{
+			// Integer keyValues
+			input: `spec.containers[name: opa].ports[containerPort: 8888].name`,
+			expected: []Node{
+				&Object{Reference: "spec"},
+				&Object{Reference: "containers"},
+				&List{KeyField: "name", KeyValue: "opa"},
+				&Object{Reference: "ports"},
+				&List{KeyField: "containerPort", KeyValue: int64(8888)},
+				&Object{Reference: "name"},
+			},
+		},
+		{
+			// Integer keyFields not supported
+			input:   `spec.containers[123: opa]`,
+			wantErr: ErrUnexpectedToken,
+		},
+		{
+			// Maximum 64bit integer
+			input: `spec[bignum: 9223372036854775807]`,
+			expected: []Node{
+				&Object{Reference: "spec"},
+				&List{KeyField: "bignum", KeyValue: int64(9223372036854775807)},
+			},
+		},
+		{
+			// Integer overflow
+			input:   `spec[bignum: 9223372036854775808]`,
+			wantErr: ErrInvalidInteger,
+		},
+		{
+			// Quoted integers are parsed as strings
+			input: `spec[quoted: "123"]`,
+			expected: []Node{
+				&Object{Reference: "spec"},
+				&List{KeyField: "quoted", KeyValue: "123"},
+			},
+		},
+		{
 			// allow leading dash
 			input: `-123-_456_`,
 			expected: []Node{
@@ -207,10 +245,54 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
-			// allow leading digits
-			input: `012345`,
+			// allow trailing digits
+			input: `area51`,
+			expected: []Node{
+				&Object{Reference: "area51"},
+			},
+		},
+		{
+			// field names cannot be integers
+			input:   `012345`,
+			wantErr: ErrUnexpectedToken,
+		},
+		{
+			input:   `spec.123.bar`,
+			wantErr: ErrUnexpectedToken,
+		},
+		{
+			// ...but they can be quoted strings that look like integers
+			input: `"012345"`,
 			expected: []Node{
 				&Object{Reference: "012345"},
+			},
+		},
+		{
+			input: `spec."123"`,
+			expected: []Node{
+				&Object{Reference: "spec"},
+				&Object{Reference: "123"},
+			},
+		},
+		{
+			input: `spec.studio54.bar`,
+			expected: []Node{
+				&Object{Reference: "spec"},
+				&Object{Reference: "studio54"},
+				&Object{Reference: "bar"},
+			},
+		},
+		{
+			// Hexadecimal notation not supported
+			input:   `spec[foo: 0x123]`,
+			wantErr: ErrUnexpectedToken,
+		},
+		{
+			// Octal notation not supported, interpreted as decimal.
+			input: `spec[not_octal: 0123]`,
+			expected: []Node{
+				&Object{Reference: "spec"},
+				&List{KeyField: "not_octal", KeyValue: int64(123)}, // rather than 83
 			},
 		},
 		{
@@ -262,7 +344,7 @@ func TestParser(t *testing.T) {
 				&Object{Reference: "spec"},
 				&Object{Reference: "this object"},
 				&Object{Reference: "is very"},
-				&List{KeyField: "much full", KeyValue: strPtr("of everyone's")},
+				&List{KeyField: "much full", KeyValue: "of everyone's"},
 				&Object{Reference: "favorite thing"},
 			},
 		},
@@ -324,7 +406,7 @@ func TestDeepCopy(t *testing.T) {
 		},
 		{
 			name:  "test list deepcopy",
-			input: &List{KeyField: "much full", KeyValue: strPtr("of everyone's")},
+			input: &List{KeyField: "much full", KeyValue: "of everyone's"},
 		},
 		{
 			name:  "test list deepcopy with nil nexted pointer",
@@ -334,12 +416,12 @@ func TestDeepCopy(t *testing.T) {
 			name: "test path deepcopy",
 			input: &Path{
 				Nodes: []Node{
-					&List{KeyField: "much full", KeyValue: strPtr("of everyone's")},
-					&List{KeyField: "name", KeyValue: strPtr("*"), Glob: false},
+					&List{KeyField: "much full", KeyValue: "of everyone's"},
+					&List{KeyField: "name", KeyValue: "*", Glob: false},
 					&Object{Reference: "foo\nbar"},
 					&Path{
 						Nodes: []Node{
-							&List{KeyField: "innername", KeyValue: strPtr("*"), Glob: false},
+							&List{KeyField: "innername", KeyValue: "*", Glob: false},
 						},
 					},
 				},
@@ -354,8 +436,4 @@ func TestDeepCopy(t *testing.T) {
 			}
 		})
 	}
-}
-
-func strPtr(s string) *string {
-	return &s
 }

--- a/pkg/mutation/path/token/scanner_test.go
+++ b/pkg/mutation/path/token/scanner_test.go
@@ -188,6 +188,22 @@ func TestScanner(t *testing.T) {
 				{Type: EOF, Literal: ""},
 			},
 		},
+		// Digits can be part of an unquoted identifier, just not at the start.
+		{
+			input: `Nexus6`,
+			expected: []Token{
+				{Type: IDENT, Literal: "Nexus6"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		{
+			input: `ItWasTheSummerOf69'🎸'`,
+			expected: []Token{
+				{Type: IDENT, Literal: "ItWasTheSummerOf69"},
+				{Type: IDENT, Literal: "🎸"},
+				{Type: EOF, Literal: ""},
+			},
+		},
 		{
 			input: `-valid-identifier-`,
 			expected: []Token{

--- a/pkg/mutation/path/token/scanner_test.go
+++ b/pkg/mutation/path/token/scanner_test.go
@@ -82,9 +82,91 @@ func TestScanner(t *testing.T) {
 			},
 		},
 		{
+			input: `"one"two`,
+			expected: []Token{
+				{Type: IDENT, Literal: "one"},
+				{Type: IDENT, Literal: "two"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		// Integer token support
+		{
+			input: `0123`,
+			expected: []Token{
+				{Type: INT, Literal: "0123"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		{
+			input: `9876543210`,
+			expected: []Token{
+				{Type: INT, Literal: "9876543210"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		// Tokenizer doesn't care about bit length
+		{
+			input: `99918446744073709551615`,
+			expected: []Token{
+				{Type: INT, Literal: "99918446744073709551615"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		// Hexadecimal not supported
+		{
+			input: `0x1A`,
+			expected: []Token{
+				{Type: INT, Literal: "0"},
+				{Type: IDENT, Literal: "x1A"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		// Signs not supported
+		{
+			input: `-1024`,
+			expected: []Token{
+				{Type: IDENT, Literal: "-1024"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		{
+			input: `+1024`,
+			expected: []Token{
+				{Type: ERROR, Literal: "+"},
+			},
+			wantErr: ErrInvalidCharacter,
+		},
+		// Decimals are not supported
+		{
+			input: `3.14`,
+			expected: []Token{
+				{Type: INT, Literal: "3"},
+				{Type: SEPARATOR, Literal: "."},
+				{Type: INT, Literal: "14"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		// Identifiers can no longer lead with digits
+		{
 			input: `0123_foobar_baz`,
 			expected: []Token{
+				{Type: INT, Literal: "0123"},
+				{Type: IDENT, Literal: "_foobar_baz"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		// Quoted numbers are identifiers
+		{
+			input: `"0123_foobar_baz"`,
+			expected: []Token{
 				{Type: IDENT, Literal: "0123_foobar_baz"},
+				{Type: EOF, Literal: ""},
+			},
+		},
+		{
+			input: `"299792458"`,
+			expected: []Token{
+				{Type: IDENT, Literal: "299792458"},
 				{Type: EOF, Literal: ""},
 			},
 		},
@@ -92,7 +174,8 @@ func TestScanner(t *testing.T) {
 			input: `  .0123_foobar_baz  .`,
 			expected: []Token{
 				{Type: SEPARATOR, Literal: "."},
-				{Type: IDENT, Literal: "0123_foobar_baz"},
+				{Type: INT, Literal: "0123"},
+				{Type: IDENT, Literal: "_foobar_baz"},
 				{Type: SEPARATOR, Literal: "."},
 				{Type: EOF, Literal: ""},
 			},
@@ -100,7 +183,8 @@ func TestScanner(t *testing.T) {
 		{
 			input: `0123_foobar-baz`,
 			expected: []Token{
-				{Type: IDENT, Literal: "0123_foobar-baz"},
+				{Type: INT, Literal: "0123"},
+				{Type: IDENT, Literal: "_foobar-baz"},
 				{Type: EOF, Literal: ""},
 			},
 		},

--- a/pkg/mutation/schema/schema.go
+++ b/pkg/mutation/schema/schema.go
@@ -371,14 +371,8 @@ func wrapObjErr(obj *parser.Object, err error) *Error {
 }
 
 func wrapListErr(list *parser.List, err error) *Error {
-	var value string
-	if list.Glob {
-		value = "*"
-	} else {
-		value = fmt.Sprintf("\"%s\"", *list.KeyValue)
-	}
 	return &Error{
 		childError: err,
-		nodeName:   fmt.Sprintf("[\"%s\": %s]", list.KeyField, value),
+		nodeName:   list.String(),
 	}
 }

--- a/pkg/mutation/schema/schema_test.go
+++ b/pkg/mutation/schema/schema_test.go
@@ -1202,13 +1202,13 @@ func TestErrors(t *testing.T) {
 			name:        "Long path with conflict at end",
 			first:       "spec.intermediate.someValue[hey: \"there\"].buddy.hallo",
 			second:      "spec.intermediate.someValue[hey: again].buddy[key: *]",
-			expectedErr: `spec.intermediate.someValue["hey": "again"].buddy: node type conflict: Object vs List`,
+			expectedErr: `spec.intermediate.someValue[hey: again].buddy: node type conflict: Object vs List`,
 		},
 		{
 			name:        "Long path with conflict at end, globbed",
 			first:       "spec.intermediate.someValue[hey: \"there\"].buddy.hallo",
 			second:      "spec.intermediate.someValue[hey: *].buddy[key: *]",
-			expectedErr: `spec.intermediate.someValue["hey": *].buddy: node type conflict: Object vs List`,
+			expectedErr: `spec.intermediate.someValue[hey: *].buddy: node type conflict: Object vs List`,
 		},
 		{
 			name:        "Long path with conflict at beginning",


### PR DESCRIPTION
Previously, the mutation path parser only supported string types for
keyValues selecting items in a list. This PR adds support for integers,
such that we can now express paths like this:

```
spec.containers[name: opa].ports[containerPort: 8888].name
```

Integers are assumed to be represented in decimal and are interpreted as
positive int64 values.

The mutation code was updated accordingly to match based on type.
Additionally, string serialization of paths was updated to be more
selective on which strings are quoted.

Fixes #1355

Signed-off-by: Oren Shomron <shomron@gmail.com>