### PR TITLE
Reduce System.Mutate runtime by 87%

### DIFF
--- a/pkg/mutation/system.go
+++ b/pkg/mutation/system.go
@@ -105,7 +105,7 @@ func (s *System) Mutate(obj *unstructured.Unstructured, ns *corev1.Namespace) (b
 
 			if m.Matches(obj, ns) {
 				mutated, err := m.Mutate(obj)
-				if mutated && (*MutationLoggingEnabled || *MutationAnnotationsEnabled) {
+				if mutated {
 					appliedMutations = append(appliedMutations, m)
 				}
 				if err != nil {
@@ -113,6 +113,13 @@ func (s *System) Mutate(obj *unstructured.Unstructured, ns *corev1.Namespace) (b
 				}
 			}
 		}
+
+		if len(appliedMutations) == 0 {
+			// If no mutations were applied, we can safely assume the object is
+			// identical to before.
+			return i > 0, nil
+		}
+
 		if cmp.Equal(old, obj) {
 			if i == 0 {
 				return false, nil

--- a/pkg/mutation/system_benchmark_test.go
+++ b/pkg/mutation/system_benchmark_test.go
@@ -1,0 +1,62 @@
+package mutation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
+	"github.com/open-policy-agent/gatekeeper/pkg/mutation/match"
+	"github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func makeValue(v interface{}) runtime.RawExtension {
+	v2 := map[string]interface{}{
+		"value": v,
+	}
+	j, err := json.Marshal(v2)
+	if err != nil {
+		panic(err)
+	}
+	return runtime.RawExtension{Raw: j}
+}
+
+func assign(value interface{}, location string) *v1alpha1.Assign {
+	result := &v1alpha1.Assign{
+		Spec: v1alpha1.AssignSpec{
+			ApplyTo: []match.ApplyTo{{
+				Groups:   []string{"*"},
+				Versions: []string{"*"},
+				Kinds:    []string{"*"},
+			}},
+			Location: location,
+			Parameters: v1alpha1.Parameters{
+				Assign: makeValue(value),
+			},
+		},
+	}
+
+	return result
+}
+
+func BenchmarkSystem_Mutate(b *testing.B) {
+	s := NewSystem()
+
+	a := assign("", "spec")
+	m, err := mutators.MutatorForAssign(a)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	err = s.Upsert(m)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	for i := 0; i < b.N; i++ {
+		u := &unstructured.Unstructured{}
+
+		_, _ = s.Mutate(u, nil)
+	}
+}

--- a/pkg/mutation/system_test.go
+++ b/pkg/mutation/system_test.go
@@ -98,7 +98,7 @@ func (m *fakeMutator) SchemaBindings() []schema.GroupVersionKind {
 	return m.GVKs
 }
 
-var mutators = []types.Mutator{
+var initMutators = []types.Mutator{
 	&fakeMutator{MID: types.ID{Group: "bbb", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 	&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "ccc", Name: "ddd"}},
 	&fakeMutator{MID: types.ID{Group: "aaa", Kind: "bbb", Namespace: "aaa", Name: "aaa"}},
@@ -116,7 +116,7 @@ func TestSorting(t *testing.T) {
 	}{
 		{
 			tname:   "testsort",
-			initial: mutators,
+			initial: initMutators,
 			expected: []types.Mutator{
 				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
@@ -129,7 +129,7 @@ func TestSorting(t *testing.T) {
 		},
 		{
 			tname:   "testremove",
-			initial: mutators,
+			initial: initMutators,
 			expected: []types.Mutator{
 				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
@@ -143,7 +143,7 @@ func TestSorting(t *testing.T) {
 		},
 		{
 			tname:   "testaddingsame",
-			initial: mutators,
+			initial: initMutators,
 			expected: []types.Mutator{
 				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},
@@ -158,7 +158,7 @@ func TestSorting(t *testing.T) {
 		},
 		{
 			tname:   "testaddingdifferent",
-			initial: mutators,
+			initial: initMutators,
 			expected: []types.Mutator{
 				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "aaa", Name: "aaa"}},
 				&fakeMutator{MID: types.ID{Group: "aaa", Kind: "aaa", Namespace: "ccc", Name: "ddd"}},


### PR DESCRIPTION
Depends on #1452.

Add a basic benchmark test for System.Mutate.

In this case benchmarking pointed to an easy way to improve performance dramatically, so I've bundled the changes together in this PR.

Most of the time we spend in System.Mutate is in cmp.Equal. However, we know that "old" and "obj" are identical if no Mutators were run. This means if in an iteration no Mutators reported making any changes, we can immediately assume:

1) If we are on the first iteration, then old == obj == original, and so no changes were made to the object.
2) Otherwise, we know that (old == obj), and both are distinct from original (since we verified this in the first iteration).

```
$ benchstat before.txt after.txt 
name              old time/op  new time/op  delta
System_Mutate-12  8.77µs ± 3%  1.14µs ± 7%  -86.97%  (p=0.000 n=20+20)
```