### PR TITLE
Enable force type assertions linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,8 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - exportloopref
+    - forcetypeassert
     - gocritic
     - goconst
     - godot

--- a/pkg/mutation/path/tester/tester.go
+++ b/pkg/mutation/path/tester/tester.go
@@ -86,10 +86,10 @@ func New(location parser.Path, tests []Test) (*Tester, error) {
 	// Read in all tests before checking for conflicts.
 	idxLowestMustNot := math.MaxInt32
 	idxHighestMust := 0
-	for _, test := range tests {
-		i := len(test.SubPath.Nodes) - 1
-		idx.tests[i] = test.Condition
-		paths[i] = &test.SubPath
+	for i, test := range tests {
+		j := len(test.SubPath.Nodes) - 1
+		idx.tests[j] = test.Condition
+		paths[j] = &tests[i].SubPath
 
 		if test.Condition == MustNotExist && i < idxLowestMustNot {
 			idxLowestMustNot = i

--- a/pkg/mutation/schema/schema.go
+++ b/pkg/mutation/schema/schema.go
@@ -87,7 +87,12 @@ func (db *DB) upsert(mutator MutatorWithSchema) error {
 
 	path := mutator.Path()
 	bindings := mutator.SchemaBindings()
-	db.cachedMutators[id] = mutator.DeepCopy().(MutatorWithSchema)
+	var ok bool
+	mutatorCopy := mutator.DeepCopy()
+	db.cachedMutators[id], ok = mutatorCopy.(MutatorWithSchema)
+	if !ok {
+		panic(fmt.Sprintf("got mutator.DeepCopy() type %T, want %T", mutatorCopy, MutatorWithSchema(nil)))
+	}
 
 	var conflicts idSet
 	for _, gvk := range bindings {

--- a/pkg/mutation/system_test.go
+++ b/pkg/mutation/system_test.go
@@ -315,7 +315,10 @@ func TestMutation(t *testing.T) {
 				t.Error(tc.tname, "Mutation not as expected", diff)
 			}
 
-			probe := c.orderedMutators[0].(*fakeMutator) // fetching a mock mutator to check the number of iterations
+			probe, ok := c.orderedMutators[0].(*fakeMutator) // fetching a mock mutator to check the number of iterations
+			if !ok {
+				t.Fatalf("mutator type %T, want %T", c.orderedMutators[0], &fakeMutator{})
+			}
 			if probe.MutationCount != tc.expectedIterations {
 				t.Error(tc.tname, "Expected %d  mutation iterations, got", tc.expectedIterations, tc.mutations[0].MutationCount)
 			}


### PR DESCRIPTION
Unchecked type assertions can lead to panics which yield obtuse errors.
This commit enables the forcedtypeassert to ensure we always check type
assertions and have the opportunity to provide useful error messages.

Also enable exportloopref to catch potential bugs when using references
to loop variables, which can behave unexpectedly and lead to
inconsistent bugs.

Signed-off-by: Will Beason <willbeason@google.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: