### PR TITLE
Restrict Capabilities.APIVersions check for PodDisruptionBudget.

### DIFF
--- a/cmd/build/helmify/main.go
+++ b/cmd/build/helmify/main.go
@@ -118,7 +118,7 @@ func (ks *kindSet) Write() error {
 			}
 
 			if name == "gatekeeper-controller-manager" && kind == "PodDisruptionBudget" {
-				obj = strings.Replace(obj, "apiVersion: policy/v1beta1", "{{- if .Capabilities.APIVersions.Has \"policy/v1\" }}\napiVersion: policy/v1\n{{ else }}\napiVersion: policy/v1beta1\n{{ end -}}", 1)
+				obj = strings.Replace(obj, "apiVersion: policy/v1beta1", "{{- if .Capabilities.APIVersions.Has \"policy/v1/PodDisruptionBudget\" }}\napiVersion: policy/v1\n{{ else }}\napiVersion: policy/v1beta1\n{{ end -}}", 1)
 			}
 
 			if err := os.WriteFile(destFile, []byte(obj), 0600); err != nil {

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 {{ else }}
 apiVersion: policy/v1beta1


### PR DESCRIPTION
Signed-off-by: Jan van den Berg <koozz@linux.com>

**What this PR does / why we need it**:
Make the capabilities check more specific (and makes installation of the latest version work on Kubernetes 1.20 too).

**Which issue(s) this PR fixes**
Fixes #1534

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**:
Deployed [forked Gatekeeper](https://github.com/koozz/gatekeeper) successfully on Kubernetes 1.20 and 1.21