### PR TITLE
[gator test] Support referential constraints

### DIFF
--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -94,9 +94,9 @@ func runE(cmd *cobra.Command, args []string) error {
 func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.Suite, filter gktest.Filter) error {
 	isFailure := false
 
-	runner := gktest.Runner{
-		FS:        fileSystem,
-		NewClient: gktest.NewOPAClient,
+	runner, err := gktest.NewRunner(fileSystem, gktest.NewOPAClient)
+	if err != nil {
+		return err
 	}
 
 	results := make([]gktest.SuiteResult, len(suites))
@@ -120,7 +120,7 @@ func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.
 	}
 	w := &strings.Builder{}
 	printer := gktest.PrinterGo{}
-	err := printer.Print(w, results, verbose)
+	err = printer.Print(w, results, verbose)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func runSuites(ctx context.Context, fileSystem fs.FS, suites map[string]*gktest.
 
 func getFS(path string) fs.FS {
 	// TODO(#1397): Check that this produces the correct file system string on
-	//  Windows. We may need to add a trailing `/` for fs.FS to function properly.
+	//  Windows. We may need to add a trailing `/` for fs.filesystem to function properly.
 	root := filepath.VolumeName(path)
 	if root == "" {
 		// We are running on a unix-like filesystem without volume names, so the

--- a/pkg/gktest/client.go
+++ b/pkg/gktest/client.go
@@ -24,6 +24,10 @@ type Client interface {
 	// AddData adds the state of the cluster. For use in referential Constraints.
 	AddData(ctx context.Context, data interface{}) (*types.Responses, error)
 
+	// RemoveData removes objects from the state of the cluster. For use in
+	// referential constraints.
+	RemoveData(ctx context.Context, data interface{}) (*types.Responses, error)
+
 	// Review runs all Constraints against obj.
 	Review(ctx context.Context, obj interface{}, opts ...client.QueryOpt) (*types.Responses, error)
 }

--- a/pkg/gktest/errors.go
+++ b/pkg/gktest/errors.go
@@ -28,4 +28,6 @@ var (
 	ErrInvalidRegex = errors.New("message contains invalid regular expression")
 	// ErrInvalidFilter indicates that Filter construction failed.
 	ErrInvalidFilter = errors.New("invalid test filter")
+	// ErrNoObjects indicates that a test Case's object file has no YAML documents
+	ErrNoObjects = errors.New("missing objects")
 )

--- a/pkg/gktest/errors.go
+++ b/pkg/gktest/errors.go
@@ -28,6 +28,12 @@ var (
 	ErrInvalidRegex = errors.New("message contains invalid regular expression")
 	// ErrInvalidFilter indicates that Filter construction failed.
 	ErrInvalidFilter = errors.New("invalid test filter")
-	// ErrNoObjects indicates that a test Case's object file has no YAML documents
+	// ErrNoObjects indicates that a test Case's object file has no YAML documents.
 	ErrNoObjects = errors.New("missing objects")
+	// ErrAddInventory indicates that an object that was declared to be part of
+	// data.inventory was unable to be added.
+	ErrAddInventory = errors.New("unable to add object to data.inventory")
+	// ErrConvertingTemplate means we were able to parse a template, but not convert
+	// it into the version-independent format.
+	ErrConvertingTemplate = errors.New("unable to convert template")
 )

--- a/pkg/gktest/errors.go
+++ b/pkg/gktest/errors.go
@@ -28,8 +28,10 @@ var (
 	ErrInvalidRegex = errors.New("message contains invalid regular expression")
 	// ErrInvalidFilter indicates that Filter construction failed.
 	ErrInvalidFilter = errors.New("invalid test filter")
-	// ErrNoObjects indicates that a test Case's object file has no YAML documents.
+	// ErrNoObjects indicates that a specified YAML file contained no objects.
 	ErrNoObjects = errors.New("missing objects")
+	// ErrMultipleObjects indicates that a specified YAML file contained multiple objects.
+	ErrMultipleObjects = errors.New("object file must contain exactly one object")
 	// ErrAddInventory indicates that an object that was declared to be part of
 	// data.inventory was unable to be added.
 	ErrAddInventory = errors.New("unable to add object to data.inventory")

--- a/pkg/gktest/filter_test.go
+++ b/pkg/gktest/filter_test.go
@@ -6,6 +6,8 @@ import (
 )
 
 func TestFilter_Error(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name   string
 		filter string
@@ -49,7 +51,12 @@ func TestFilter_Error(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// Required for parallel tests.
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			_, err := NewFilter(tc.filter)
 			if !errors.Is(err, tc.want) {
 				t.Fatalf(`got NewFilter("(") error = %v, want %v`, err, ErrInvalidFilter)
@@ -59,6 +66,8 @@ func TestFilter_Error(t *testing.T) {
 }
 
 func TestFilter_MatchesTest(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name   string
 		filter string
@@ -146,7 +155,12 @@ func TestFilter_MatchesTest(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// Required for parallel tests.
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter, err := NewFilter(tc.filter)
 			if err != nil {
 				t.Fatal(err)
@@ -161,6 +175,8 @@ func TestFilter_MatchesTest(t *testing.T) {
 }
 
 func TestFilter_MatchesCase(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name      string
 		filter    string
@@ -225,7 +241,12 @@ func TestFilter_MatchesCase(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// Required for parallel tests.
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			filter, err := NewFilter(tc.filter)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/gktest/filter_test.go
+++ b/pkg/gktest/filter_test.go
@@ -101,13 +101,13 @@ func TestFilter_MatchesTest(t *testing.T) {
 		{
 			name:   "filter matches case",
 			filter: "foo",
-			test:   Test{Name: "bar", Cases: []Case{{Name: "foo"}}},
+			test:   Test{Name: "bar", Cases: []*Case{{Name: "foo"}}},
 			want:   true,
 		},
 		{
 			name:   "filter matches case submatch",
 			filter: "foo",
-			test:   Test{Name: "bar", Cases: []Case{{Name: "foo-bar"}}},
+			test:   Test{Name: "bar", Cases: []*Case{{Name: "foo-bar"}}},
 			want:   true,
 		},
 		{
@@ -119,37 +119,37 @@ func TestFilter_MatchesTest(t *testing.T) {
 		{
 			name:   "test name mismatch",
 			filter: "foo//",
-			test:   Test{Name: "bar", Cases: []Case{{Name: "foo"}}},
+			test:   Test{Name: "bar", Cases: []*Case{{Name: "foo"}}},
 			want:   false,
 		},
 		{
 			name:   "test and case match",
 			filter: "bar//qux",
-			test:   Test{Name: "bar", Cases: []Case{{Name: "qux"}}},
+			test:   Test{Name: "bar", Cases: []*Case{{Name: "qux"}}},
 			want:   true,
 		},
 		{
 			name:   "test and case submatch",
 			filter: "bar//qux",
-			test:   Test{Name: "foo-bar", Cases: []Case{{Name: "qux-corge"}}},
+			test:   Test{Name: "foo-bar", Cases: []*Case{{Name: "qux-corge"}}},
 			want:   true,
 		},
 		{
 			name:   "test mismatch",
 			filter: "bar-bar//qux",
-			test:   Test{Name: "bar-foo", Cases: []Case{{Name: "qux-corge"}}},
+			test:   Test{Name: "bar-foo", Cases: []*Case{{Name: "qux-corge"}}},
 			want:   false,
 		},
 		{
 			name:   "case mismatch",
 			filter: "bar//qux-qux",
-			test:   Test{Name: "foo", Cases: []Case{{Name: "corge-qux"}}},
+			test:   Test{Name: "foo", Cases: []*Case{{Name: "corge-qux"}}},
 			want:   false,
 		},
 		{
 			name:   "test match case mismatch",
 			filter: "bar-bar//qux-qux",
-			test:   Test{Name: "bar", Cases: []Case{{Name: "foo"}}},
+			test:   Test{Name: "bar", Cases: []*Case{{Name: "foo"}}},
 			want:   false,
 		},
 	}

--- a/pkg/gktest/printer_go_test.go
+++ b/pkg/gktest/printer_go_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestPrinterGo_Print(t *testing.T) {
+	t.Parallel()
+
 	// TODO(#1430): Not final. While this will eventually exactly match the output
 	//  of go test, this is a first pass.
 
@@ -226,7 +228,12 @@ PASS
 	printer := PrinterGo{}
 
 	for _, tc := range testCases {
+		// Required for parallel tests.
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			w := &strings.Builder{}
 			gotErr := printer.Print(w, tc.result, false)
 
@@ -241,6 +248,8 @@ PASS
 		})
 
 		t.Run(tc.name+" verbose", func(t *testing.T) {
+			t.Parallel()
+
 			w := &strings.Builder{}
 			gotErr := printer.Print(w, tc.result, true)
 

--- a/pkg/gktest/read_constraints.go
+++ b/pkg/gktest/read_constraints.go
@@ -87,7 +87,7 @@ func readTemplate(f fs.FS, path string) (*templates.ConstraintTemplate, error) {
 	return template, nil
 }
 
-func readConstraint(f fs.FS, path string) (*unstructured.Unstructured, error) {
+func readObject(f fs.FS, path string) (*unstructured.Unstructured, error) {
 	bytes, err := fs.ReadFile(f, path)
 	if err != nil {
 		return nil, fmt.Errorf("reading Constraint from %q: %w", path, err)
@@ -96,6 +96,15 @@ func readConstraint(f fs.FS, path string) (*unstructured.Unstructured, error) {
 	u, err := readUnstructured(bytes)
 	if err != nil {
 		return nil, fmt.Errorf("%w: parsing Constraint from %q: %v", ErrAddingConstraint, path, err)
+	}
+
+	return u, nil
+}
+
+func readConstraint(f fs.FS, path string) (*unstructured.Unstructured, error) {
+	u, err := readObject(f, path)
+	if err != nil {
+		return nil, err
 	}
 
 	gvk := u.GroupVersionKind()

--- a/pkg/gktest/read_constraints.go
+++ b/pkg/gktest/read_constraints.go
@@ -115,7 +115,6 @@ func readTemplate(scheme *runtime.Scheme, f fs.FS, path string) (*templates.Cons
 
 	v, isVersionless := t.(versionless)
 	if !isVersionless {
-		// This likely means a
 		return nil, fmt.Errorf("%w: %T", ErrConvertingTemplate, t)
 	}
 

--- a/pkg/gktest/read_suites_test.go
+++ b/pkg/gktest/read_suites_test.go
@@ -309,6 +309,8 @@ tests:
   - object: deny.yaml
     assertions:
     - violations: "yes"
+  - object: referential.yaml
+    inventory: [inventory.yaml]
 `),
 				},
 			},
@@ -323,6 +325,9 @@ tests:
 						Assertions: []Assertion{{
 							Violations: intStrFromStr("yes"),
 						}},
+					}, {
+						Object: "referential.yaml",
+						Inventory: []string{"inventory.yaml"},
 					}},
 				}},
 			}},

--- a/pkg/gktest/read_suites_test.go
+++ b/pkg/gktest/read_suites_test.go
@@ -279,7 +279,7 @@ tests:
 				Tests: []Test{{
 					Template:   "template.yaml",
 					Constraint: "constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "allow.yaml",
 					}, {
 						Object: "deny.yaml",
@@ -318,7 +318,7 @@ tests:
 				Tests: []Test{{
 					Template:   "template.yaml",
 					Constraint: "constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "allow.yaml",
 					}, {
 						Object: "deny.yaml",
@@ -326,7 +326,7 @@ tests:
 							Violations: intStrFromStr("yes"),
 						}},
 					}, {
-						Object: "referential.yaml",
+						Object:    "referential.yaml",
 						Inventory: []string{"inventory.yaml"},
 					}},
 				}},

--- a/pkg/gktest/read_suites_test.go
+++ b/pkg/gktest/read_suites_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestReadSuites(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name       string
 		target     string
@@ -367,7 +369,12 @@ tests: {}
 	}
 
 	for _, tc := range testCases {
+		// Required for parallel tests.
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, gotErr := ReadSuites(tc.fileSystem, tc.target, tc.recursive)
 			if !errors.Is(gotErr, tc.wantErr) {
 				t.Fatalf("got error %v, want error %v",

--- a/pkg/gktest/runner.go
+++ b/pkg/gktest/runner.go
@@ -120,8 +120,8 @@ func (r *Runner) runCases(ctx context.Context, suiteDir string, filter Filter, t
 	return results, nil
 }
 
-func (r *Runner) skipCase(c Case) CaseResult {
-	return CaseResult{Name: c.Name, Skipped: true}
+func (r *Runner) skipCase(tc *Case) CaseResult {
+	return CaseResult{Name: tc.Name, Skipped: true}
 }
 
 func (r *Runner) makeTestClient(ctx context.Context, suiteDir string, t Test) (Client, error) {
@@ -179,7 +179,7 @@ func (r *Runner) addTemplate(ctx context.Context, suiteDir, templatePath string,
 }
 
 // RunCase executes a Case and returns the result of the run.
-func (r *Runner) runCase(ctx context.Context, newClient func() (Client, error), suiteDir string, tc Case) CaseResult {
+func (r *Runner) runCase(ctx context.Context, newClient func() (Client, error), suiteDir string, tc *Case) CaseResult {
 	start := time.Now()
 
 	err := r.checkCase(ctx, newClient, suiteDir, tc)
@@ -191,7 +191,7 @@ func (r *Runner) runCase(ctx context.Context, newClient func() (Client, error), 
 	}
 }
 
-func (r *Runner) checkCase(ctx context.Context, newClient func() (Client, error), suiteDir string, tc Case) (err error) {
+func (r *Runner) checkCase(ctx context.Context, newClient func() (Client, error), suiteDir string, tc *Case) (err error) {
 	if tc.Object == "" {
 		return fmt.Errorf("%w: must define object", ErrInvalidCase)
 	}
@@ -219,7 +219,7 @@ func (r *Runner) checkCase(ctx context.Context, newClient func() (Client, error)
 	return nil
 }
 
-func (r *Runner) runReview(ctx context.Context, newClient func() (Client, error), suiteDir string, tc Case) (*types.Responses, error) {
+func (r *Runner) runReview(ctx context.Context, newClient func() (Client, error), suiteDir string, tc *Case) (*types.Responses, error) {
 	c, err := newClient()
 	if err != nil {
 		return nil, err
@@ -283,7 +283,6 @@ func readObjects(f fs.FS, path string) ([]*unstructured.Unstructured, error) {
 	}
 
 	nObjs := len(objs)
-
 	if nObjs == 0 {
 		return nil, fmt.Errorf("%w: path %q defines no YAML objects", ErrNoObjects, path)
 	}

--- a/pkg/gktest/runner_integer_test.go
+++ b/pkg/gktest/runner_integer_test.go
@@ -281,7 +281,7 @@ func TestRunner_Run_Integer(t *testing.T) {
 				Tests: []Test{{
 					Template:   "template.yaml",
 					Constraint: "constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "allow.yaml",
 					}, {
 						Object:     "disallow.yaml",

--- a/pkg/gktest/runner_integer_test.go
+++ b/pkg/gktest/runner_integer_test.go
@@ -224,6 +224,8 @@ spec:
 `
 
 func TestRunner_Run_Integer(t *testing.T) {
+	t.Parallel()
+
 	testCases := []struct {
 		name       string
 		template   string
@@ -247,7 +249,12 @@ func TestRunner_Run_Integer(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		// Required for parallel tests.
+		tc := tc
+
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctx := context.Background()
 
 			f := &fstest.MapFS{
@@ -265,9 +272,9 @@ func TestRunner_Run_Integer(t *testing.T) {
 				},
 			}
 
-			runner := Runner{
-				FS:        f,
-				NewClient: NewOPAClient,
+			runner, err := NewRunner(f, NewOPAClient)
+			if err != nil {
+				t.Fatal(err)
 			}
 
 			suite := &Suite{

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -468,13 +468,13 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "object.yaml",
 					}},
 				}, {
 					Template:   "deny-template.yaml",
 					Constraint: "deny-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "object.yaml",
 						Assertions: []Assertion{{
 							Violations: intStrFromStr("yes"),
@@ -513,7 +513,7 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "object.yaml",
 					}},
 				}},
@@ -543,8 +543,8 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
-						Object: "object.yaml",
+					Cases: []*Case{{
+						Object:    "object.yaml",
 						Inventory: []string{"inventory.yaml"},
 					}},
 				}},
@@ -577,7 +577,7 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "object.yaml",
 					}},
 				}},
@@ -607,7 +607,7 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "object.yaml",
 					}},
 				}},
@@ -637,7 +637,7 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object:    "object.yaml",
 						Inventory: []string{"inventory.yaml"},
 					}},
@@ -776,7 +776,7 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "object.yaml",
 					}},
 				}},
@@ -803,7 +803,7 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object: "object.yaml",
 						Assertions: []Assertion{{
 							Violations: intStrFromStr("yes"),
@@ -833,7 +833,7 @@ func TestRunner_Run(t *testing.T) {
 				Tests: []Test{{
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases:      []Case{{}},
+					Cases:      []*Case{{}},
 				}},
 			},
 			f: fstest.MapFS{
@@ -858,7 +858,7 @@ func TestRunner_Run(t *testing.T) {
 					Name:       "allow",
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Name:   "allowed-1",
 						Object: "object.yaml",
 					}, {
@@ -869,7 +869,7 @@ func TestRunner_Run(t *testing.T) {
 					Name:       "deny",
 					Template:   "deny-template.yaml",
 					Constraint: "deny-constraint.yaml",
-					Cases: []Case{{
+					Cases: []*Case{{
 						Name:   "denied",
 						Object: "object.yaml",
 						Assertions: []Assertion{{
@@ -915,13 +915,13 @@ func TestRunner_Run(t *testing.T) {
 					Name:       "referential constraint",
 					Template:   "template.yaml",
 					Constraint: "constraint.yaml",
-					Cases: []Case{{
-						Name:   "allow",
-						Object: "allow.yaml",
+					Cases: []*Case{{
+						Name:      "allow",
+						Object:    "allow.yaml",
 						Inventory: []string{"inventory.yaml"},
 					}, {
-						Name:   "deny",
-						Object: "deny.yaml",
+						Name:      "deny",
+						Object:    "deny.yaml",
 						Inventory: []string{"inventory.yaml"},
 						Assertions: []Assertion{{
 							Violations: intStrFromStr("yes"),
@@ -1330,7 +1330,7 @@ func TestRunner_RunCase(t *testing.T) {
 				Tests: []Test{{
 					Template:   templateFile,
 					Constraint: constraintFile,
-					Cases: []Case{{
+					Cases: []*Case{{
 						Object:     objectFile,
 						Assertions: tc.assertions,
 					}},

--- a/pkg/gktest/suite.go
+++ b/pkg/gktest/suite.go
@@ -37,10 +37,6 @@ type Case struct {
 	// Object is the path to the file containing a Kubernetes object to test.
 	Object string `json:"object"`
 
-	// Inventory is the path to objects containing objects for referential
-	// constraints.
-	Inventory []string `json:"inventory"`
-
 	// Assertions are statements which must be true about the result of running
 	// Review with the Test's Constraint on the Case's Object.
 	//

--- a/pkg/gktest/suite.go
+++ b/pkg/gktest/suite.go
@@ -37,6 +37,10 @@ type Case struct {
 	// Object is the path to the file containing a Kubernetes object to test.
 	Object string `json:"object"`
 
+	// Inventory is the path to objects containing objects for referential
+	// constraints.
+	Inventory []string `json:"inventory"`
+
 	// Assertions are statements which must be true about the result of running
 	// Review with the Test's Constraint on the Case's Object.
 	//

--- a/pkg/gktest/suite.go
+++ b/pkg/gktest/suite.go
@@ -27,7 +27,7 @@ type Test struct {
 	Constraint string `json:"constraint"`
 
 	// Cases are the test cases to run on the instantiated Constraint.
-	Cases []Case `json:"cases,omitempty"`
+	Cases []*Case `json:"cases,omitempty"`
 }
 
 // Case runs Constraint against a YAML object.

--- a/pkg/gktest/suite.go
+++ b/pkg/gktest/suite.go
@@ -37,6 +37,10 @@ type Case struct {
 	// Object is the path to the file containing a Kubernetes object to test.
 	Object string `json:"object"`
 
+	// Inventory is a list of paths to files containing Kubernetes objects to put
+	// in data.inventory for testing referential constraints.
+	Inventory []string `json:"inventory"`
+
 	// Assertions are statements which must be true about the result of running
 	// Review with the Test's Constraint on the Case's Object.
 	//

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache.go
@@ -75,7 +75,7 @@ func BuilderWithOptions(options cache.Options) cache.NewCacheFunc {
 }
 
 func defaultOpts(config *rest.Config, opts cache.Options) (cache.Options, error) {
-	// Use the default Kubernetes Scheme if unset
+	// Use the default Kubernetes scheme if unset
 	if opts.Scheme == nil {
 		opts.Scheme = scheme.Scheme
 	}

--- a/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache.go
+++ b/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache/cache.go
@@ -75,7 +75,7 @@ func BuilderWithOptions(options cache.Options) cache.NewCacheFunc {
 }
 
 func defaultOpts(config *rest.Config, opts cache.Options) (cache.Options, error) {
-	// Use the default Kubernetes scheme if unset
+	// Use the default Kubernetes Scheme if unset
 	if opts.Scheme == nil {
 		opts.Scheme = scheme.Scheme
 	}


### PR DESCRIPTION
Support `gator test` for referential constraints.

To keep tests hermetic, we now instantiate a new OPA client for each test case. Otherwise, we risk crosstalk between tests if resetting Data in the OPA client fails.

Other minor changes:

- Make tests run in parallel
- Require Runner to be instantiated with builder method to ensure required dependencies are passed