### PR TITLE
run gator test

### DIFF
--- a/cmd/gator/gator.go
+++ b/cmd/gator/gator.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/open-policy-agent/gatekeeper/cmd/gator/test"
@@ -26,7 +25,6 @@ var rootCmd = &cobra.Command{
 func main() {
 	err := rootCmd.Execute()
 	if err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }

--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -104,9 +104,7 @@ func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.
 	i := 0
 
 	for path, suite := range suites {
-		suiteDir := filepath.Dir(path)
-
-		suiteResult := runner.Run(ctx, filter, suiteDir, suite)
+		suiteResult := runner.Run(ctx, filter, path, suite)
 		for _, testResult := range suiteResult.TestResults {
 			if testResult.Error != nil {
 				isFailure = true

--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -33,7 +33,7 @@ const (
 )
 
 var (
-	run string
+	run     string
 	verbose bool
 )
 
@@ -114,10 +114,10 @@ func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.
 					isFailure = true
 				}
 			}
-
-			results[i] = suiteResult
-			i++
 		}
+
+		results[i] = suiteResult
+		i++
 
 		w := &strings.Builder{}
 		printer := gktest.PrinterGo{}

--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -119,10 +119,6 @@ func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.
 			i++
 		}
 
-		sort.Slice(results, func(i, j int) bool {
-			return results[i].Path < results[j].Path
-		})
-
 		w := &strings.Builder{}
 		printer := gktest.PrinterGo{}
 		err := printer.Print(w, results, verbose)
@@ -131,6 +127,10 @@ func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.
 		}
 		fmt.Println(w)
 	}
+
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Path < results[j].Path
+	})
 
 	if isFailure {
 		// At least one test failed or there was a problem executing tests in at

--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/open-policy-agent/gatekeeper/pkg/gktest"
@@ -118,19 +117,14 @@ func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.
 
 		results[i] = suiteResult
 		i++
-
-		w := &strings.Builder{}
-		printer := gktest.PrinterGo{}
-		err := printer.Print(w, results, verbose)
-		if err != nil {
-			return err
-		}
-		fmt.Println(w)
 	}
-
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Path < results[j].Path
-	})
+	w := &strings.Builder{}
+	printer := gktest.PrinterGo{}
+	err := printer.Print(w, results, verbose)
+	if err != nil {
+		return err
+	}
+	fmt.Println(w)
 
 	if isFailure {
 		// At least one test failed or there was a problem executing tests in at

--- a/pkg/gktest/client.go
+++ b/pkg/gktest/client.go
@@ -6,10 +6,13 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type Client interface {
+	CreateCRD(ctx context.Context, templ *templates.ConstraintTemplate) (*apiextensions.CustomResourceDefinition, error)
+
 	// AddTemplate adds a Template to the Client. Templates define the structure
 	// and parameters of potential Constraints.
 	AddTemplate(ctx context.Context, templ *templates.ConstraintTemplate) (*types.Responses, error)

--- a/pkg/gktest/client.go
+++ b/pkg/gktest/client.go
@@ -6,13 +6,10 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type Client interface {
-	CreateCRD(ctx context.Context, templ *templates.ConstraintTemplate) (*apiextensions.CustomResourceDefinition, error)
-
 	// AddTemplate adds a Template to the Client. Templates define the structure
 	// and parameters of potential Constraints.
 	AddTemplate(ctx context.Context, templ *templates.ConstraintTemplate) (*types.Responses, error)

--- a/pkg/gktest/printer_go.go
+++ b/pkg/gktest/printer_go.go
@@ -54,6 +54,12 @@ func (p PrinterGo) PrintSuite(w StringWriter, r *SuiteResult, verbose bool) erro
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrWritingString, err)
 		}
+		if r.Error != nil {
+			_, err = w.WriteString(fmt.Sprintf("  %v\n", r.Error))
+		}
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrWritingString, err)
+		}
 	} else {
 		_, err := w.WriteString(fmt.Sprintf("ok\t%s\t%v\n", r.Path, r.Runtime))
 		if err != nil {
@@ -80,6 +86,12 @@ func (p PrinterGo) PrintTest(w StringWriter, r *TestResult, verbose bool) error 
 
 	if r.IsFailure() {
 		_, err := w.WriteString(fmt.Sprintf("--- FAIL: %s\t(%v)\n", r.Name, r.Runtime))
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrWritingString, err)
+		}
+		if r.Error != nil {
+			_, err = w.WriteString(fmt.Sprintf("  %v\n", r.Error))
+		}
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrWritingString, err)
 		}

--- a/pkg/gktest/printer_go.go
+++ b/pkg/gktest/printer_go.go
@@ -56,9 +56,9 @@ func (p PrinterGo) PrintSuite(w StringWriter, r *SuiteResult, verbose bool) erro
 		}
 		if r.Error != nil {
 			_, err = w.WriteString(fmt.Sprintf("  %v\n", r.Error))
-		}
-		if err != nil {
-			return fmt.Errorf("%w: %v", ErrWritingString, err)
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrWritingString, err)
+			}
 		}
 	} else {
 		_, err := w.WriteString(fmt.Sprintf("ok\t%s\t%v\n", r.Path, r.Runtime))
@@ -91,9 +91,9 @@ func (p PrinterGo) PrintTest(w StringWriter, r *TestResult, verbose bool) error 
 		}
 		if r.Error != nil {
 			_, err = w.WriteString(fmt.Sprintf("  %v\n", r.Error))
-		}
-		if err != nil {
-			return fmt.Errorf("%w: %v", ErrWritingString, err)
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrWritingString, err)
+			}
 		}
 	} else if verbose {
 		_, err := w.WriteString(fmt.Sprintf("--- PASS: %s\t(%v)\n", r.Name, r.Runtime))

--- a/pkg/gktest/printer_go_test.go
+++ b/pkg/gktest/printer_go_test.go
@@ -32,10 +32,10 @@ func TestPrinterGo_Print(t *testing.T) {
 			result: []SuiteResult{{
 				Path: "tests.go",
 			}},
-			want: `ok	tests.go	0s
+			want: `ok	tests.go	0.000s
 PASS
 `,
-			wantVerbose: `ok	tests.go	0s
+			wantVerbose: `ok	tests.go	0.000s
 PASS
 `,
 		},
@@ -49,12 +49,12 @@ PASS
 					Runtime: Duration(330 * time.Millisecond),
 				}},
 			}},
-			want: `ok	tests.go	0.33s
+			want: `ok	tests.go	0.330s
 PASS
 `,
 			wantVerbose: `=== RUN   forbid-labels
---- PASS: forbid-labels	(0.33s)
-ok	tests.go	0.33s
+--- PASS: forbid-labels	(0.330s)
+ok	tests.go	0.330s
 PASS
 `,
 		},
@@ -75,16 +75,16 @@ PASS
 					}},
 				}},
 			}},
-			want: `ok	tests.go	0.33s
+			want: `ok	tests.go	0.330s
 PASS
 `,
 			wantVerbose: `=== RUN   forbid-labels
     === RUN   forbid-labels/with label
-    --- PASS: forbid-labels/with label	(0.1s)
+    --- PASS: forbid-labels/with label	(0.100s)
     === RUN   forbid-labels/without label
-    --- PASS: forbid-labels/without label	(0.23s)
---- PASS: forbid-labels	(0.33s)
-ok	tests.go	0.33s
+    --- PASS: forbid-labels/without label	(0.230s)
+--- PASS: forbid-labels	(0.330s)
+ok	tests.go	0.330s
 PASS
 `,
 		},
@@ -106,20 +106,20 @@ PASS
 					}},
 				}},
 			}},
-			want: `    --- FAIL: forbid-labels/without label	(0.23s)
+			want: `    --- FAIL: forbid-labels/without label	(0.230s)
         got violation but want allow
---- FAIL: forbid-labels	(0.33s)
-FAIL	tests.go	0.33s
+--- FAIL: forbid-labels	(0.330s)
+FAIL	tests.go	0.330s
 FAIL
 `,
 			wantVerbose: `=== RUN   forbid-labels
     === RUN   forbid-labels/with label
-    --- PASS: forbid-labels/with label	(0.1s)
+    --- PASS: forbid-labels/with label	(0.100s)
     === RUN   forbid-labels/without label
-    --- FAIL: forbid-labels/without label	(0.23s)
+    --- FAIL: forbid-labels/without label	(0.230s)
         got violation but want allow
---- FAIL: forbid-labels	(0.33s)
-FAIL	tests.go	0.33s
+--- FAIL: forbid-labels	(0.330s)
+FAIL	tests.go	0.330s
 FAIL
 `,
 		},
@@ -154,24 +154,24 @@ FAIL
 					}},
 				}},
 			}},
-			want: `ok	tests.go	0.33s
-ok	tests-2.go	0.4s
+			want: `ok	tests.go	0.330s
+ok	tests-2.go	0.400s
 PASS
 `,
 			wantVerbose: `=== RUN   forbid-labels
     === RUN   forbid-labels/with label
-    --- PASS: forbid-labels/with label	(0.1s)
+    --- PASS: forbid-labels/with label	(0.100s)
     === RUN   forbid-labels/without label
-    --- PASS: forbid-labels/without label	(0.23s)
---- PASS: forbid-labels	(0.33s)
-ok	tests.go	0.33s
+    --- PASS: forbid-labels/without label	(0.230s)
+--- PASS: forbid-labels	(0.330s)
+ok	tests.go	0.330s
 === RUN   require-labels
     === RUN   require-labels/with label
-    --- PASS: require-labels/with label	(0.17s)
+    --- PASS: require-labels/with label	(0.170s)
     === RUN   require-labels/without label
-    --- PASS: require-labels/without label	(0.23s)
---- PASS: require-labels	(0.4s)
-ok	tests-2.go	0.4s
+    --- PASS: require-labels/without label	(0.230s)
+--- PASS: require-labels	(0.400s)
+ok	tests-2.go	0.400s
 PASS
 `,
 		},
@@ -202,22 +202,22 @@ PASS
 					}},
 				}},
 			}},
-			want: `ok	tests.go	0.73s
+			want: `ok	tests.go	0.730s
 PASS
 `,
 			wantVerbose: `=== RUN   forbid-labels
     === RUN   forbid-labels/with label
-    --- PASS: forbid-labels/with label	(0.1s)
+    --- PASS: forbid-labels/with label	(0.100s)
     === RUN   forbid-labels/without label
-    --- PASS: forbid-labels/without label	(0.23s)
---- PASS: forbid-labels	(0.33s)
+    --- PASS: forbid-labels/without label	(0.230s)
+--- PASS: forbid-labels	(0.330s)
 === RUN   require-labels
     === RUN   require-labels/with label
-    --- PASS: require-labels/with label	(0.17s)
+    --- PASS: require-labels/with label	(0.170s)
     === RUN   require-labels/without label
-    --- PASS: require-labels/without label	(0.23s)
---- PASS: require-labels	(0.4s)
-ok	tests.go	0.73s
+    --- PASS: require-labels/without label	(0.230s)
+--- PASS: require-labels	(0.400s)
+ok	tests.go	0.730s
 PASS
 `,
 		},

--- a/pkg/gktest/read_suites.go
+++ b/pkg/gktest/read_suites.go
@@ -46,7 +46,7 @@ const (
 // Returns an error if:
 // - path is a file that does not define a Suite
 // - any matched files containing Suites are not parseable.
-func ReadSuites(f fs.FS, target string, recursive bool) ([]Suite, error) {
+func ReadSuites(f fs.FS, target string, recursive bool) (map[string]*Suite, error) {
 	if f == nil {
 		return nil, ErrNoFileSystem
 	}
@@ -86,15 +86,16 @@ func ReadSuites(f fs.FS, target string, recursive bool) ([]Suite, error) {
 }
 
 // readSuites reads the passed set of files into Suites on the given filesystem.
-func readSuites(f fs.FS, files []string) ([]Suite, error) {
-	var suites []Suite
+func readSuites(f fs.FS, files []string) (map[string]*Suite, error) {
+	suites := make(map[string]*Suite)
 	for _, file := range files {
 		suite, err := readSuite(f, file)
 		if err != nil {
 			return nil, err
 		}
+
 		if suite != nil {
-			suites = append(suites, *suite)
+			suites[file] = suite
 		}
 	}
 	return suites, nil

--- a/pkg/gktest/read_suites_test.go
+++ b/pkg/gktest/read_suites_test.go
@@ -7,6 +7,7 @@ import (
 	"testing/fstest"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestReadSuites(t *testing.T) {
@@ -15,7 +16,7 @@ func TestReadSuites(t *testing.T) {
 		target     string
 		recursive  bool
 		fileSystem fs.FS
-		want       []Suite
+		want       map[string]*Suite
 		wantErr    error
 	}{
 		{
@@ -66,7 +67,7 @@ apiVersion: test.gatekeeper.sh/v1alpha1
 `),
 				},
 			},
-			want:    []Suite{{}},
+			want:    map[string]*Suite{"test.yaml": {}},
 			wantErr: nil,
 		},
 		{
@@ -141,7 +142,7 @@ apiVersion: test.gatekeeper.sh/v1alpha1
 `),
 				},
 			},
-			want:    []Suite{{}},
+			want:     map[string]*Suite{"tests/test.yaml": {}},
 			wantErr: nil,
 		},
 		{
@@ -159,7 +160,7 @@ apiVersion: test.gatekeeper.sh/v1alpha1
 					Data: []byte(`some data`),
 				},
 			},
-			want:    []Suite{{}},
+			want:    map[string]*Suite{"tests/test.yaml": {}},
 			wantErr: nil,
 		},
 		{
@@ -186,7 +187,7 @@ apiVersion: test.gatekeeper.sh/v1alpha1
 `),
 				},
 			},
-			want:    []Suite{{}},
+			want:    map[string]*Suite{"tests/test.yaml": {}},
 			wantErr: nil,
 		},
 		{
@@ -213,7 +214,11 @@ apiVersion: test.gatekeeper.sh/v1alpha1
 `),
 				},
 			},
-			want:    []Suite{{}, {}, {}},
+			want:    map[string]*Suite{
+				"tests/labels/test.yaml": {},
+				"tests/annotations/test.yaml": {},
+				"tests/test.yaml": {},
+			},
 			wantErr: nil,
 		},
 		{
@@ -228,7 +233,7 @@ apiVersion: test.gatekeeper.sh/v1alpha1
 `),
 				},
 			},
-			want:    []Suite{{}},
+			want:    map[string]*Suite{"tests/labels.yaml/test.yaml": {}},
 			wantErr: nil,
 		},
 		{
@@ -264,8 +269,8 @@ tests:
 `),
 				},
 			},
-			want: []Suite{{
-				Tests: []Test{{
+			want: map[string]*Suite{"test.yaml":
+				{Tests: []Test{{
 					Template:   "template.yaml",
 					Constraint: "constraint.yaml",
 					Cases: []Case{{
@@ -292,7 +297,7 @@ tests:
 `),
 				},
 			},
-			want: []Suite{{
+			want: map[string]*Suite{"test.yaml": {
 				Tests: []Test{{
 					Template:   "template.yaml",
 					Constraint: "constraint.yaml",
@@ -310,7 +315,7 @@ tests:
 					gotErr, tc.wantErr)
 			}
 
-			if diff := cmp.Diff(tc.want, got); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/pkg/gktest/read_suites_test.go
+++ b/pkg/gktest/read_suites_test.go
@@ -269,15 +269,16 @@ tests:
 `),
 				},
 			},
-			want: map[string]*Suite{"test.yaml": {Tests: []Test{{
-				Template:   "template.yaml",
-				Constraint: "constraint.yaml",
-				Cases: []Case{{
-					Allow: "allow.yaml",
-				}, {
-					Deny: "deny.yaml",
+			want: map[string]*Suite{"test.yaml": {
+				Tests: []Test{{
+					Template:   "template.yaml",
+					Constraint: "constraint.yaml",
+					Cases: []Case{{
+						Allow: "allow.yaml",
+					}, {
+						Deny: "deny.yaml",
+					}},
 				}},
-			}},
 			}},
 			wantErr: nil,
 		},

--- a/pkg/gktest/read_suites_test.go
+++ b/pkg/gktest/read_suites_test.go
@@ -142,7 +142,7 @@ apiVersion: test.gatekeeper.sh/v1alpha1
 `),
 				},
 			},
-			want:     map[string]*Suite{"tests/test.yaml": {}},
+			want:    map[string]*Suite{"tests/test.yaml": {}},
 			wantErr: nil,
 		},
 		{
@@ -214,10 +214,10 @@ apiVersion: test.gatekeeper.sh/v1alpha1
 `),
 				},
 			},
-			want:    map[string]*Suite{
-				"tests/labels/test.yaml": {},
+			want: map[string]*Suite{
+				"tests/labels/test.yaml":      {},
 				"tests/annotations/test.yaml": {},
-				"tests/test.yaml": {},
+				"tests/test.yaml":             {},
 			},
 			wantErr: nil,
 		},
@@ -269,16 +269,15 @@ tests:
 `),
 				},
 			},
-			want: map[string]*Suite{"test.yaml":
-				{Tests: []Test{{
-					Template:   "template.yaml",
-					Constraint: "constraint.yaml",
-					Cases: []Case{{
-						Allow: "allow.yaml",
-					}, {
-						Deny: "deny.yaml",
-					}},
+			want: map[string]*Suite{"test.yaml": {Tests: []Test{{
+				Template:   "template.yaml",
+				Constraint: "constraint.yaml",
+				Cases: []Case{{
+					Allow: "allow.yaml",
+				}, {
+					Deny: "deny.yaml",
 				}},
+			}},
 			}},
 			wantErr: nil,
 		},

--- a/pkg/gktest/result.go
+++ b/pkg/gktest/result.go
@@ -10,7 +10,7 @@ import (
 type Duration time.Duration
 
 func (d Duration) String() string {
-	return fmt.Sprintf("%.3gs", float64(time.Duration(d).Milliseconds())/1000.0)
+	return fmt.Sprintf("%.3gs", time.Duration(d).Seconds())
 }
 
 // SuiteResult is the Result of running a Suite of tests.

--- a/pkg/gktest/result.go
+++ b/pkg/gktest/result.go
@@ -10,7 +10,7 @@ import (
 type Duration time.Duration
 
 func (d Duration) String() string {
-	return fmt.Sprintf("%.3gs", time.Duration(d).Seconds())
+	return fmt.Sprintf("%.3fs", time.Duration(d).Seconds())
 }
 
 // SuiteResult is the Result of running a Suite of tests.

--- a/pkg/gktest/runner.go
+++ b/pkg/gktest/runner.go
@@ -22,11 +22,14 @@ type Runner struct {
 }
 
 // Run executes all Tests in the Suite and returns the results.
-func (r *Runner) Run(ctx context.Context, filter Filter, suiteDir string, s *Suite) SuiteResult {
+func (r *Runner) Run(ctx context.Context, filter Filter, suitePath string, s *Suite) SuiteResult {
 	start := time.Now()
 	result := SuiteResult{
+		Path: suitePath,
 		TestResults: make([]TestResult, len(s.Tests)),
 	}
+	suiteDir := filepath.Dir(suitePath)
+
 	for i, t := range s.Tests {
 		if filter.MatchesTest(t) {
 			start := time.Now()

--- a/pkg/gktest/runner.go
+++ b/pkg/gktest/runner.go
@@ -25,7 +25,7 @@ type Runner struct {
 func (r *Runner) Run(ctx context.Context, filter Filter, suitePath string, s *Suite) SuiteResult {
 	start := time.Now()
 	result := SuiteResult{
-		Path: suitePath,
+		Path:        suitePath,
 		TestResults: make([]TestResult, len(s.Tests)),
 	}
 	suiteDir := filepath.Dir(suitePath)

--- a/pkg/gktest/runner.go
+++ b/pkg/gktest/runner.go
@@ -23,7 +23,7 @@ type Runner struct {
 
 // Run executes all Tests in the Suite and returns the results.
 func (r *Runner) Run(ctx context.Context, filter Filter, suitePath string, s *Suite) SuiteResult {
-	start := time.Now()
+	suiteStart := time.Now()
 	result := SuiteResult{
 		Path:        suitePath,
 		TestResults: make([]TestResult, len(s.Tests)),
@@ -32,14 +32,14 @@ func (r *Runner) Run(ctx context.Context, filter Filter, suitePath string, s *Su
 
 	for i, t := range s.Tests {
 		if filter.MatchesTest(t) {
-			start := time.Now()
+			testStart := time.Now()
 			result.TestResults[i] = r.runTest(ctx, suiteDir, filter, t)
 			result.TestResults[i].Name = t.Name
-			result.TestResults[i].Runtime = Duration(time.Since(start))
+			result.TestResults[i].Runtime = Duration(time.Since(testStart))
 		}
 	}
 
-	result.Runtime = Duration(time.Since(start))
+	result.Runtime = Duration(time.Since(suiteStart))
 	return result
 }
 

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -28,6 +28,7 @@ spec:
         package k8salwaysvalidate
         violation[{"msg": msg}] {
           false
+          msg := "should always pass"
         }
 `
 
@@ -65,8 +66,9 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8sdisallowedtags
-        violation {
-          false
+        violation[{"msg": msg}] {
+          true
+          msg := "never validate"
         }
 `
 
@@ -85,8 +87,9 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8sdisallowedtags
-        violation {
-          false
+        violation[{"msg": msg}] {
+          true
+          msg := "never validate"
         }
 `
 
@@ -112,8 +115,9 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8sdisallowedtags
-        violation {
+        violation[{"msg": msg}] {
           f
+          msg := "never validate"
         }
 `
 
@@ -601,9 +605,11 @@ func TestRunner_Run(t *testing.T) {
 		}
 
 		t.Run(tc.name, func(t *testing.T) {
-			got := runner.Run(ctx, Filter{}, &tc.suite)
+			got := runner.Run(ctx, Filter{}, "", &tc.suite)
 
-			if diff := cmp.Diff(tc.want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(tc.want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(SuiteResult{}, "Runtime"), cmpopts.IgnoreFields(TestResult{}, "Runtime"), cmpopts.IgnoreFields(CaseResult{}, "Runtime"),
+				); diff != "" {
 				t.Errorf(diff)
 			}
 		})
@@ -627,9 +633,11 @@ func TestRunner_Run_ClientError(t *testing.T) {
 	suite := &Suite{
 		Tests: []Test{{}},
 	}
-	got := runner.Run(ctx, Filter{}, suite)
+	got := runner.Run(ctx, Filter{}, "", suite)
 
-	if diff := cmp.Diff(want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty()); diff != "" {
+	if diff := cmp.Diff(want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty(),
+		cmpopts.IgnoreFields(SuiteResult{}, "Runtime"), cmpopts.IgnoreFields(TestResult{}, "Runtime"), cmpopts.IgnoreFields(CaseResult{}, "Runtime"),
+		); diff != "" {
 		t.Error(diff)
 	}
 }

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -609,7 +609,7 @@ func TestRunner_Run(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(SuiteResult{}, "Runtime"), cmpopts.IgnoreFields(TestResult{}, "Runtime"), cmpopts.IgnoreFields(CaseResult{}, "Runtime"),
-				); diff != "" {
+			); diff != "" {
 				t.Errorf(diff)
 			}
 		})
@@ -637,7 +637,7 @@ func TestRunner_Run_ClientError(t *testing.T) {
 
 	if diff := cmp.Diff(want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(SuiteResult{}, "Runtime"), cmpopts.IgnoreFields(TestResult{}, "Runtime"), cmpopts.IgnoreFields(CaseResult{}, "Runtime"),
-		); diff != "" {
+	); diff != "" {
 		t.Error(diff)
 	}
 }

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -26,7 +26,7 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package k8salwaysvalidate
-        violation {
+        violation[{"msg": msg}] {
           false
         }
 `

--- a/pkg/gktest/suite.go
+++ b/pkg/gktest/suite.go
@@ -16,6 +16,8 @@ type Suite struct {
 // Test defines a Template&Constraint pair to instantiate, and Cases to
 // run on the instantiated Constraint.
 type Test struct {
+	Name string `json:"name"`
+
 	// Template is the path to the ConstraintTemplate, relative to the file
 	// defining the Suite.
 	Template string `json:"template"`
@@ -30,6 +32,7 @@ type Test struct {
 
 // Case runs Constraint against a YAML object.
 type Case struct {
+	Name       string `json:"name"`
 	Allow      string `json:"allow"`
 	Deny       string `json:"deny"`
 	Assertions []Assertion


### PR DESCRIPTION
Make it possible to run gator test successfully.

A note on timings: The sum of the times for a case adds up to significantly less than the reported runtime for the test. This is because the test runtime includes compiling the Template and instantiating the Constraint, but individual cases do not. Times for suites are approximately the sum of their test runtimes as there is no significant overhead.

Failure:
```
$ gator test suite.yaml
    --- FAIL: allow object	(0.00417s)
        got violations: All namespaces must have an `owner` label that points to your company username
--- FAIL: deny if name is forbidden	(0.0778s)
FAIL		0.0778s
FAIL
```

Verbose Failure:
```
$ gator test suite.yaml  -v
=== RUN   deny if name is forbidden
    === RUN   allow object
    --- FAIL: allow object	(0.0029s)
        got violations: All namespaces must have an `owner` label that points to your company username
    === RUN   deny object
    --- PASS: deny object	(0.00161s)
--- FAIL: deny if name is forbidden	(0.0838s)
FAIL		0.0838s
FAIL
```

Success:
```
$ gator test suite.yaml
ok		0.0859s
PASS
```

Verbose Success:
```
$ gator test suite.yaml  -v
=== RUN   deny if name is forbidden
    === RUN   allow object
    --- PASS: allow object	(0.00264s)
    === RUN   deny object
    --- PASS: deny object	(0.00252s)
--- PASS: deny if name is forbidden	(0.0879s)
ok	usr/local/google/home/willbeason/gator-test/suite.yaml	0.0879s
PASS
```