### PR TITLE
fix: use objects namespace instead of gatekeeper

### DIFF
--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -276,7 +276,6 @@ func (h *validationHandler) getValidationMessages(res []*rtypes.Result, req *adm
 				reason = "FailedAdmission"
 			}
 			ref := getViolationRef(
-				h.gkNamespace,
 				req.AdmissionRequest.Kind.Kind,
 				resourceName,
 				req.AdmissionRequest.Namespace,
@@ -465,11 +464,11 @@ func (h *validationHandler) reviewRequest(ctx context.Context, req *admission.Re
 	return resp, err
 }
 
-func getViolationRef(gkNamespace, rkind, rname, rnamespace, ckind, cname, cnamespace string) *corev1.ObjectReference {
+func getViolationRef(rkind, rname, rnamespace, ckind, cname, cnamespace string) *corev1.ObjectReference {
 	return &corev1.ObjectReference{
 		Kind:      rkind,
 		Name:      rname,
 		UID:       types.UID(rkind + "/" + rnamespace + "/" + rname + "/" + ckind + "/" + cnamespace + "/" + cname),
-		Namespace: gkNamespace,
+		Namespace: rnamespace,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Event Object references namespace was set incorrectly

**Which issue(s) this PR fixes** :
Fixes #1559

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**:

I'm not sure if you still with want to add gatekeeper's namespace to the event.