### PR TITLE
Use containerized kustomize

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -59,14 +59,9 @@ jobs:
           curl -L -O "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${KUBEBUILDER_VERSION}/kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64.tar.gz" &&\
             tar -zxvf kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64.tar.gz &&\
             sudo mv kubebuilder_${KUBEBUILDER_VERSION}_linux_amd64 /usr/local/kubebuilder
-          curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz" &&\
-            tar -zxvf kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz &&\
-            chmod +x kustomize &&\
-            sudo mv kustomize /usr/local/bin
           make native-test
         env:
           KUBEBUILDER_VERSION: 2.3.1
-          KUSTOMIZE_VERSION: 3.7.0
 
       - name: Codecov Upload
         uses: codecov/codecov-action@v1.5.2


### PR DESCRIPTION
The flag is `--load-restrictor`, not `--load_restrictor`

Without change, `make deploy-mutation` shows:
```
kustomize build --load_restrictor LoadRestrictionsNone config/overlays/mutation | kubectl apply -f -
Error: unknown flag: --load_restrictor
```
With the change, `make deploy-mutation` succeeds.

I'm using kustomize v4.1.3:
```
gatekeeper$ kustomize version
{Version:kustomize/v4.1.3 GitCommit:0f614e92f72f1b938a9171b964d90b197ca8fb68 BuildDate:2021-05-20T20:52:40Z GoOs:linux GoArch:amd64}
```

Signed-off-by: Will Beason <willbeason@google.com>