### PR TITLE
Add go runtime metrics to /metrics endpoint

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/pkg/errors"
+	"go.opencensus.io/plugin/runmetrics"
 	"go.opencensus.io/stats/view"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -21,6 +23,17 @@ var _ manager.Runnable = &runner{}
 
 type runner struct {
 	mgr manager.Manager
+}
+
+func init() {
+	err := runmetrics.Enable(runmetrics.RunMetricOptions{
+		EnableCPU:    true,
+		EnableMemory: true,
+		Prefix:       "go_runtime/",
+	})
+	if err != nil {
+		panic(errors.Wrap(err, "Failed to Enable golang runtime metrics"))
+	}
 }
 
 func AddToManager(m manager.Manager) error {

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -32,7 +32,7 @@ func init() {
 		Prefix:       "go_runtime/",
 	})
 	if err != nil {
-		panic(errors.Wrap(err, "Failed to Enable golang runtime metrics"))
+		panic(errors.Wrap(err, "Failed to enable golang runtime metrics"))
 	}
 }
 

--- a/vendor/go.opencensus.io/metric/common.go
+++ b/vendor/go.opencensus.io/metric/common.go
@@ -1,0 +1,143 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"sync"
+	"time"
+
+	"go.opencensus.io/internal/tagencoding"
+
+	"go.opencensus.io/metric/metricdata"
+)
+
+// baseMetric is common representation for gauge and cumulative metrics.
+//
+// baseMetric maintains a value for each combination of label values passed to
+// Set, Add, or Inc method.
+//
+// baseMetric should not be used directly, use metric specific type such as
+// Float64Gauge or Int64Gauge.
+type baseMetric struct {
+	vals             sync.Map
+	desc             metricdata.Descriptor
+	start            time.Time
+	keys             []metricdata.LabelKey
+	constLabelValues []metricdata.LabelValue
+	bmType           baseMetricType
+}
+
+type baseMetricType int
+
+const (
+	gaugeInt64 baseMetricType = iota
+	gaugeFloat64
+	derivedGaugeInt64
+	derivedGaugeFloat64
+	cumulativeInt64
+	cumulativeFloat64
+	derivedCumulativeInt64
+	derivedCumulativeFloat64
+)
+
+type baseEntry interface {
+	read(t time.Time) metricdata.Point
+}
+
+func (bm *baseMetric) startTime() *time.Time {
+	switch bm.bmType {
+	case cumulativeInt64, cumulativeFloat64, derivedCumulativeInt64, derivedCumulativeFloat64:
+		return &bm.start
+	default:
+		// gauges don't have start time.
+		return nil
+	}
+}
+
+// Read returns the current values of the baseMetric as a metric for export.
+func (bm *baseMetric) read() *metricdata.Metric {
+	now := time.Now()
+	startTime := bm.startTime()
+	if startTime == nil {
+		startTime = &now
+	}
+	m := &metricdata.Metric{
+		Descriptor: bm.desc,
+	}
+	bm.vals.Range(func(k, v interface{}) bool {
+		entry := v.(baseEntry)
+		key := k.(string)
+		labelVals := bm.decodeLabelVals(key)
+		m.TimeSeries = append(m.TimeSeries, &metricdata.TimeSeries{
+			StartTime:   *startTime,
+			LabelValues: labelVals,
+			Points: []metricdata.Point{
+				entry.read(now),
+			},
+		})
+		return true
+	})
+	return m
+}
+
+func (bm *baseMetric) encodeLabelVals(labelVals []metricdata.LabelValue) string {
+	vb := &tagencoding.Values{}
+	for _, v := range labelVals {
+		b := make([]byte, 1, len(v.Value)+1)
+		if v.Present {
+			b[0] = 1
+			b = append(b, []byte(v.Value)...)
+		}
+		vb.WriteValue(b)
+	}
+	return string(vb.Bytes())
+}
+
+func (bm *baseMetric) decodeLabelVals(s string) []metricdata.LabelValue {
+	vals := make([]metricdata.LabelValue, 0, len(bm.keys))
+	vb := &tagencoding.Values{Buffer: []byte(s)}
+	for range bm.keys {
+		v := vb.ReadValue()
+		if v[0] == 0 {
+			vals = append(vals, metricdata.LabelValue{})
+		} else {
+			vals = append(vals, metricdata.NewLabelValue(string(v[1:])))
+		}
+	}
+	return vals
+}
+
+func (bm *baseMetric) entryForValues(labelVals []metricdata.LabelValue, newEntry func() baseEntry) (interface{}, error) {
+	labelVals = append(bm.constLabelValues, labelVals...)
+	if len(labelVals) != len(bm.keys) {
+		return nil, errKeyValueMismatch
+	}
+	mapKey := bm.encodeLabelVals(labelVals)
+	if entry, ok := bm.vals.Load(mapKey); ok {
+		return entry, nil
+	}
+	entry, _ := bm.vals.LoadOrStore(mapKey, newEntry())
+	return entry, nil
+}
+
+func (bm *baseMetric) upsertEntry(labelVals []metricdata.LabelValue, newEntry func() baseEntry) error {
+	if len(labelVals) != len(bm.keys) {
+		return errKeyValueMismatch
+	}
+	mapKey := bm.encodeLabelVals(labelVals)
+	bm.vals.Delete(mapKey)
+	bm.vals.Store(mapKey, newEntry())
+	return nil
+}

--- a/vendor/go.opencensus.io/metric/cumulative.go
+++ b/vendor/go.opencensus.io/metric/cumulative.go
@@ -1,0 +1,188 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+
+	"go.opencensus.io/metric/metricdata"
+)
+
+// Float64Cumulative represents a float64 value that can only go up.
+//
+// Float64Cumulative maintains a float64 value for each combination of label values
+// passed to the Set or Inc methods.
+type Float64Cumulative struct {
+	bm baseMetric
+}
+
+// Float64CumulativeEntry represents a single value of the cumulative corresponding to a set
+// of label values.
+type Float64CumulativeEntry struct {
+	val uint64 // needs to be uint64 for atomic access, interpret with math.Float64frombits
+}
+
+func (e *Float64CumulativeEntry) read(t time.Time) metricdata.Point {
+	v := math.Float64frombits(atomic.LoadUint64(&e.val))
+	if v < 0 {
+		v = 0
+	}
+	return metricdata.NewFloat64Point(t, v)
+}
+
+// GetEntry returns a cumulative entry where each key for this cumulative has the value
+// given.
+//
+// The number of label values supplied must be exactly the same as the number
+// of keys supplied when this cumulative was created.
+func (c *Float64Cumulative) GetEntry(labelVals ...metricdata.LabelValue) (*Float64CumulativeEntry, error) {
+	entry, err := c.bm.entryForValues(labelVals, func() baseEntry {
+		return &Float64CumulativeEntry{}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entry.(*Float64CumulativeEntry), nil
+}
+
+// Inc increments the cumulative entry value by val. It returns without incrementing if the val
+// is negative.
+func (e *Float64CumulativeEntry) Inc(val float64) {
+	var swapped bool
+	if val <= 0.0 {
+		return
+	}
+	for !swapped {
+		oldVal := atomic.LoadUint64(&e.val)
+		newVal := math.Float64bits(math.Float64frombits(oldVal) + val)
+		swapped = atomic.CompareAndSwapUint64(&e.val, oldVal, newVal)
+	}
+}
+
+// Int64Cumulative represents a int64 cumulative value that can only go up.
+//
+// Int64Cumulative maintains an int64 value for each combination of label values passed to the
+// Set or Inc methods.
+type Int64Cumulative struct {
+	bm baseMetric
+}
+
+// Int64CumulativeEntry represents a single value of the cumulative corresponding to a set
+// of label values.
+type Int64CumulativeEntry struct {
+	val int64
+}
+
+func (e *Int64CumulativeEntry) read(t time.Time) metricdata.Point {
+	v := atomic.LoadInt64(&e.val)
+	if v < 0 {
+		v = 0.0
+	}
+	return metricdata.NewInt64Point(t, v)
+}
+
+// GetEntry returns a cumulative entry where each key for this cumulative has the value
+// given.
+//
+// The number of label values supplied must be exactly the same as the number
+// of keys supplied when this cumulative was created.
+func (c *Int64Cumulative) GetEntry(labelVals ...metricdata.LabelValue) (*Int64CumulativeEntry, error) {
+	entry, err := c.bm.entryForValues(labelVals, func() baseEntry {
+		return &Int64CumulativeEntry{}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entry.(*Int64CumulativeEntry), nil
+}
+
+// Inc increments the current cumulative entry value by val. It returns without incrementing if
+// the val is negative.
+func (e *Int64CumulativeEntry) Inc(val int64) {
+	if val <= 0 {
+		return
+	}
+	atomic.AddInt64(&e.val, val)
+}
+
+// Int64DerivedCumulative represents int64 cumulative value that is derived from an object.
+//
+// Int64DerivedCumulative maintains objects for each combination of label values.
+// These objects implement Int64DerivedCumulativeInterface to read instantaneous value
+// representing the object.
+type Int64DerivedCumulative struct {
+	bm baseMetric
+}
+
+type int64DerivedCumulativeEntry struct {
+	fn func() int64
+}
+
+func (e *int64DerivedCumulativeEntry) read(t time.Time) metricdata.Point {
+	// TODO: [rghetia] handle a condition where new value return by fn is lower than previous call.
+	// It requires that we maintain the old values.
+	return metricdata.NewInt64Point(t, e.fn())
+}
+
+// UpsertEntry inserts or updates a derived cumulative entry for the given set of label values.
+// The object for which this cumulative entry is inserted or updated, must implement func() int64
+//
+// It returns an error if
+// 1. The number of label values supplied are not the same as the number
+// of keys supplied when this cumulative was created.
+// 2. fn func() int64 is nil.
+func (c *Int64DerivedCumulative) UpsertEntry(fn func() int64, labelVals ...metricdata.LabelValue) error {
+	if fn == nil {
+		return errInvalidParam
+	}
+	return c.bm.upsertEntry(labelVals, func() baseEntry {
+		return &int64DerivedCumulativeEntry{fn}
+	})
+}
+
+// Float64DerivedCumulative represents float64 cumulative value that is derived from an object.
+//
+// Float64DerivedCumulative maintains objects for each combination of label values.
+// These objects implement Float64DerivedCumulativeInterface to read instantaneous value
+// representing the object.
+type Float64DerivedCumulative struct {
+	bm baseMetric
+}
+
+type float64DerivedCumulativeEntry struct {
+	fn func() float64
+}
+
+func (e *float64DerivedCumulativeEntry) read(t time.Time) metricdata.Point {
+	return metricdata.NewFloat64Point(t, e.fn())
+}
+
+// UpsertEntry inserts or updates a derived cumulative entry for the given set of label values.
+// The object for which this cumulative entry is inserted or updated, must implement func() float64
+//
+// It returns an error if
+// 1. The number of label values supplied are not the same as the number
+// of keys supplied when this cumulative was created.
+// 2. fn func() float64 is nil.
+func (c *Float64DerivedCumulative) UpsertEntry(fn func() float64, labelVals ...metricdata.LabelValue) error {
+	if fn == nil {
+		return errInvalidParam
+	}
+	return c.bm.upsertEntry(labelVals, func() baseEntry {
+		return &float64DerivedCumulativeEntry{fn}
+	})
+}

--- a/vendor/go.opencensus.io/metric/doc.go
+++ b/vendor/go.opencensus.io/metric/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package metric support for gauge and cumulative metrics.
+//
+// This is an EXPERIMENTAL package, and may change in arbitrary ways without
+// notice.
+package metric // import "go.opencensus.io/metric"

--- a/vendor/go.opencensus.io/metric/error_const.go
+++ b/vendor/go.opencensus.io/metric/error_const.go
@@ -1,0 +1,23 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import "errors"
+
+var (
+	errInvalidParam             = errors.New("invalid parameter")
+	errMetricExistsWithDiffType = errors.New("metric with same name exists with a different type")
+	errKeyValueMismatch         = errors.New("must supply the same number of label values as keys used to construct this metric")
+)

--- a/vendor/go.opencensus.io/metric/gauge.go
+++ b/vendor/go.opencensus.io/metric/gauge.go
@@ -1,0 +1,188 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"math"
+	"sync/atomic"
+	"time"
+
+	"go.opencensus.io/metric/metricdata"
+)
+
+// Float64Gauge represents a float64 value that can go up and down.
+//
+// Float64Gauge maintains a float64 value for each combination of of label values
+// passed to the Set or Add methods.
+type Float64Gauge struct {
+	bm baseMetric
+}
+
+// Float64Entry represents a single value of the gauge corresponding to a set
+// of label values.
+type Float64Entry struct {
+	val uint64 // needs to be uint64 for atomic access, interpret with math.Float64frombits
+}
+
+func (e *Float64Entry) read(t time.Time) metricdata.Point {
+	v := math.Float64frombits(atomic.LoadUint64(&e.val))
+	if v < 0 {
+		v = 0
+	}
+	return metricdata.NewFloat64Point(t, v)
+}
+
+// GetEntry returns a gauge entry where each key for this gauge has the value
+// given.
+//
+// The number of label values supplied must be exactly the same as the number
+// of keys supplied when this gauge was created.
+func (g *Float64Gauge) GetEntry(labelVals ...metricdata.LabelValue) (*Float64Entry, error) {
+	entry, err := g.bm.entryForValues(labelVals, func() baseEntry {
+		return &Float64Entry{}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entry.(*Float64Entry), nil
+}
+
+// Set sets the gauge entry value to val.
+func (e *Float64Entry) Set(val float64) {
+	atomic.StoreUint64(&e.val, math.Float64bits(val))
+}
+
+// Add increments the gauge entry value by val.
+func (e *Float64Entry) Add(val float64) {
+	var swapped bool
+	for !swapped {
+		oldVal := atomic.LoadUint64(&e.val)
+		newVal := math.Float64bits(math.Float64frombits(oldVal) + val)
+		swapped = atomic.CompareAndSwapUint64(&e.val, oldVal, newVal)
+	}
+}
+
+// Int64Gauge represents a int64 gauge value that can go up and down.
+//
+// Int64Gauge maintains an int64 value for each combination of label values passed to the
+// Set or Add methods.
+type Int64Gauge struct {
+	bm baseMetric
+}
+
+// Int64GaugeEntry represents a single value of the gauge corresponding to a set
+// of label values.
+type Int64GaugeEntry struct {
+	val int64
+}
+
+func (e *Int64GaugeEntry) read(t time.Time) metricdata.Point {
+	v := atomic.LoadInt64(&e.val)
+	if v < 0 {
+		v = 0.0
+	}
+	return metricdata.NewInt64Point(t, v)
+}
+
+// GetEntry returns a gauge entry where each key for this gauge has the value
+// given.
+//
+// The number of label values supplied must be exactly the same as the number
+// of keys supplied when this gauge was created.
+func (g *Int64Gauge) GetEntry(labelVals ...metricdata.LabelValue) (*Int64GaugeEntry, error) {
+	entry, err := g.bm.entryForValues(labelVals, func() baseEntry {
+		return &Int64GaugeEntry{}
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entry.(*Int64GaugeEntry), nil
+}
+
+// Set sets the value of the gauge entry to the provided value.
+func (e *Int64GaugeEntry) Set(val int64) {
+	atomic.StoreInt64(&e.val, val)
+}
+
+// Add increments the current gauge entry value by val, which may be negative.
+func (e *Int64GaugeEntry) Add(val int64) {
+	atomic.AddInt64(&e.val, val)
+}
+
+// Int64DerivedGauge represents int64 gauge value that is derived from an object.
+//
+// Int64DerivedGauge maintains objects for each combination of label values.
+// These objects implement Int64DerivedGaugeInterface to read instantaneous value
+// representing the object.
+type Int64DerivedGauge struct {
+	bm baseMetric
+}
+
+type int64DerivedGaugeEntry struct {
+	fn func() int64
+}
+
+func (e *int64DerivedGaugeEntry) read(t time.Time) metricdata.Point {
+	return metricdata.NewInt64Point(t, e.fn())
+}
+
+// UpsertEntry inserts or updates a derived gauge entry for the given set of label values.
+// The object for which this gauge entry is inserted or updated, must implement func() int64
+//
+// It returns an error if
+// 1. The number of label values supplied are not the same as the number
+// of keys supplied when this gauge was created.
+// 2. fn func() int64 is nil.
+func (g *Int64DerivedGauge) UpsertEntry(fn func() int64, labelVals ...metricdata.LabelValue) error {
+	if fn == nil {
+		return errInvalidParam
+	}
+	return g.bm.upsertEntry(labelVals, func() baseEntry {
+		return &int64DerivedGaugeEntry{fn}
+	})
+}
+
+// Float64DerivedGauge represents float64 gauge value that is derived from an object.
+//
+// Float64DerivedGauge maintains objects for each combination of label values.
+// These objects implement Float64DerivedGaugeInterface to read instantaneous value
+// representing the object.
+type Float64DerivedGauge struct {
+	bm baseMetric
+}
+
+type float64DerivedGaugeEntry struct {
+	fn func() float64
+}
+
+func (e *float64DerivedGaugeEntry) read(t time.Time) metricdata.Point {
+	return metricdata.NewFloat64Point(t, e.fn())
+}
+
+// UpsertEntry inserts or updates a derived gauge entry for the given set of label values.
+// The object for which this gauge entry is inserted or updated, must implement func() float64
+//
+// It returns an error if
+// 1. The number of label values supplied are not the same as the number
+// of keys supplied when this gauge was created.
+// 2. fn func() float64 is nil.
+func (g *Float64DerivedGauge) UpsertEntry(fn func() float64, labelVals ...metricdata.LabelValue) error {
+	if fn == nil {
+		return errInvalidParam
+	}
+	return g.bm.upsertEntry(labelVals, func() baseEntry {
+		return &float64DerivedGaugeEntry{fn}
+	})
+}

--- a/vendor/go.opencensus.io/metric/registry.go
+++ b/vendor/go.opencensus.io/metric/registry.go
@@ -1,0 +1,284 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metric
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"go.opencensus.io/metric/metricdata"
+)
+
+// Registry creates and manages a set of gauges and cumulative.
+// External synchronization is required if you want to add gauges and cumulative to the same
+// registry from multiple goroutines.
+type Registry struct {
+	baseMetrics sync.Map
+}
+
+type metricOptions struct {
+	unit        metricdata.Unit
+	labelkeys   []metricdata.LabelKey
+	constLabels map[metricdata.LabelKey]metricdata.LabelValue
+	desc        string
+}
+
+// Options apply changes to metricOptions.
+type Options func(*metricOptions)
+
+// WithDescription applies provided description.
+func WithDescription(desc string) Options {
+	return func(mo *metricOptions) {
+		mo.desc = desc
+	}
+}
+
+// WithUnit applies provided unit.
+func WithUnit(unit metricdata.Unit) Options {
+	return func(mo *metricOptions) {
+		mo.unit = unit
+	}
+}
+
+// WithLabelKeys applies provided label.
+func WithLabelKeys(keys ...string) Options {
+	return func(mo *metricOptions) {
+		labelKeys := make([]metricdata.LabelKey, 0)
+		for _, key := range keys {
+			labelKeys = append(labelKeys, metricdata.LabelKey{Key: key})
+		}
+		mo.labelkeys = labelKeys
+	}
+}
+
+// WithLabelKeysAndDescription applies provided label.
+func WithLabelKeysAndDescription(labelKeys ...metricdata.LabelKey) Options {
+	return func(mo *metricOptions) {
+		mo.labelkeys = labelKeys
+	}
+}
+
+// WithConstLabel applies provided constant label.
+func WithConstLabel(constLabels map[metricdata.LabelKey]metricdata.LabelValue) Options {
+	return func(mo *metricOptions) {
+		mo.constLabels = constLabels
+	}
+}
+
+// NewRegistry initializes a new Registry.
+func NewRegistry() *Registry {
+	return &Registry{}
+}
+
+// AddFloat64Gauge creates and adds a new float64-valued gauge to this registry.
+func (r *Registry) AddFloat64Gauge(name string, mos ...Options) (*Float64Gauge, error) {
+	f := &Float64Gauge{
+		bm: baseMetric{
+			bmType: gaugeFloat64,
+		},
+	}
+	_, err := r.initBaseMetric(&f.bm, name, mos...)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// AddInt64Gauge creates and adds a new int64-valued gauge to this registry.
+func (r *Registry) AddInt64Gauge(name string, mos ...Options) (*Int64Gauge, error) {
+	i := &Int64Gauge{
+		bm: baseMetric{
+			bmType: gaugeInt64,
+		},
+	}
+	_, err := r.initBaseMetric(&i.bm, name, mos...)
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// AddInt64DerivedGauge creates and adds a new derived int64-valued gauge to this registry.
+// A derived gauge is convenient form of gauge where the object associated with the gauge
+// provides its value by implementing func() int64.
+func (r *Registry) AddInt64DerivedGauge(name string, mos ...Options) (*Int64DerivedGauge, error) {
+	i := &Int64DerivedGauge{
+		bm: baseMetric{
+			bmType: derivedGaugeInt64,
+		},
+	}
+	_, err := r.initBaseMetric(&i.bm, name, mos...)
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// AddFloat64DerivedGauge creates and adds a new derived float64-valued gauge to this registry.
+// A derived gauge is convenient form of gauge where the object associated with the gauge
+// provides its value by implementing func() float64.
+func (r *Registry) AddFloat64DerivedGauge(name string, mos ...Options) (*Float64DerivedGauge, error) {
+	f := &Float64DerivedGauge{
+		bm: baseMetric{
+			bmType: derivedGaugeFloat64,
+		},
+	}
+	_, err := r.initBaseMetric(&f.bm, name, mos...)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func bmTypeToMetricType(bm *baseMetric) metricdata.Type {
+	switch bm.bmType {
+	case derivedGaugeFloat64:
+		return metricdata.TypeGaugeFloat64
+	case derivedGaugeInt64:
+		return metricdata.TypeGaugeInt64
+	case gaugeFloat64:
+		return metricdata.TypeGaugeFloat64
+	case gaugeInt64:
+		return metricdata.TypeGaugeInt64
+	case derivedCumulativeFloat64:
+		return metricdata.TypeCumulativeFloat64
+	case derivedCumulativeInt64:
+		return metricdata.TypeCumulativeInt64
+	case cumulativeFloat64:
+		return metricdata.TypeCumulativeFloat64
+	case cumulativeInt64:
+		return metricdata.TypeCumulativeInt64
+	default:
+		panic("unsupported metric type")
+	}
+}
+
+// AddFloat64Cumulative creates and adds a new float64-valued cumulative to this registry.
+func (r *Registry) AddFloat64Cumulative(name string, mos ...Options) (*Float64Cumulative, error) {
+	f := &Float64Cumulative{
+		bm: baseMetric{
+			bmType: cumulativeFloat64,
+		},
+	}
+	_, err := r.initBaseMetric(&f.bm, name, mos...)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+// AddInt64Cumulative creates and adds a new int64-valued cumulative to this registry.
+func (r *Registry) AddInt64Cumulative(name string, mos ...Options) (*Int64Cumulative, error) {
+	i := &Int64Cumulative{
+		bm: baseMetric{
+			bmType: cumulativeInt64,
+		},
+	}
+	_, err := r.initBaseMetric(&i.bm, name, mos...)
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// AddInt64DerivedCumulative creates and adds a new derived int64-valued cumulative to this registry.
+// A derived cumulative is convenient form of cumulative where the object associated with the cumulative
+// provides its value by implementing func() int64.
+func (r *Registry) AddInt64DerivedCumulative(name string, mos ...Options) (*Int64DerivedCumulative, error) {
+	i := &Int64DerivedCumulative{
+		bm: baseMetric{
+			bmType: derivedCumulativeInt64,
+		},
+	}
+	_, err := r.initBaseMetric(&i.bm, name, mos...)
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
+}
+
+// AddFloat64DerivedCumulative creates and adds a new derived float64-valued gauge to this registry.
+// A derived cumulative is convenient form of cumulative where the object associated with the cumulative
+// provides its value by implementing func() float64.
+func (r *Registry) AddFloat64DerivedCumulative(name string, mos ...Options) (*Float64DerivedCumulative, error) {
+	f := &Float64DerivedCumulative{
+		bm: baseMetric{
+			bmType: derivedCumulativeFloat64,
+		},
+	}
+	_, err := r.initBaseMetric(&f.bm, name, mos...)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func createMetricOption(mos ...Options) *metricOptions {
+	o := &metricOptions{}
+	for _, mo := range mos {
+		mo(o)
+	}
+	return o
+}
+
+func (r *Registry) initBaseMetric(bm *baseMetric, name string, mos ...Options) (*baseMetric, error) {
+	val, ok := r.baseMetrics.Load(name)
+	if ok {
+		existing := val.(*baseMetric)
+		if existing.bmType != bm.bmType {
+			return nil, errMetricExistsWithDiffType
+		}
+	}
+	bm.start = time.Now()
+	o := createMetricOption(mos...)
+
+	var constLabelKeys []metricdata.LabelKey
+	for k := range o.constLabels {
+		constLabelKeys = append(constLabelKeys, k)
+	}
+	sort.Slice(constLabelKeys, func(i, j int) bool {
+		return constLabelKeys[i].Key < constLabelKeys[j].Key
+	})
+
+	var constLabelValues []metricdata.LabelValue
+	for _, k := range constLabelKeys {
+		constLabelValues = append(constLabelValues, o.constLabels[k])
+	}
+
+	bm.keys = append(constLabelKeys, o.labelkeys...)
+	bm.constLabelValues = constLabelValues
+
+	bm.desc = metricdata.Descriptor{
+		Name:        name,
+		Description: o.desc,
+		Unit:        o.unit,
+		LabelKeys:   bm.keys,
+		Type:        bmTypeToMetricType(bm),
+	}
+	r.baseMetrics.Store(name, bm)
+	return bm, nil
+}
+
+// Read reads all gauges and cumulatives in this registry and returns their values as metrics.
+func (r *Registry) Read() []*metricdata.Metric {
+	ms := []*metricdata.Metric{}
+	r.baseMetrics.Range(func(k, v interface{}) bool {
+		bm := v.(*baseMetric)
+		ms = append(ms, bm.read())
+		return true
+	})
+	return ms
+}

--- a/vendor/go.opencensus.io/plugin/runmetrics/doc.go
+++ b/vendor/go.opencensus.io/plugin/runmetrics/doc.go
@@ -1,0 +1,23 @@
+// Copyright 2019, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package runmetrics contains support for runtime metrics.
+//
+// To enable collecting runtime metrics, just call Enable():
+//
+//     _ := runmetrics.Enable(runmetrics.RunMetricOptions{
+//         EnableCPU: true,
+//         EnableMemory: true,
+//     })
+package runmetrics // import "go.opencensus.io/plugin/runmetrics"

--- a/vendor/go.opencensus.io/plugin/runmetrics/producer.go
+++ b/vendor/go.opencensus.io/plugin/runmetrics/producer.go
@@ -1,0 +1,291 @@
+package runmetrics
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+
+	"go.opencensus.io/metric"
+	"go.opencensus.io/metric/metricdata"
+	"go.opencensus.io/metric/metricproducer"
+)
+
+type (
+	// producer produces runtime metrics.
+	//
+	// Enable collection of runtime metrics with Enable().
+	producer struct {
+		options RunMetricOptions
+		reg     *metric.Registry
+
+		memStats *memStats
+		cpuStats *cpuStats
+	}
+
+	// RunMetricOptions allows to configure runtime metrics.
+	RunMetricOptions struct {
+		EnableCPU    bool   // EnableCPU whether CPU metrics shall be recorded
+		EnableMemory bool   // EnableMemory whether memory metrics shall be recorded
+		Prefix       string // Prefix is a custom prefix for metric names
+	}
+
+	memStats struct {
+		memStats runtime.MemStats
+
+		memAlloc   *metric.Int64GaugeEntry
+		memTotal   *metric.Int64GaugeEntry
+		memSys     *metric.Int64GaugeEntry
+		memLookups *metric.Int64GaugeEntry
+		memMalloc  *metric.Int64GaugeEntry
+		memFrees   *metric.Int64GaugeEntry
+
+		heapAlloc    *metric.Int64GaugeEntry
+		heapSys      *metric.Int64GaugeEntry
+		heapIdle     *metric.Int64GaugeEntry
+		heapInuse    *metric.Int64GaugeEntry
+		heapObjects  *metric.Int64GaugeEntry
+		heapReleased *metric.Int64GaugeEntry
+
+		stackInuse       *metric.Int64GaugeEntry
+		stackSys         *metric.Int64GaugeEntry
+		stackMSpanInuse  *metric.Int64GaugeEntry
+		stackMSpanSys    *metric.Int64GaugeEntry
+		stackMCacheInuse *metric.Int64GaugeEntry
+		stackMCacheSys   *metric.Int64GaugeEntry
+	}
+
+	cpuStats struct {
+		numGoroutines *metric.Int64GaugeEntry
+		numCgoCalls   *metric.Int64GaugeEntry
+	}
+)
+
+var (
+	_               metricproducer.Producer = (*producer)(nil)
+	enableMutex     sync.Mutex
+	enabledProducer *producer
+)
+
+// Enable enables collection of runtime metrics.
+//
+// Supply RunMetricOptions to configure the behavior of metrics collection.
+// An error might be returned, if creating metrics gauges fails.
+//
+// Previous calls will be overwritten by subsequent ones.
+func Enable(options RunMetricOptions) error {
+	producer := &producer{options: options, reg: metric.NewRegistry()}
+	var err error
+
+	if options.EnableMemory {
+		producer.memStats, err = newMemStats(producer)
+		if err != nil {
+			return err
+		}
+	}
+
+	if options.EnableCPU {
+		producer.cpuStats, err = newCPUStats(producer)
+		if err != nil {
+			return err
+		}
+	}
+
+	enableMutex.Lock()
+	defer enableMutex.Unlock()
+
+	metricproducer.GlobalManager().DeleteProducer(enabledProducer)
+	metricproducer.GlobalManager().AddProducer(producer)
+	enabledProducer = producer
+
+	return nil
+}
+
+// Disable disables collection of runtime metrics.
+func Disable() {
+	enableMutex.Lock()
+	defer enableMutex.Unlock()
+
+	metricproducer.GlobalManager().DeleteProducer(enabledProducer)
+	enabledProducer = nil
+}
+
+// Read reads the current runtime metrics.
+func (p *producer) Read() []*metricdata.Metric {
+	if p.memStats != nil {
+		p.memStats.read()
+	}
+
+	if p.cpuStats != nil {
+		p.cpuStats.read()
+	}
+
+	return p.reg.Read()
+}
+
+func newMemStats(producer *producer) (*memStats, error) {
+	var err error
+	memStats := &memStats{}
+
+	// General
+	memStats.memAlloc, err = producer.createInt64GaugeEntry("process/memory_alloc", "Number of bytes currently allocated in use", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memTotal, err = producer.createInt64GaugeEntry("process/total_memory_alloc", "Number of allocations in total", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memSys, err = producer.createInt64GaugeEntry("process/sys_memory_alloc", "Number of bytes given to the process to use in total", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memLookups, err = producer.createInt64GaugeEntry("process/memory_lookups", "Number of pointer lookups performed by the runtime", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memMalloc, err = producer.createInt64GaugeEntry("process/memory_malloc", "Cumulative count of heap objects allocated", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.memFrees, err = producer.createInt64GaugeEntry("process/memory_frees", "Cumulative count of heap objects freed", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	// Heap
+	memStats.heapAlloc, err = producer.createInt64GaugeEntry("process/heap_alloc", "Process heap allocation", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapSys, err = producer.createInt64GaugeEntry("process/sys_heap", "Bytes of heap memory obtained from the OS", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapIdle, err = producer.createInt64GaugeEntry("process/heap_idle", "Bytes in idle (unused) spans", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapInuse, err = producer.createInt64GaugeEntry("process/heap_inuse", "Bytes in in-use spans", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapObjects, err = producer.createInt64GaugeEntry("process/heap_objects", "The number of objects allocated on the heap", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.heapReleased, err = producer.createInt64GaugeEntry("process/heap_release", "The number of objects released from the heap", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Stack
+	memStats.stackInuse, err = producer.createInt64GaugeEntry("process/stack_inuse", "Bytes in stack spans", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackSys, err = producer.createInt64GaugeEntry("process/sys_stack", "The memory used by stack spans and OS thread stacks", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackMSpanInuse, err = producer.createInt64GaugeEntry("process/stack_mspan_inuse", "Bytes of allocated mspan structures", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackMSpanSys, err = producer.createInt64GaugeEntry("process/sys_stack_mspan", "Bytes of memory obtained from the OS for mspan structures", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackMCacheInuse, err = producer.createInt64GaugeEntry("process/stack_mcache_inuse", "Bytes of allocated mcache structures", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	memStats.stackMCacheSys, err = producer.createInt64GaugeEntry("process/sys_stack_mcache", "Bytes of memory obtained from the OS for mcache structures", metricdata.UnitBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return memStats, nil
+}
+
+func (m *memStats) read() {
+	runtime.ReadMemStats(&m.memStats)
+
+	m.memAlloc.Set(int64(m.memStats.Alloc))
+	m.memTotal.Set(int64(m.memStats.TotalAlloc))
+	m.memSys.Set(int64(m.memStats.Sys))
+	m.memLookups.Set(int64(m.memStats.Lookups))
+	m.memMalloc.Set(int64(m.memStats.Mallocs))
+	m.memFrees.Set(int64(m.memStats.Frees))
+
+	m.heapAlloc.Set(int64(m.memStats.HeapAlloc))
+	m.heapSys.Set(int64(m.memStats.HeapSys))
+	m.heapIdle.Set(int64(m.memStats.HeapIdle))
+	m.heapInuse.Set(int64(m.memStats.HeapInuse))
+	m.heapReleased.Set(int64(m.memStats.HeapReleased))
+	m.heapObjects.Set(int64(m.memStats.HeapObjects))
+
+	m.stackInuse.Set(int64(m.memStats.StackInuse))
+	m.stackSys.Set(int64(m.memStats.StackSys))
+	m.stackMSpanInuse.Set(int64(m.memStats.MSpanInuse))
+	m.stackMSpanSys.Set(int64(m.memStats.MSpanSys))
+	m.stackMCacheInuse.Set(int64(m.memStats.MCacheInuse))
+	m.stackMCacheSys.Set(int64(m.memStats.MCacheSys))
+}
+
+func newCPUStats(producer *producer) (*cpuStats, error) {
+	cpuStats := &cpuStats{}
+	var err error
+
+	cpuStats.numGoroutines, err = producer.createInt64GaugeEntry("process/cpu_goroutines", "Number of goroutines that currently exist", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	cpuStats.numCgoCalls, err = producer.createInt64GaugeEntry("process/cpu_cgo_calls", "Number of cgo calls made by the current process", metricdata.UnitDimensionless)
+	if err != nil {
+		return nil, err
+	}
+
+	return cpuStats, nil
+}
+
+func (c *cpuStats) read() {
+	c.numGoroutines.Set(int64(runtime.NumGoroutine()))
+	c.numCgoCalls.Set(runtime.NumCgoCall())
+}
+
+func (p *producer) createInt64GaugeEntry(name string, description string, unit metricdata.Unit) (*metric.Int64GaugeEntry, error) {
+	if len(p.options.Prefix) > 0 {
+		name = p.options.Prefix + name
+	}
+
+	gauge, err := p.reg.AddInt64Gauge(
+		name,
+		metric.WithDescription(description),
+		metric.WithUnit(unit))
+	if err != nil {
+		return nil, errors.New("error creating gauge for " + name + ": " + err.Error())
+	}
+
+	entry, err := gauge.GetEntry()
+	if err != nil {
+		return nil, errors.New("error getting gauge entry for " + name + ": " + err.Error())
+	}
+
+	return entry, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -268,9 +268,11 @@ github.com/yashtewari/glob-intersection
 go.opencensus.io
 go.opencensus.io/internal
 go.opencensus.io/internal/tagencoding
+go.opencensus.io/metric
 go.opencensus.io/metric/metricdata
 go.opencensus.io/metric/metricexport
 go.opencensus.io/metric/metricproducer
+go.opencensus.io/plugin/runmetrics
 go.opencensus.io/resource
 go.opencensus.io/stats
 go.opencensus.io/stats/internal


### PR DESCRIPTION
This PR uses the OpenCensus `runmetrics` package to expose the golang
runtime metrics as part of our /metrics endpoint.

Fixes #1420

Signed-off-by: juliankatz <juliankatz@google.com>