### PR TITLE
[mutators] Remove erroneous print statement

### DIFF
--- a/pkg/mutation/mutators/assign_mutator.go
+++ b/pkg/mutation/mutators/assign_mutator.go
@@ -140,7 +140,6 @@ func (m *AssignMutator) DeepCopy() types.Mutator {
 	}
 	copy(res.path.Nodes, m.path.Nodes)
 	copy(res.bindings, m.bindings)
-	fmt.Println(len(res.bindings))
 	res.tester = m.tester.DeepCopy()
 	res.valueTest = m.valueTest.DeepCopy()
 	return res


### PR DESCRIPTION
I forgot to remove this debug line in a previous commit.

Signed-off-by: Will Beason <willbeason@google.com>