### PR TITLE
Update the upper limit of request duration metrics to 3 seconds

### DIFF
--- a/pkg/webhook/stats_reporter.go
+++ b/pkg/webhook/stats_reporter.go
@@ -87,7 +87,7 @@ func register() error {
 			Name:        validationRequestDurationMetricName,
 			Description: validationResponseTimeInSecM.Description(),
 			Measure:     validationResponseTimeInSecM,
-			Aggregation: view.Distribution(0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05),
+			Aggregation: view.Distribution(0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 2.5, 3),
 			TagKeys:     []tag.Key{admissionStatusKey},
 		},
 		{
@@ -101,8 +101,7 @@ func register() error {
 			Name:        mutationRequestDurationMetricName,
 			Description: mutationResponseTimeInSecM.Description(),
 			Measure:     mutationResponseTimeInSecM,
-			// TODO: Adjust the distribution once we know what value make sense here
-			Aggregation: view.Distribution(0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05),
+			Aggregation: view.Distribution(0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 2.5, 3),
 			TagKeys:     []tag.Key{mutationStatusKey},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Tsubasa Umeuchi <tsubasa.umeuchi@gmail.com>

**What this PR does / why we need it**:
The upper limit for the metrics `validation_request_duration_seconds_bucket` and `mutation_request_duration_seconds_bucket` is set to 0.05 seconds.
On the other hand, this value is very low considering real-world use cases. So most of the actual requests will exceed the upper limit of 0.05 seconds and will be aggregated into the `+Inf` bucket.
The following is the environment of a cluster managed by the org to which I belong. In this environment, the number of requests within a certain period of time was about 50,000, but there were only 3 requests that were processed within 0.05 seconds, which is the current limit.

- Number of Nodes: 185
- Number of running Pods (avg): 2500
- Number of Constraint Templates: 10
- Number of Constraints: 10

In this PR, I updated the upper limit of these metrics to 3 seconds, which is the number of timeout seconds of webhook.
cf. https://github.com/open-policy-agent/gatekeeper/issues/761#issuecomment-736033145 and https://github.com/open-policy-agent/gatekeeper/issues/761#issuecomment-736089926.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
N/A

**Special notes for your reviewer**:
Please let me know if there is a better setting for the number of `view.Distribution` arguments and its value.