### PR TITLE
[gator-test] add filter

### DIFF
--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -91,7 +91,7 @@ func runE(cmd *cobra.Command, args []string) error {
 	return runSuites(cmd.Context(), fileSystem, suites, filter)
 }
 
-func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.Suite, filter gktest.Filter) error {
+func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.Suite, filter *gktest.Filter) error {
 	isFailure := false
 
 	runner := gktest.Runner{

--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -91,7 +91,7 @@ func runE(cmd *cobra.Command, args []string) error {
 	return runSuites(cmd.Context(), fileSystem, suites, filter)
 }
 
-func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.Suite, filter *gktest.Filter) error {
+func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.Suite, filter gktest.Filter) error {
 	isFailure := false
 
 	runner := gktest.Runner{

--- a/pkg/gktest/errors.go
+++ b/pkg/gktest/errors.go
@@ -26,4 +26,6 @@ var (
 	// ErrInvalidRegex indicates a Case specified a Violation regex that could not
 	// be compiled.
 	ErrInvalidRegex = errors.New("message contains invalid regular expression")
+	// ErrInvalidFilter indicates that Filter construction failed.
+	ErrInvalidFilter = errors.New("invalid test filter")
 )

--- a/pkg/gktest/filter.go
+++ b/pkg/gktest/filter.go
@@ -33,7 +33,7 @@ type Filter interface {
 // - Test: "forbid-missing-label", Case: "with-foo-label"
 // - Test: "required-labels", Case: "missing-label"
 //
-// 3) NewFilter("^require-foo-label//")
+// 3) NewFilter("^require-foo-label$//")
 // Matches tests which exactly match "require-foo-label". Matches the following:
 // - Test: "require-foo-label", Case: "with-foo-label"
 // - Test: "require-foo-label", Case: "no-labels"

--- a/pkg/gktest/filter.go
+++ b/pkg/gktest/filter.go
@@ -1,7 +1,14 @@
 package gktest
 
+import (
+	"fmt"
+	"regexp"
+)
+
 // Filter filters tests and cases to run.
-type Filter struct{}
+type Filter struct {
+	regex *regexp.Regexp
+}
 
 // NewFilter parses run into a Filter for selecting constraint tests and
 // individual cases to run.
@@ -10,12 +17,12 @@ type Filter struct{}
 //
 // Examples:
 // 1) NewFiler("require-foo-label//missing-label")
-// Matches tests containing the string "require-foo-label"
-// and cases containing the string "missing-label". So this would match all of the
-// following:
+// Matches tests ending with the string "require-foo-label"
+// and cases beginning with the string "missing-label". So this would match all
+// of the following:
 // - Test: "require-foo-label", Case: "missing-label"
 // - Test: "not-require-foo-label, Case: "not-missing-label"
-// - Test: "require-foo-label-and-bar-annotation", Case: "missing-label-and-annotation"
+// - Test: "require-foo-label", Case: "missing-label-and-annotation"
 //
 // 2) NewFilter("missing-label")
 // Matches cases which either have a name containing "missing-label" or which
@@ -23,7 +30,7 @@ type Filter struct{}
 // - Test: "forbid-missing-label", Case: "with-foo-label"
 // - Test: "required-labels", Case: "missing-label"
 //
-// 3) NewFilter("^require-foo-label$//")
+// 3) NewFilter("^require-foo-label//")
 // Matches tests which exactly match "require-foo-label". Matches the following:
 // - Test: "require-foo-label", Case: "with-foo-label"
 // - Test: "require-foo-label", Case: "no-labels"
@@ -34,22 +41,54 @@ type Filter struct{}
 // - Test: "forbid-foo-label", Case: "empty-object"
 // - Test: "forbid-foo-label", Case: "another-empty-object"
 // - Test: "require-bar-annotation", Case: "empty-object".
-func NewFilter(run string) (Filter, error) {
-	return Filter{}, nil
+func NewFilter(filter string) (*Filter, error) {
+	if filter == "" {
+		return &Filter{}, nil
+	}
+
+	regex, err := regexp.Compile(filter)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidFilter, err)
+	}
+
+	return &Filter{regex: regex}, nil
 }
 
 // MatchesTest filters the set of tests to run by test name
 // and the cases contained in the test. Returns true if the Test should be run.
 //
-// If a test regex was not specified but a case regex was, returns true if
-// at least one case in `c` matches the case regex.
-func (f Filter) MatchesTest(c Test) bool {
-	return true
+// If a constraint regex was specified, returns true if the constraint regex
+// matches `constraint`.
+// If a constraint regex was not specified but a test regex was, returns true if
+// at least one test in `tests` matches the test regex.
+func (f Filter) MatchesTest(t Test) bool {
+	if f.regex == nil {
+		return true
+	}
+
+	testName := t.Name + "//"
+	if f.regex.MatchString(testName) {
+		return true
+	}
+
+	for _, c := range t.Cases {
+		if f.MatchesCase(t.Name, c.Name) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // MatchesCase filters Cases to run by name.
 //
-// Returns true if the case regex matches c.
-func (f Filter) MatchesCase(c Case) bool {
-	return true
+// Returns true if the test regex matches test.
+func (f Filter) MatchesCase(testName, caseName string) bool {
+	if f.regex == nil {
+		return true
+	}
+
+	fullName := fmt.Sprintf("%s//%s", testName, caseName)
+
+	return f.regex.MatchString(fullName)
 }

--- a/pkg/gktest/filter_test.go
+++ b/pkg/gktest/filter_test.go
@@ -1,0 +1,200 @@
+package gktest
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFilter_Error(t *testing.T) {
+	_, err := NewFilter("[")
+	if !errors.Is(err, ErrInvalidFilter) {
+		t.Fatalf(`got NewFilter("[") error = nil, want %v`, ErrInvalidFilter)
+	}
+}
+
+func TestFilter_MatchesTest(t *testing.T) {
+	testCases := []struct {
+		name   string
+		filter string
+		test   Test
+		want   bool
+	}{
+		{
+			name:   "empty matches test",
+			filter: "",
+			test:   Test{Name: "foo"},
+			want:   true,
+		},
+		{
+			name:   "filter matches test with no cases",
+			filter: "foo",
+			test:   Test{Name: "foo"},
+			want:   true,
+		},
+		{
+			name:   "filter matches test with no cases submatch",
+			filter: "foo",
+			test:   Test{Name: "foo-bar"},
+			want:   true,
+		},
+		{
+			name:   "filter matches test with no cases 2",
+			filter: "foo//",
+			test:   Test{Name: "foo"},
+			want:   true,
+		},
+		{
+			name:   "filter matches case",
+			filter: "foo",
+			test:   Test{Name: "bar", Cases: []Case{{Name: "foo"}}},
+			want:   true,
+		},
+		{
+			name:   "filter matches case submatch",
+			filter: "foo",
+			test:   Test{Name: "bar", Cases: []Case{{Name: "foo-bar"}}},
+			want:   true,
+		},
+		{
+			name:   "test name matches test with no cases 2",
+			filter: "foo//",
+			test:   Test{Name: "foo"},
+			want:   true,
+		},
+		{
+			name:   "test name mismatch",
+			filter: "foo//",
+			test:   Test{Name: "bar", Cases: []Case{{Name: "foo"}}},
+			want:   false,
+		},
+		{
+			name:   "test and case match",
+			filter: "bar//qux",
+			test:   Test{Name: "bar", Cases: []Case{{Name: "qux"}}},
+			want:   true,
+		},
+		{
+			name:   "test and case submatch",
+			filter: "bar//qux",
+			test:   Test{Name: "foo-bar", Cases: []Case{{Name: "qux-corge"}}},
+			want:   true,
+		},
+		{
+			name:   "test mismatch",
+			filter: "bar//qux",
+			test:   Test{Name: "bar-foo", Cases: []Case{{Name: "qux-corge"}}},
+			want:   false,
+		},
+		{
+			name:   "case mismatch",
+			filter: "bar//qux",
+			test:   Test{Name: "foo", Cases: []Case{{Name: "corge-qux"}}},
+			want:   false,
+		},
+		{
+			name:   "test match case mismatch",
+			filter: "bar//qux",
+			test:   Test{Name: "bar", Cases: []Case{{Name: "foo"}}},
+			want:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter, err := NewFilter(tc.filter)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := filter.MatchesTest(tc.test)
+			if got != tc.want {
+				t.Errorf("got MatchesTest(%q) = %t, want %t", tc.test.Name, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilter_MatchesCase(t *testing.T) {
+	testCases := []struct {
+		name      string
+		filter    string
+		wantMatch map[string]map[string]bool
+	}{
+		{
+			name:   "empty matches all cases",
+			filter: "",
+			wantMatch: map[string]map[string]bool{
+				"bar": {
+					"foo": true,
+					"qux": true,
+				},
+				"corge": {
+					"foo": true,
+					"qux": true,
+				},
+			},
+		},
+		{
+			name:   "test name match",
+			filter: "bar//",
+			wantMatch: map[string]map[string]bool{
+				"bar": {
+					"foo": true,
+					"qux": true,
+				},
+				"corge": {
+					"foo": false,
+					"qux": false,
+				},
+			},
+		},
+		{
+			name:   "case name match",
+			filter: "//foo",
+			wantMatch: map[string]map[string]bool{
+				"bar": {
+					"foo": true,
+					"qux": false,
+				},
+				"corge": {
+					"foo": true,
+					"qux": false,
+				},
+			},
+		},
+		{
+			name:   "test and case name match",
+			filter: "bar//foo",
+			wantMatch: map[string]map[string]bool{
+				"bar": {
+					"foo": true,
+					"qux": false,
+				},
+				"corge": {
+					"foo": false,
+					"qux": false,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter, err := NewFilter(tc.filter)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			for testName, cases := range tc.wantMatch {
+				for caseName, want := range cases {
+					got := filter.MatchesCase(testName, caseName)
+
+					if got != want {
+						t.Errorf("got Filter(%q).MatchesCase(%q, %q) = %t, want %t",
+							tc.filter, testName, caseName, got, want)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/gktest/result.go
+++ b/pkg/gktest/result.go
@@ -52,6 +52,9 @@ type TestResult struct {
 	// Name is the name given to the Template/Constraint pair under test.
 	Name string
 
+	// Skipped is whether this Test was skipped while running its parent Suite.
+	Skipped bool
+
 	// Error is the error which prevented running tests for this Constraint.
 	// If defined, CaseResults is empty.
 	Error error
@@ -83,6 +86,9 @@ func (r *TestResult) IsFailure() bool {
 type CaseResult struct {
 	// Name is the name given to this test for the Constraint under test.
 	Name string
+
+	// Skipped is whether this Case was skipped while running its parent Test.
+	Skipped bool
 
 	// Error is the either:
 	// 1) why this case failed, or

--- a/pkg/gktest/runner.go
+++ b/pkg/gktest/runner.go
@@ -23,7 +23,7 @@ type Runner struct {
 }
 
 // Run executes all Tests in the Suite and returns the results.
-func (r *Runner) Run(ctx context.Context, filter *Filter, suitePath string, s *Suite) SuiteResult {
+func (r *Runner) Run(ctx context.Context, filter Filter, suitePath string, s *Suite) SuiteResult {
 	start := time.Now()
 
 	results, err := r.runTests(ctx, filter, suitePath, s.Tests)
@@ -37,7 +37,7 @@ func (r *Runner) Run(ctx context.Context, filter *Filter, suitePath string, s *S
 }
 
 // runTests runs every Test in Suite.
-func (r *Runner) runTests(ctx context.Context, filter *Filter, suitePath string, tests []Test) ([]TestResult, error) {
+func (r *Runner) runTests(ctx context.Context, filter Filter, suitePath string, tests []Test) ([]TestResult, error) {
 	suiteDir := filepath.Dir(suitePath)
 
 	results := make([]TestResult, len(tests))
@@ -58,7 +58,7 @@ func (r *Runner) skipTest(t Test) TestResult {
 }
 
 // runTest runs an individual Test.
-func (r *Runner) runTest(ctx context.Context, suiteDir string, filter *Filter, t Test) TestResult {
+func (r *Runner) runTest(ctx context.Context, suiteDir string, filter Filter, t Test) TestResult {
 	start := time.Now()
 
 	results, err := r.runCases(ctx, suiteDir, filter, t)
@@ -73,7 +73,7 @@ func (r *Runner) runTest(ctx context.Context, suiteDir string, filter *Filter, t
 
 // runCases executes every Case in the Test. Returns the results for every Case,
 // or an error if there was a problem executing the Test.
-func (r *Runner) runCases(ctx context.Context, suiteDir string, filter *Filter, t Test) ([]CaseResult, error) {
+func (r *Runner) runCases(ctx context.Context, suiteDir string, filter Filter, t Test) ([]CaseResult, error) {
 	client, err := r.makeTestClient(ctx, suiteDir, t)
 	if err != nil {
 		return nil, err

--- a/pkg/gktest/runner_integer_test.go
+++ b/pkg/gktest/runner_integer_test.go
@@ -283,7 +283,7 @@ func TestRunner_Run_Integer(t *testing.T) {
 				}},
 			}
 
-			result := runner.Run(ctx, Filter{}, "", suite)
+			result := runner.Run(ctx, &nilFilter{}, "", suite)
 
 			if result.IsFailure() {
 				sb := strings.Builder{}

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -193,10 +193,11 @@ metadata:
 
 func TestRunner_Run(t *testing.T) {
 	testCases := []struct {
-		name  string
-		suite Suite
-		f     fs.FS
-		want  SuiteResult
+		name   string
+		filter string
+		suite  Suite
+		f      fs.FS
+		want   SuiteResult
 	}{
 		{
 			name: "Suite missing Template",
@@ -562,6 +563,64 @@ func TestRunner_Run(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name:   "valid Suite with filter",
+			filter: "allowed-2",
+			suite: Suite{
+				Tests: []Test{{
+					Name:       "allow",
+					Template:   "allow-template.yaml",
+					Constraint: "allow-constraint.yaml",
+					Cases: []Case{{
+						Name:   "allowed-1",
+						Object: "object.yaml",
+					}, {
+						Name:   "allowed-2",
+						Object: "object.yaml",
+					}},
+				}, {
+					Name:       "deny",
+					Template:   "deny-template.yaml",
+					Constraint: "deny-constraint.yaml",
+					Cases: []Case{{
+						Name:   "denied",
+						Object: "object.yaml",
+						Assertions: []Assertion{{
+							Violations: intStrFromStr("yes"),
+						}},
+					}},
+				}},
+			},
+			f: fstest.MapFS{
+				"allow-template.yaml": &fstest.MapFile{
+					Data: []byte(templateAlwaysValidate),
+				},
+				"allow-constraint.yaml": &fstest.MapFile{
+					Data: []byte(constraintAlwaysValidate),
+				},
+				"deny-template.yaml": &fstest.MapFile{
+					Data: []byte(templateNeverValidate),
+				},
+				"deny-constraint.yaml": &fstest.MapFile{
+					Data: []byte(constraintNeverValidate),
+				},
+				"object.yaml": &fstest.MapFile{
+					Data: []byte(object),
+				},
+			},
+			want: SuiteResult{
+				TestResults: []TestResult{{
+					Name: "allow",
+					CaseResults: []CaseResult{{
+						Name: "allowed-1", Skipped: true,
+					}, {
+						Name: "allowed-2",
+					}},
+				}, {
+					Name: "deny", Skipped: true,
+				}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -573,7 +632,12 @@ func TestRunner_Run(t *testing.T) {
 				NewClient: NewOPAClient,
 			}
 
-			got := runner.Run(ctx, Filter{}, "", &tc.suite)
+			filter, err := NewFilter(tc.filter)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := runner.Run(ctx, filter, "", &tc.suite)
 
 			if diff := cmp.Diff(tc.want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty(),
 				cmpopts.IgnoreFields(SuiteResult{}, "Runtime"), cmpopts.IgnoreFields(TestResult{}, "Runtime"), cmpopts.IgnoreFields(CaseResult{}, "Runtime"),
@@ -601,7 +665,7 @@ func TestRunner_Run_ClientError(t *testing.T) {
 	suite := &Suite{
 		Tests: []Test{{}},
 	}
-	got := runner.Run(ctx, Filter{}, "", suite)
+	got := runner.Run(ctx, &Filter{}, "", suite)
 
 	if diff := cmp.Diff(want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(SuiteResult{}, "Runtime"), cmpopts.IgnoreFields(TestResult{}, "Runtime"), cmpopts.IgnoreFields(CaseResult{}, "Runtime"),
@@ -934,7 +998,7 @@ func TestRunner_RunCase(t *testing.T) {
 				NewClient: NewOPAClient,
 			}
 
-			got := runner.Run(ctx, Filter{}, "", suite)
+			got := runner.Run(ctx, &Filter{}, "", suite)
 
 			want := SuiteResult{
 				TestResults: []TestResult{{

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -665,7 +665,7 @@ func TestRunner_Run_ClientError(t *testing.T) {
 	suite := &Suite{
 		Tests: []Test{{}},
 	}
-	got := runner.Run(ctx, &Filter{}, "", suite)
+	got := runner.Run(ctx, &nilFilter{}, "", suite)
 
 	if diff := cmp.Diff(want, got, cmpopts.EquateErrors(), cmpopts.EquateEmpty(),
 		cmpopts.IgnoreFields(SuiteResult{}, "Runtime"), cmpopts.IgnoreFields(TestResult{}, "Runtime"), cmpopts.IgnoreFields(CaseResult{}, "Runtime"),
@@ -998,7 +998,7 @@ func TestRunner_RunCase(t *testing.T) {
 				NewClient: NewOPAClient,
 			}
 
-			got := runner.Run(ctx, &Filter{}, "", suite)
+			got := runner.Run(ctx, &nilFilter{}, "", suite)
 
 			want := SuiteResult{
 				TestResults: []TestResult{{


### PR DESCRIPTION
Define --run filter for `gator test`.

The filter is often run twice on case names - first to check if a Test should be run, and then when running the Case itself. I've done this in the interest of simpler filtering code. This isn't likely to be a performance bottleneck.

Also, note that the regex passed to --run is matches against strings of the form "$TEST_NAME//$CASE_NAME". I considered splitting the value passed to --run and matching against test name and test name separately, but this resulted in much more complex code. As-is accomplishes the behavior specified in the design.

Fixes: #1381 