### PR TITLE
fix: Add gatekeeper-crds image pull secrets to Helm Chart

### DIFF
--- a/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
+++ b/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
@@ -75,6 +75,10 @@ spec:
     spec:
       serviceAccountName: gatekeeper-admin-upgrade-crds
       restartPolicy: Never
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: crds-upgrade
         image: '{{ .Values.image.crdRepository }}:{{ .Values.image.release }}'

--- a/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
@@ -75,6 +75,10 @@ spec:
     spec:
       serviceAccountName: gatekeeper-admin-upgrade-crds
       restartPolicy: Never
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 8 }}
+      {{- end }}
       containers:
       - name: crds-upgrade
         image: '{{ .Values.image.crdRepository }}:{{ .Values.image.release }}'


### PR DESCRIPTION
Signed-off-by: Julian Dolce <jdolce@qnx.com>

**What this PR does / why we need it**:

The Helm Chart currently has a hook to update the crds using image gatekeeper-crds. However it doesn't provide a way to add image pull secrets. This causes an issue if you have a constraint that restricts which image repo's are allowed, causing the hook to fail. This change allows users to specify the image pull secrets just for the crd migration hook. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: