### PR TITLE
Add label to bats http.send test for idempotence

### DIFF
--- a/test/bats/tests/templates/use_http_send_template.yaml
+++ b/test/bats/tests/templates/use_http_send_template.yaml
@@ -2,6 +2,8 @@ apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
   name: k8sdenynamehttpsend
+  labels:
+    gatekeeper.sh/tests: "yes"
 spec:
   crd:
     spec:


### PR DESCRIPTION
Signed-off-by: Ivan Font <ifont@redhat.com>

**What this PR does / why we need it**:
The bats tests rely on common labels to cleanup the test resources such as `constrainttemplates` that are created throughout the bats tests. This particular CT was missing that common label and as a result was not being deleted at the end. This now adds the label so the bats tests can remain idempotent.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Ref #1119.

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: