### PR TITLE
fixing the base url for the gatekeeper icon

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,6 +22,7 @@ module.exports = {
       logo: {
         alt: 'Gatekeeper logo',
         src: 'img/logo.svg',
+        href: 'https://open-policy-agent.github.io/gatekeeper/website/docs/',
       },
       items: [
         {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, if someone clicks on the Gatekeeper icon it is going to a broken URL

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: