### PR TITLE
Upgrade to golangci-lint v1.42.1

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -40,7 +40,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.40.1
+        version: v1.42.1
 
   test:
     name: "Unit test"

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GATEKEEPER_NAMESPACE ?= gatekeeper-system
 
 # When updating this, make sure to update the corresponding action in
 # workflow.yaml
-GOLANGCI_LINT_VERSION := v1.40.1
+GOLANGCI_LINT_VERSION := v1.42.1
 
 # Detects the location of the user golangci-lint cache.
 GOLANGCI_LINT_CACHE := $(shell pwd)/.tmp/golangci-lint

--- a/cmd/build/helmify/main.go
+++ b/cmd/build/helmify/main.go
@@ -134,8 +134,8 @@ func (ks *kindSet) Write() error {
 }
 
 func doReplacements(obj string) string {
-	for old, new := range replacements {
-		obj = strings.ReplaceAll(obj, old, new)
+	for old, replacement := range replacements {
+		obj = strings.ReplaceAll(obj, old, replacement)
 	}
 	return obj
 }

--- a/cmd/build/helmify/main.go
+++ b/cmd/build/helmify/main.go
@@ -75,7 +75,7 @@ func (ks *kindSet) Write() error {
 			subPath = "crds"
 			parentDir := path.Join(*outputDir, subPath)
 			fmt.Printf("Making %s\n", parentDir)
-			if err := os.Mkdir(parentDir, 0750); err != nil {
+			if err := os.Mkdir(parentDir, 0o750); err != nil {
 				return err
 			}
 		}
@@ -125,7 +125,7 @@ func (ks *kindSet) Write() error {
 				obj = "{{- if .Values.psp.enabled }}\n" + obj + "{{- end }}\n"
 			}
 
-			if err := os.WriteFile(destFile, []byte(obj), 0600); err != nil {
+			if err := os.WriteFile(destFile, []byte(obj), 0o600); err != nil {
 				return err
 			}
 		}
@@ -152,7 +152,7 @@ func copyStaticFiles(root string, subdirs ...string) error {
 		destination := path.Join(append([]string{*outputDir}, newSubDirs...)...)
 		if f.IsDir() {
 			fmt.Printf("Making %s\n", destination)
-			if err := os.Mkdir(destination, 0750); err != nil {
+			if err := os.Mkdir(destination, 0o750); err != nil {
 				return err
 			}
 			if err := copyStaticFiles(root, newSubDirs...); err != nil {
@@ -164,7 +164,7 @@ func copyStaticFiles(root string, subdirs ...string) error {
 				return err
 			}
 			fmt.Printf("Writing %s\n", destination)
-			if err := os.WriteFile(destination, contents, 0600); err != nil {
+			if err := os.WriteFile(destination, contents, 0o600); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Upgrade to the most recent version and fix linter errors.

Signed-off-by: Will Beason <willbeason@google.com>