### PR TITLE
[gk-test] Refactor run code into Runner

### DIFF
--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -17,17 +17,17 @@ const (
 	examples = `  # Run all tests in label-tests.yaml
   gator test label-tests.yaml
 
-  # Run all suites whose names contain "forbid-labels".
+  # Run all tests whose names contain "forbid-labels".
   gator test tests/... --run forbid-labels//
 
-  # Run all tests whose names contain "nginx-deployment".
+  # Run all cases whose names contain "nginx-deployment".
   gator test tests/... --run //nginx-deployment
 
-  # Run all tests whose names exactly match "nginx-deployment".
+  # Run all cases whose names exactly match "nginx-deployment".
   gator test tests/... --run '//^nginx-deployment$'
 
-  # Run all tests that are either named "forbid-labels" or are
-  # in suites named "forbid-labels".
+  # Run all cases that are either named "forbid-labels" or are
+  # in tests named "forbid-labels".
   gator test tests/... --run '^forbid-labels$'`
 )
 
@@ -87,15 +87,16 @@ func runE(cmd *cobra.Command, args []string) error {
 
 func runSuites(ctx context.Context, fileSystem fs.FS, suites []gktest.Suite, filter gktest.Filter) error {
 	isFailure := false
+
+	runner := gktest.Runner{
+		FS:        fileSystem,
+		NewClient: gktest.NewOPAClient,
+	}
+
 	for i := range suites {
 		s := &suites[i]
 
-		c, err := gktest.NewOPAClient()
-		if err != nil {
-			return err
-		}
-
-		suiteResult := s.Run(ctx, c, fileSystem, filter)
+		suiteResult := runner.Run(ctx, filter, s)
 		for _, testResult := range suiteResult.TestResults {
 			if testResult.Error != nil {
 				isFailure = true

--- a/pkg/gktest/errors.go
+++ b/pkg/gktest/errors.go
@@ -1,0 +1,21 @@
+package gktest
+
+import "errors"
+
+var (
+	// ErrNotATemplate indicates the user-indicated file does not contain a
+	// ConstraintTemplate.
+	ErrNotATemplate = errors.New("not a ConstraintTemplate")
+	// ErrNotAConstraint indicates the user-indicated file does not contain a
+	// Constraint.
+	ErrNotAConstraint = errors.New("not a Constraint")
+	// ErrAddingTemplate indicates a problem instantiating a Suite's ConstraintTemplate.
+	ErrAddingTemplate = errors.New("adding template")
+	// ErrAddingConstraint indicates a problem instantiating a Suite's Constraint.
+	ErrAddingConstraint = errors.New("adding constraint")
+	// ErrInvalidSuite indicates a Suite does not define the required fields.
+	ErrInvalidSuite = errors.New("invalid Suite")
+	// ErrCreatingClient indicates an error instantiating the Client which compiles
+	// Constraints and runs validation.
+	ErrCreatingClient = errors.New("creating client")
+)

--- a/pkg/gktest/opa.go
+++ b/pkg/gktest/opa.go
@@ -6,7 +6,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/target"
 )
 
-func NewOPAClient() (*opaclient.Client, error) {
+func NewOPAClient() (Client, error) {
 	driver := local.New(local.Tracing(false))
 	backend, err := opaclient.NewBackend(opaclient.Driver(driver))
 	if err != nil {

--- a/pkg/gktest/read_constraints.go
+++ b/pkg/gktest/read_constraints.go
@@ -1,0 +1,96 @@
+package gktest
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+
+	templatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
+	"github.com/open-policy-agent/gatekeeper/apis"
+	"gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// scheme stores the k8s resource types we can instantiate as Templates.
+var scheme = runtime.NewScheme()
+
+func init() {
+	_ = apis.AddToScheme(scheme)
+}
+
+// readTemplate reads the contents of the path and returns the
+// ConstraintTemplate it defines. Returns an error if the file does not define
+// a ConstraintTemplate.
+func readTemplate(f fs.FS, path string) (*templates.ConstraintTemplate, error) {
+	bytes, err := fs.ReadFile(f, path)
+	if err != nil {
+		return nil, fmt.Errorf("reading ConstraintTemplate from %q: %w", path, err)
+	}
+
+	u := unstructured.Unstructured{
+		Object: make(map[string]interface{}),
+	}
+	err = yaml.Unmarshal(bytes, u.Object)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parsing ConstraintTemplate YAML from %q: %v", ErrAddingTemplate, path, err)
+	}
+
+	gvk := u.GroupVersionKind()
+	if gvk.Group != templatesv1.SchemeGroupVersion.Group || gvk.Kind != "ConstraintTemplate" {
+		return nil, fmt.Errorf("%w: %q", ErrNotATemplate, path)
+	}
+
+	t, err := scheme.New(gvk)
+	if err != nil {
+		// The type isn't registered in the scheme.
+		return nil, fmt.Errorf("%w: %v", ErrAddingTemplate, err)
+	}
+
+	// YAML parsing doesn't properly handle ObjectMeta, so we must
+	// marshal/unmashal through JSON.
+	jsonBytes, err := u.MarshalJSON()
+	if err != nil {
+		// Indicates a bug in unstructured.MarshalJSON(). Any Unstructured
+		// unmarshalled from YAML should be marshallable to JSON.
+		return nil, fmt.Errorf("calling unstructured.MarshalJSON(): %w", err)
+	}
+	err = json.Unmarshal(jsonBytes, t)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrAddingTemplate, err)
+	}
+
+	template := &templates.ConstraintTemplate{}
+	err = scheme.Convert(t, template, nil)
+	if err != nil {
+		// This shouldn't happen unless there's a bug in the conversion functions.
+		// Most likely it means the conversion functions weren't generated.
+		return nil, err
+	}
+
+	return template, nil
+}
+
+func readConstraint(f fs.FS, path string) (*unstructured.Unstructured, error) {
+	bytes, err := fs.ReadFile(f, path)
+	if err != nil {
+		return nil, fmt.Errorf("reading Constraint from %q: %w", path, err)
+	}
+
+	c := &unstructured.Unstructured{
+		Object: make(map[string]interface{}),
+	}
+
+	err = yaml.Unmarshal(bytes, c.Object)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parsing Constraint from %q: %v", ErrAddingConstraint, path, err)
+	}
+
+	gvk := c.GroupVersionKind()
+	if gvk.Group != "constraints.gatekeeper.sh" {
+		return nil, ErrNotAConstraint
+	}
+
+	return c, nil
+}

--- a/pkg/gktest/runner.go
+++ b/pkg/gktest/runner.go
@@ -1,0 +1,80 @@
+package gktest
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+)
+
+// Runner defines logic independent of how tests are run and the results are
+// printed.
+type Runner struct {
+	// FS is the filesystem the Runner interacts with to read Suites and objects.
+	FS fs.FS
+
+	// NewClient instantiates a Client for compiling Templates/Constraints, and
+	// validating objects against them.
+	NewClient func() (Client, error)
+
+	// TODO: Add Printer.
+}
+
+// Run executes all Tests in the Suite and returns the results.
+func (r *Runner) Run(ctx context.Context, filter Filter, s *Suite) SuiteResult {
+	result := SuiteResult{
+		TestResults: make([]TestResult, len(s.Tests)),
+	}
+	for i, t := range s.Tests {
+		if filter.MatchesTest(t) {
+			result.TestResults[i] = r.runTest(ctx, filter, t)
+		}
+	}
+	return result
+}
+
+// runTest executes every Case in the Test. Returns the results for every Case.
+func (r *Runner) runTest(ctx context.Context, filter Filter, t Test) TestResult {
+	client, err := r.NewClient()
+	if err != nil {
+		return TestResult{Error: fmt.Errorf("%w: %v", ErrCreatingClient, err)}
+	}
+
+	if t.Template == "" {
+		return TestResult{Error: fmt.Errorf("%w: missing template", ErrInvalidSuite)}
+	}
+	template, err := readTemplate(r.FS, t.Template)
+	if err != nil {
+		return TestResult{Error: err}
+	}
+	_, err = client.AddTemplate(ctx, template)
+	if err != nil {
+		return TestResult{Error: fmt.Errorf("%w: %v", ErrAddingTemplate, err)}
+	}
+
+	if t.Constraint == "" {
+		return TestResult{Error: fmt.Errorf("%w: missing constraint", ErrInvalidSuite)}
+	}
+	cObj, err := readConstraint(r.FS, t.Constraint)
+	if err != nil {
+		return TestResult{Error: err}
+	}
+	_, err = client.AddConstraint(ctx, cObj)
+	if err != nil {
+		return TestResult{Error: fmt.Errorf("%w: %v", ErrAddingConstraint, err)}
+	}
+
+	results := make([]CaseResult, len(t.Cases))
+	for i, c := range t.Cases {
+		if !filter.MatchesCase(c) {
+			continue
+		}
+
+		results[i] = r.runCase(ctx, client, c)
+	}
+	return TestResult{CaseResults: results}
+}
+
+// RunCase executes a Case and returns the result of the run.
+func (r *Runner) runCase(ctx context.Context, client Client, c Case) CaseResult {
+	return CaseResult{}
+}

--- a/pkg/gktest/suite.go
+++ b/pkg/gktest/suite.go
@@ -1,27 +1,8 @@
 package gktest
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/fs"
-
-	"github.com/open-policy-agent/frameworks/constraint/pkg/apis"
-	templatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
-	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 )
-
-// scheme stores the k8s resource types we can instantiate as Templates.
-var scheme = runtime.NewScheme()
-
-func init() {
-	_ = apis.AddToScheme(scheme)
-}
 
 // Suite defines a set of Constraint tests.
 type Suite struct {
@@ -30,19 +11,6 @@ type Suite struct {
 	// Tests is a list of Template&Constraint pairs, with tests to run on
 	// each.
 	Tests []Test
-}
-
-// Run executes all Tests in the Suite and returns the results.
-func (s *Suite) Run(ctx context.Context, client Client, f fs.FS, filter Filter) SuiteResult {
-	result := SuiteResult{
-		TestResults: make([]TestResult, len(s.Tests)),
-	}
-	for i, c := range s.Tests {
-		if filter.MatchesTest(c) {
-			result.TestResults[i] = c.run(ctx, client, f, filter)
-		}
-	}
-	return result
 }
 
 // Test defines a Template&Constraint pair to instantiate, and Cases to
@@ -60,137 +28,5 @@ type Test struct {
 	Cases []Case
 }
 
-var (
-	// ErrNotATemplate indicates the user-indicated file does not contain a
-	// ConstraintTemplate.
-	ErrNotATemplate = errors.New("not a ConstraintTemplate")
-	// ErrNotAConstraint indicates the user-indicated file does not contain a
-	// Constraint.
-	ErrNotAConstraint = errors.New("not a Constraint")
-	// ErrAddingTemplate indicates a problem instantiating a Suite's ConstraintTemplate.
-	ErrAddingTemplate = errors.New("adding template")
-	// ErrAddingConstraint indicates a problem instantiating a Suite's Constraint.
-	ErrAddingConstraint = errors.New("adding constraint")
-	// ErrInvalidSuite indicates a Suite does not define the required fields.
-	ErrInvalidSuite = errors.New("invalid Suite")
-)
-
-// readTemplate reads the contents of the path and returns the
-// ConstraintTemplate it defines. Returns an error if the file does not define
-// a ConstraintTemplate.
-func readTemplate(f fs.FS, path string) (*templates.ConstraintTemplate, error) {
-	bytes, err := fs.ReadFile(f, path)
-	if err != nil {
-		return nil, fmt.Errorf("reading ConstraintTemplate from %q: %w", path, err)
-	}
-
-	u := unstructured.Unstructured{
-		Object: make(map[string]interface{}),
-	}
-	err = yaml.Unmarshal(bytes, u.Object)
-	if err != nil {
-		return nil, fmt.Errorf("%w: parsing ConstraintTemplate YAML from %q: %v", ErrAddingTemplate, path, err)
-	}
-
-	gvk := u.GroupVersionKind()
-	if gvk.Group != templatesv1.SchemeGroupVersion.Group || gvk.Kind != "ConstraintTemplate" {
-		return nil, fmt.Errorf("%w: %q", ErrNotATemplate, path)
-	}
-
-	t, err := scheme.New(gvk)
-	if err != nil {
-		// The type isn't registered in the scheme.
-		return nil, fmt.Errorf("%w: %v", ErrAddingTemplate, err)
-	}
-
-	// YAML parsing doesn't properly handle ObjectMeta, so we must
-	// marshal/unmashal through JSON.
-	jsonBytes, err := u.MarshalJSON()
-	if err != nil {
-		// Indicates a bug in unstructured.MarshalJSON(). Any Unstructured
-		// unmarshalled from YAML should be marshallable to JSON.
-		return nil, fmt.Errorf("calling unstructured.MarshalJSON(): %w", err)
-	}
-	err = json.Unmarshal(jsonBytes, t)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrAddingTemplate, err)
-	}
-
-	template := &templates.ConstraintTemplate{}
-	err = scheme.Convert(t, template, nil)
-	if err != nil {
-		// This shouldn't happen unless there's a bug in the conversion functions.
-		// Most likely it means the conversion functions weren't generated.
-		return nil, err
-	}
-
-	return template, nil
-}
-
-func readConstraint(f fs.FS, path string) (*unstructured.Unstructured, error) {
-	bytes, err := fs.ReadFile(f, path)
-	if err != nil {
-		return nil, fmt.Errorf("reading Constraint from %q: %w", path, err)
-	}
-
-	c := &unstructured.Unstructured{
-		Object: make(map[string]interface{}),
-	}
-
-	err = yaml.Unmarshal(bytes, c.Object)
-	if err != nil {
-		return nil, fmt.Errorf("%w: parsing Constraint from %q: %v", ErrAddingConstraint, path, err)
-	}
-
-	gvk := c.GroupVersionKind()
-	if gvk.Group != "constraints.gatekeeper.sh" {
-		return nil, ErrNotAConstraint
-	}
-
-	return c, nil
-}
-
-// run executes every Case in the Test. Returns the results for every Case.
-func (t Test) run(ctx context.Context, client Client, f fs.FS, filter Filter) TestResult {
-	if t.Template == "" {
-		return TestResult{Error: fmt.Errorf("%w: missing template", ErrInvalidSuite)}
-	}
-	template, err := readTemplate(f, t.Template)
-	if err != nil {
-		return TestResult{Error: err}
-	}
-	_, err = client.AddTemplate(ctx, template)
-	if err != nil {
-		return TestResult{Error: fmt.Errorf("%w: %v", ErrAddingTemplate, err)}
-	}
-
-	if t.Constraint == "" {
-		return TestResult{Error: fmt.Errorf("%w: missing constraint", ErrInvalidSuite)}
-	}
-	cObj, err := readConstraint(f, t.Constraint)
-	if err != nil {
-		return TestResult{Error: err}
-	}
-	_, err = client.AddConstraint(ctx, cObj)
-	if err != nil {
-		return TestResult{Error: fmt.Errorf("%w: %v", ErrAddingConstraint, err)}
-	}
-
-	results := make([]CaseResult, len(t.Cases))
-	for i, tc := range t.Cases {
-		if !filter.MatchesCase(tc) {
-			continue
-		}
-
-		results[i] = tc.run(f, client)
-	}
-	return TestResult{CaseResults: results}
-}
-
 // Case runs Constraint against a YAML object.
 type Case struct{}
-
-// run executes the Case and returns the Result of the run.
-func (c Case) run(f fs.FS, client Client) CaseResult {
-	return CaseResult{}
-}


### PR DESCRIPTION
Now that much of the test running logic is defined, it is more apparent
how to organize it.

Code specific to running tests, but which does not change with the
nature of the tests being run or how the results are printed, should
live in its own place. It may be decorated in the future with objects
(like Printers) which are specified by the user.

This PR has zero changes to logic - it only moves logic around.

Signed-off-by: Will Beason <willbeason@google.com>