### PR TITLE
[mutation] Cache tester in AssignMetadata like we do in Assign mutators

### DIFF
--- a/pkg/mutation/mutators/assignmeta_mutator_benchmark_test.go
+++ b/pkg/mutation/mutators/assignmeta_mutator_benchmark_test.go
@@ -1,0 +1,65 @@
+package mutators
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func assignMetadata(value interface{}, location string) *v1alpha1.AssignMetadata {
+	result := &v1alpha1.AssignMetadata{
+		Spec: v1alpha1.AssignMetadataSpec{
+			Location: location,
+			Parameters: v1alpha1.MetadataParameters{
+				Assign: makeValue(value),
+			},
+		},
+	}
+
+	return result
+}
+
+func BenchmarkAssignMetadataMutator_Always(b *testing.B) {
+	mutator, err := MutatorForAssignMetadata(assignMetadata("bar", "metadata.labels.foo"))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Create a fresh object each time as AssignMetadata.Mutate does nothing if
+		// a label/annotation already exists. Thus, this test is for when we do
+		// actually make the mutation.
+
+		// The performance cost of instantiating the Unstructured is negligible
+		// compared to the time to perform Mutate.
+		obj := &unstructured.Unstructured{
+			Object: make(map[string]interface{}),
+		}
+		_, _ = mutator.Mutate(obj)
+	}
+}
+
+func BenchmarkAssignMetadataMutator_Never(b *testing.B) {
+	mutator, err := MutatorForAssignMetadata(assignMetadata("bar", "metadata.labels.foo"))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: make(map[string]interface{}),
+	}
+	_, err = mutator.Mutate(obj)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Use the same object each time as AssignMetadata.Mutate does nothing if
+		// a label/annotation already exists. Thus, this test is for the case where
+		// no mutation is necessary.
+		_, _ = mutator.Mutate(obj)
+	}
+}


### PR DESCRIPTION
Note: depends on #1441 

Per findings in #1441, we can greatly improve the speed of AssignMetadata.Mutate by caching the tester instead of recreating it every time we call Mutate.

This reduces the runtime when no mutation is made by 97%, and when mutations are made by 30%!
```
$ for i in {1..20}; do echo $i; go test github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators --bench=BenchmarkAssignMetadata >> before.out; done
$ git checkout benchmark-metadata-2
$ for i in {1..20}; do echo $i; go test github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators --bench=BenchmarkAssignMetadata >> after.out; done
$ benchstat before.out after.out 

name                        old time/op  new time/op  delta
AssignMetadataMutator_Always-12    6.64µs ± 2%  4.70µs ± 1%  -29.22%  (p=0.000 n=19+19)
AssignMetadataMutator_Never-12     1.84µs ± 6%  0.05µs ± 0%  -97.04%  (p=0.000 n=19+18)
```

I'll send a separate PR which removes the unnecessary json unmarshalling in the case where we perform the mutation, once/if #1439 is merged.