### PR TITLE
fix whitespace error in the debugging docs

### DIFF
--- a/website/docs/debug.md
+++ b/website/docs/debug.md
@@ -84,8 +84,8 @@ spec:
           group: ""
           version: "v1"
           kind: "Namespace"
-          # If dump is defined and set to `All`, also dump the state of OPA
-          dump: "All"
+        # If dump is defined and set to `All`, also dump the state of OPA
+        dump: "All"
 ```
 
 Traces will be written to the stdout logs of the Gatekeeper controller.


### PR DESCRIPTION
**What this PR does / why we need it**: it fixes an error in the docs

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: https://github.com/open-policy-agent/gatekeeper/blob/master/apis/config/v1alpha1/config_types.go#L45-L52