### PR TITLE
Remove PodOwnership option

### DIFF
--- a/apis/status/v1beta1/constraintpodstatus_types.go
+++ b/apis/status/v1beta1/constraintpodstatus_types.go
@@ -80,7 +80,7 @@ func init() {
 // NewConstraintStatusForPod returns a constraint status object
 // that has been initialized with the bare minimum of fields to make it functional
 // with the constraint status controller.
-func NewConstraintStatusForPod(pod *corev1.Pod, podOwnershipMode PodOwnershipMode, constraint *unstructured.Unstructured, scheme *runtime.Scheme) (*ConstraintPodStatus, error) {
+func NewConstraintStatusForPod(pod *corev1.Pod, constraint *unstructured.Unstructured, scheme *runtime.Scheme) (*ConstraintPodStatus, error) {
 	obj := &ConstraintPodStatus{}
 	name, err := KeyForConstraint(pod.Name, constraint)
 	if err != nil {
@@ -97,11 +97,11 @@ func NewConstraintStatusForPod(pod *corev1.Pod, podOwnershipMode PodOwnershipMod
 		// the template name is the lower-case of the constraint kind
 		ConstraintTemplateNameLabel: strings.ToLower(constraint.GetKind()),
 	})
-	if podOwnershipMode == PodOwnershipEnabled {
-		if err := controllerutil.SetOwnerReference(pod, obj, scheme); err != nil {
-			return nil, err
-		}
+
+	if err = controllerutil.SetOwnerReference(pod, obj, scheme); err != nil {
+		return nil, err
 	}
+
 	return obj, nil
 }
 

--- a/apis/status/v1beta1/constraintpodstatus_types_test.go
+++ b/apis/status/v1beta1/constraintpodstatus_types_test.go
@@ -14,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
+
 func TestNewConstraintStatusForPod(t *testing.T) {
 	g := NewGomegaWithT(t)
 	podName := "some-gk-pod"
@@ -30,6 +32,7 @@ func TestNewConstraintStatusForPod(t *testing.T) {
 	pod := &corev1.Pod{}
 	pod.SetName(podName)
 	pod.SetNamespace(podNS)
+	pod.SetUID(podUID)
 
 	cstr := &unstructured.Unstructured{}
 	cstr.SetGroupVersionKind(schema.GroupVersionKind{Group: ConstraintsGroup, Version: "v1beta1", Kind: cstrKind})
@@ -49,7 +52,7 @@ func TestNewConstraintStatusForPod(t *testing.T) {
 		})
 	g.Expect(controllerutil.SetOwnerReference(pod, expectedStatus, scheme)).NotTo(HaveOccurred())
 
-	status, err := NewConstraintStatusForPod(pod, PodOwnershipEnabled, cstr, scheme)
+	status, err := NewConstraintStatusForPod(pod, cstr, scheme)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(status).To(Equal(expectedStatus))
 	cmVal, err := KeyForConstraint(podName, cstr)

--- a/apis/status/v1beta1/constrainttemplatepodstatus_types.go
+++ b/apis/status/v1beta1/constrainttemplatepodstatus_types.go
@@ -63,7 +63,7 @@ func init() {
 // NewConstraintTemplateStatusForPod returns a constraint template status object
 // that has been initialized with the bare minimum of fields to make it functional
 // with the constraint template status controller.
-func NewConstraintTemplateStatusForPod(pod *corev1.Pod, podOwnershipMode PodOwnershipMode, templateName string, scheme *runtime.Scheme) (*ConstraintTemplatePodStatus, error) {
+func NewConstraintTemplateStatusForPod(pod *corev1.Pod, templateName string, scheme *runtime.Scheme) (*ConstraintTemplatePodStatus, error) {
 	obj := &ConstraintTemplatePodStatus{}
 	name, err := KeyForConstraintTemplate(pod.Name, templateName)
 	if err != nil {
@@ -77,11 +77,11 @@ func NewConstraintTemplateStatusForPod(pod *corev1.Pod, podOwnershipMode PodOwne
 		ConstraintTemplateNameLabel: templateName,
 		PodLabel:                    pod.Name,
 	})
-	if podOwnershipMode == PodOwnershipEnabled {
-		if err := controllerutil.SetOwnerReference(pod, obj, scheme); err != nil {
-			return nil, err
-		}
+
+	if err := controllerutil.SetOwnerReference(pod, obj, scheme); err != nil {
+		return nil, err
 	}
+
 	return obj, nil
 }
 

--- a/apis/status/v1beta1/constrainttemplatepodstatus_types_test.go
+++ b/apis/status/v1beta1/constrainttemplatepodstatus_types_test.go
@@ -26,6 +26,7 @@ func TestNewConstraintTemplateStatusForPod(t *testing.T) {
 	pod := &corev1.Pod{}
 	pod.SetName(podName)
 	pod.SetNamespace(podNS)
+	pod.SetUID(podUID)
 
 	expectedStatus := &ConstraintTemplatePodStatus{}
 	expectedStatus.SetName("some--gk--pod-a--template")
@@ -38,7 +39,7 @@ func TestNewConstraintTemplateStatusForPod(t *testing.T) {
 	})
 	g.Expect(controllerutil.SetOwnerReference(pod, expectedStatus, scheme)).NotTo(HaveOccurred())
 
-	status, err := NewConstraintTemplateStatusForPod(pod, PodOwnershipEnabled, templateName, scheme)
+	status, err := NewConstraintTemplateStatusForPod(pod, templateName, scheme)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(status).To(Equal(expectedStatus))
 	n, err := KeyForConstraintTemplate(podName, templateName)

--- a/apis/status/v1beta1/constrainttemplatepodstatus_types_test.go
+++ b/apis/status/v1beta1/constrainttemplatepodstatus_types_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/operations"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,17 +17,27 @@ func TestNewConstraintTemplateStatusForPod(t *testing.T) {
 	podName := "some-gk-pod"
 	podNS := "a-gk-namespace"
 	templateName := "a-template"
-	os.Setenv("POD_NAMESPACE", podNS)
-	defer os.Unsetenv("POD_NAMESPACE")
+
+	err := os.Setenv("POD_NAMESPACE", podNS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err = os.Unsetenv("POD_NAMESPACE")
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	scheme := runtime.NewScheme()
 	g.Expect(AddToScheme(scheme)).NotTo(HaveOccurred())
 	g.Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
 
-	pod := &corev1.Pod{}
-	pod.SetName(podName)
-	pod.SetNamespace(podNS)
-	pod.SetUID(podUID)
+	pod := fakes.Pod(
+		fakes.WithNamespace(podNS),
+		fakes.WithName(podName),
+	)
 
 	expectedStatus := &ConstraintTemplatePodStatus{}
 	expectedStatus.SetName("some--gk--pod-a--template")

--- a/apis/status/v1beta1/mutatorpodstatus_types.go
+++ b/apis/status/v1beta1/mutatorpodstatus_types.go
@@ -81,7 +81,7 @@ func init() {
 // NewMutatorStatusForPod returns a mutator status object
 // that has been initialized with the bare minimum of fields to make it functional
 // with the mutator status controller.
-func NewMutatorStatusForPod(pod *corev1.Pod, podOwnershipMode PodOwnershipMode, mutatorID mtypes.ID, scheme *runtime.Scheme) (*MutatorPodStatus, error) {
+func NewMutatorStatusForPod(pod *corev1.Pod, mutatorID mtypes.ID, scheme *runtime.Scheme) (*MutatorPodStatus, error) {
 	obj := &MutatorPodStatus{}
 	name, err := KeyForMutatorID(pod.Name, mutatorID)
 	if err != nil {
@@ -97,11 +97,11 @@ func NewMutatorStatusForPod(pod *corev1.Pod, podOwnershipMode PodOwnershipMode, 
 		MutatorKindLabel: mutatorID.Kind,
 		PodLabel:         pod.Name,
 	})
-	if podOwnershipMode == PodOwnershipEnabled {
-		if err := controllerutil.SetOwnerReference(pod, obj, scheme); err != nil {
-			return nil, err
-		}
+
+	if err := controllerutil.SetOwnerReference(pod, obj, scheme); err != nil {
+		return nil, err
 	}
+
 	return obj, nil
 }
 

--- a/apis/status/v1beta1/mutatorpodstatus_types_test.go
+++ b/apis/status/v1beta1/mutatorpodstatus_types_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/testhelpers"
 	"github.com/open-policy-agent/gatekeeper/pkg/operations"
 	corev1 "k8s.io/api/core/v1"
@@ -33,10 +34,10 @@ func TestNewMutatorStatusForPod(t *testing.T) {
 	g.Expect(AddToScheme(scheme)).NotTo(HaveOccurred())
 	g.Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
 
-	pod := &corev1.Pod{}
-	pod.SetName(podName)
-	pod.SetNamespace(podNS)
-	pod.SetUID(podUID)
+	pod := fakes.Pod(
+		fakes.WithNamespace(podNS),
+		fakes.WithName(podName),
+	)
 
 	expectedStatus := &MutatorPodStatus{}
 	expectedStatus.SetName("some--gk--pod--m-dummymutator-a--mutator")

--- a/apis/status/v1beta1/mutatorpodstatus_types_test.go
+++ b/apis/status/v1beta1/mutatorpodstatus_types_test.go
@@ -36,6 +36,7 @@ func TestNewMutatorStatusForPod(t *testing.T) {
 	pod := &corev1.Pod{}
 	pod.SetName(podName)
 	pod.SetNamespace(podNS)
+	pod.SetUID(podUID)
 
 	expectedStatus := &MutatorPodStatus{}
 	expectedStatus.SetName("some--gk--pod--m-dummymutator-a--mutator")
@@ -50,7 +51,7 @@ func TestNewMutatorStatusForPod(t *testing.T) {
 		})
 	g.Expect(controllerutil.SetOwnerReference(pod, expectedStatus, scheme)).NotTo(HaveOccurred())
 
-	status, err := NewMutatorStatusForPod(pod, PodOwnershipEnabled, mutator.ID(), scheme)
+	status, err := NewMutatorStatusForPod(pod, mutator.ID(), scheme)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(status).To(Equal(expectedStatus))
 	cmVal, err := KeyForMutatorID(podName, mutator.ID())

--- a/apis/status/v1beta1/util.go
+++ b/apis/status/v1beta1/util.go
@@ -3,38 +3,7 @@ package v1beta1
 import (
 	"fmt"
 	"strings"
-	"sync"
 )
-
-type PodOwnershipMode bool
-
-const (
-	// PodOwnershipDisabled indicates that owner references should not be put on
-	// dependent resources.
-	PodOwnershipDisabled PodOwnershipMode = false
-	// PodOwnershipEnabled indicates that owner references should be put on
-	// dependent resources.
-	PodOwnershipEnabled PodOwnershipMode = true
-)
-
-var (
-	podOwnershipMode = PodOwnershipEnabled
-	ownerMutex       = sync.RWMutex{}
-)
-
-// DisablePodOwnership disables setting the owner reference for Status resource.
-// This should only be used for testing, where a Pod resource may not be available.
-func DisablePodOwnership() {
-	ownerMutex.Lock()
-	defer ownerMutex.Unlock()
-	podOwnershipMode = PodOwnershipDisabled
-}
-
-func GetPodOwnershipMode() PodOwnershipMode {
-	ownerMutex.RLock()
-	defer ownerMutex.RUnlock()
-	return podOwnershipMode == PodOwnershipEnabled
-}
 
 // dashExtractor unpacks the status resource name, unescaping `-`.
 func dashExtractor(val string) []string {

--- a/apis/status/v1beta1/util.go
+++ b/apis/status/v1beta1/util.go
@@ -53,7 +53,7 @@ func dashPacker(vals ...string) (string, error) {
 			return "", fmt.Errorf("dashPacker cannot pack strings that begin or end with a dash: %+v", vals)
 		}
 		if len(val) == 0 {
-			return "", fmt.Errorf("dashPacker cannot pack empty strings")
+			return "", fmt.Errorf("dashPacker cannot pack empty strings: %v", vals)
 		}
 		if i != 0 {
 			b.WriteString("-")

--- a/apis/status/v1beta1/util_test.go
+++ b/apis/status/v1beta1/util_test.go
@@ -6,17 +6,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestOwnership(t *testing.T) {
-	g := NewGomegaWithT(t)
-	t.Run("Ownership defaults to enabled", func(t *testing.T) {
-		g.Expect(GetPodOwnershipMode()).Should(Equal(PodOwnershipEnabled))
-	})
-	t.Run("Disabling is honored", func(t *testing.T) {
-		DisablePodOwnership()
-		g.Expect(GetPodOwnershipMode()).Should(Equal(PodOwnershipDisabled))
-	})
-}
-
 var dashingTestCases = []struct {
 	name      string
 	extracted []string

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -61,6 +61,8 @@ var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{
 
 const timeout = time.Second * 20
 
+const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
+
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) (manager.Manager, *watch.Manager) {
 	t.Helper()
@@ -271,6 +273,7 @@ func TestConfig_DeleteSyncResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
 			Namespace: "default",
+			UID:       podUID,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
@@ -330,6 +333,7 @@ func TestConfig_DeleteSyncResources(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testpod",
 			Namespace: "default",
+			UID:       podUID,
 		},
 	}
 

--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -135,8 +135,6 @@ func newReconciler(
 		reporter:         reporter,
 		constraintsCache: constraintsCache,
 		tracker:          tracker,
-
-		podOwnershipMode: constraintstatusv1beta1.GetPodOwnershipMode(),
 	}
 	r.getPod = r.defaultGetPod
 	// default
@@ -194,8 +192,6 @@ type ReconcileConstraint struct {
 	// assumeDeleted allows us to short-circuit get requests
 	// that would otherwise trigger a watch
 	assumeDeleted func(schema.GroupVersionKind) bool
-
-	podOwnershipMode constraintstatusv1beta1.PodOwnershipMode
 }
 
 // +kubebuilder:rbac:groups=constraints.gatekeeper.sh,resources=*,verbs=get;list;watch;create;update;patch;delete
@@ -360,7 +356,7 @@ func (r *ReconcileConstraint) getOrCreatePodStatus(ctx context.Context, constrai
 	if err != nil {
 		return nil, err
 	}
-	statusObj, err = constraintstatusv1beta1.NewConstraintStatusForPod(pod, r.podOwnershipMode, constraint, r.scheme)
+	statusObj, err = constraintstatusv1beta1.NewConstraintStatusForPod(pod, constraint, r.scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -166,16 +166,15 @@ func newReconciler(mgr manager.Manager, opa *opa.Client, wm *watch.Manager, cs *
 	}
 	r := newStatsReporter()
 	reconciler := &ReconcileConstraintTemplate{
-		Client:           mgr.GetClient(),
-		scheme:           mgr.GetScheme(),
-		opa:              opa,
-		watcher:          w,
-		statusWatcher:    statusW,
-		cs:               cs,
-		metrics:          r,
-		tracker:          tracker,
-		getPod:           getPod,
-		podOwnershipMode: statusv1beta1.GetPodOwnershipMode(),
+		Client:        mgr.GetClient(),
+		scheme:        mgr.GetScheme(),
+		opa:           opa,
+		watcher:       w,
+		statusWatcher: statusW,
+		cs:            cs,
+		metrics:       r,
+		tracker:       tracker,
+		getPod:        getPod,
 	}
 	if getPod == nil {
 		reconciler.getPod = reconciler.defaultGetPod
@@ -234,8 +233,6 @@ type ReconcileConstraintTemplate struct {
 	metrics       *reporter
 	tracker       *readiness.Tracker
 	getPod        func(context.Context) (*corev1.Pod, error)
-
-	podOwnershipMode statusv1beta1.PodOwnershipMode
 }
 
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
@@ -552,7 +549,7 @@ func (r *ReconcileConstraintTemplate) getOrCreatePodStatus(ctx context.Context, 
 	if err != nil {
 		return nil, err
 	}
-	statusObj, err = statusv1beta1.NewConstraintTemplateStatusForPod(pod, r.podOwnershipMode, ctName, r.scheme)
+	statusObj, err = statusv1beta1.NewConstraintTemplateStatusForPod(pod, ctName, r.scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local"
 	podstatus "github.com/open-policy-agent/gatekeeper/apis/status/v1beta1"
 	statusv1beta1 "github.com/open-policy-agent/gatekeeper/apis/status/v1beta1"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/pkg/target"
 	"github.com/open-policy-agent/gatekeeper/pkg/util"
@@ -62,8 +63,6 @@ import (
 )
 
 const timeout = time.Second * 15
-
-const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) (manager.Manager, *watch.Manager) {
@@ -158,10 +157,11 @@ violation[{"msg": "denied!"}] {
 	cs := watch.NewSwitch()
 	tracker, err := readiness.SetupTracker(mgr, false)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	pod := &corev1.Pod{}
-	pod.Name = "no-pod"
-	pod.Namespace = "gatekeeper-system"
-	pod.UID = podUID
+
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
 
 	// events will be used to receive events from dynamic watches registered
 	events := make(chan event.GenericEvent, 1024)
@@ -487,10 +487,10 @@ violation[{"msg": "denied!"}] {
 	}
 
 	cs := watch.NewSwitch()
-	pod := &corev1.Pod{}
-	pod.Name = "no-pod"
-	pod.Namespace = "gatekeeper-system"
-	pod.UID = podUID
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
 
 	// events will be used to receive events from dynamic watches registered
 	events := make(chan event.GenericEvent, 1024)

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -36,8 +37,6 @@ import (
 )
 
 const timeout = time.Second * 15
-
-const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) (manager.Manager, *watch.Manager) {
@@ -130,10 +129,10 @@ violation[{"msg": "denied!"}] {
 	cs := watch.NewSwitch()
 	tracker, err := readiness.SetupTracker(mgr, false)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	pod := &corev1.Pod{}
-	pod.Name = "no-pod"
-	pod.Namespace = "gatekeeper-system"
-	pod.UID = podUID
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
 
 	adder := constrainttemplate.Adder{
 		Opa:              opaClient,

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
@@ -37,6 +37,8 @@ import (
 
 const timeout = time.Second * 15
 
+const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
+
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) (manager.Manager, *watch.Manager) {
 	t.Helper()
@@ -120,14 +122,19 @@ violation[{"msg": "denied!"}] {
 		t.Fatalf("unable to set up OPA client: %s", err)
 	}
 
-	os.Setenv("POD_NAME", "no-pod")
-	podstatus.DisablePodOwnership()
+	err = os.Setenv("POD_NAME", "no-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cs := watch.NewSwitch()
 	tracker, err := readiness.SetupTracker(mgr, false)
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	pod := &corev1.Pod{}
 	pod.Name = "no-pod"
 	pod.Namespace = "gatekeeper-system"
+	pod.UID = podUID
+
 	adder := constrainttemplate.Adder{
 		Opa:              opaClient,
 		WatchManager:     wm,
@@ -172,7 +179,7 @@ violation[{"msg": "denied!"}] {
 	fakePod := pod.DeepCopy()
 	fakePod.SetName("fake-pod")
 	t.Run("Multiple constraint template statuses are reported", func(t *testing.T) {
-		fakeTStatus, err := podstatus.NewConstraintTemplateStatusForPod(fakePod, podstatus.PodOwnershipDisabled, "denyall", mgr.GetScheme())
+		fakeTStatus, err := podstatus.NewConstraintTemplateStatusForPod(fakePod, "denyall", mgr.GetScheme())
 		g.Expect(err).To(gomega.BeNil())
 		fakeTStatus.Status.TemplateUID = templateCpy.UID
 		defer func() { g.Expect(ignoreNotFound(c.Delete(ctx, fakeTStatus))).To(gomega.BeNil()) }()
@@ -183,7 +190,7 @@ violation[{"msg": "denied!"}] {
 	})
 
 	t.Run("Multiple constraint statuses are reported", func(t *testing.T) {
-		fakeCStatus, err := podstatus.NewConstraintStatusForPod(fakePod, podstatus.PodOwnershipDisabled, newDenyAllConstraint(), mgr.GetScheme())
+		fakeCStatus, err := podstatus.NewConstraintStatusForPod(fakePod, newDenyAllConstraint(), mgr.GetScheme())
 		g.Expect(err).To(gomega.BeNil())
 		fakeCStatus.Status.ConstraintUID = constraint.GetUID()
 		g.Expect(err).To(gomega.BeNil())
@@ -223,13 +230,13 @@ violation[{"msg": "denied!"}] {
 		g.Eventually(verifyCStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyCByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 
-		fakeTStatus, err := podstatus.NewConstraintTemplateStatusForPod(fakePod, podstatus.PodOwnershipDisabled, "denyall", mgr.GetScheme())
+		fakeTStatus, err := podstatus.NewConstraintTemplateStatusForPod(fakePod, "denyall", mgr.GetScheme())
 		g.Expect(err).To(gomega.BeNil())
 		fakeTStatus.Status.TemplateUID = templateCpy.UID
 		g.Expect(c.Create(ctx, fakeTStatus)).NotTo(gomega.HaveOccurred())
 		defer func() { g.Expect(ignoreNotFound(c.Delete(ctx, fakeTStatus))).NotTo(gomega.HaveOccurred()) }()
 
-		fakeCStatus, err := podstatus.NewConstraintStatusForPod(fakePod, podstatus.PodOwnershipDisabled, newDenyAllConstraint(), mgr.GetScheme())
+		fakeCStatus, err := podstatus.NewConstraintStatusForPod(fakePod, newDenyAllConstraint(), mgr.GetScheme())
 		g.Expect(err).To(gomega.BeNil())
 		fakeCStatus.Status.ConstraintUID = constraint.GetUID()
 		g.Expect(c.Create(ctx, fakeCStatus)).NotTo(gomega.HaveOccurred())

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -140,7 +140,6 @@ func AddToManager(ctx context.Context, m manager.Manager, deps Dependencies) err
 			pod := &corev1.Pod{}
 			pod.Name = util.GetPodName()
 			pod.Namespace = util.GetNamespace()
-			pod.UID = "fake-uid"
 
 			return pod, nil
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -22,7 +22,6 @@ import (
 	"sync"
 
 	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
-	podstatus "github.com/open-policy-agent/gatekeeper/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/pkg/readiness"
@@ -136,10 +135,13 @@ func AddToManager(ctx context.Context, m manager.Manager, deps Dependencies) err
 		if err != nil {
 			return err
 		}
-		podstatus.DisablePodOwnership()
+
 		fakePodGetter := func(ctx context.Context) (*corev1.Pod, error) {
 			pod := &corev1.Pod{}
 			pod.Name = util.GetPodName()
+			pod.Namespace = util.GetNamespace()
+			pod.UID = "fake-uid"
+
 			return pod, nil
 		}
 		deps.GetPod = fakePodGetter

--- a/pkg/controller/mutators/core/controller_test.go
+++ b/pkg/controller/mutators/core/controller_test.go
@@ -28,6 +28,7 @@ import (
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
 	podstatus "github.com/open-policy-agent/gatekeeper/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/mutatorstatus"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/match"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators"
@@ -55,8 +56,6 @@ import (
 )
 
 const timeout = time.Second * 15
-
-const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) manager.Manager {
@@ -136,10 +135,10 @@ func TestReconcile(t *testing.T) {
 		}
 	}()
 
-	pod := &corev1.Pod{}
-	pod.Name = "no-pod"
-	pod.Namespace = "gatekeeper-system"
-	pod.UID = podUID
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
 
 	kind := "Assign"
 	newObj := func() client.Object { return &mutationsv1alpha1.Assign{} }

--- a/pkg/controller/mutators/core/controller_test.go
+++ b/pkg/controller/mutators/core/controller_test.go
@@ -56,6 +56,8 @@ import (
 
 const timeout = time.Second * 15
 
+const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
+
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) manager.Manager {
 	t.Helper()
@@ -134,10 +136,10 @@ func TestReconcile(t *testing.T) {
 		}
 	}()
 
-	podstatus.DisablePodOwnership()
 	pod := &corev1.Pod{}
 	pod.Name = "no-pod"
 	pod.Namespace = "gatekeeper-system"
+	pod.UID = podUID
 
 	kind := "Assign"
 	newObj := func() client.Object { return &mutationsv1alpha1.Assign{} }

--- a/pkg/controller/mutators/core/reconciler.go
+++ b/pkg/controller/mutators/core/reconciler.go
@@ -56,19 +56,18 @@ func newReconciler(
 	events chan event.GenericEvent,
 ) *Reconciler {
 	r := &Reconciler{
-		system:           mutationSystem,
-		Client:           mgr.GetClient(),
-		tracker:          tracker,
-		getPod:           getPod,
-		scheme:           mgr.GetScheme(),
-		reporter:         ctrlmutators.NewStatsReporter(),
-		cache:            ctrlmutators.NewMutationCache(),
-		gvk:              mutationsv1alpha1.GroupVersion.WithKind(kind),
-		newMutationObj:   newMutationObj,
-		mutatorFor:       mutatorFor,
-		log:              logf.Log.WithName("controller").WithValues(logging.Process, fmt.Sprintf("%s_controller", strings.ToLower(kind))),
-		podOwnershipMode: statusv1beta1.GetPodOwnershipMode(),
-		events:           events,
+		system:         mutationSystem,
+		Client:         mgr.GetClient(),
+		tracker:        tracker,
+		getPod:         getPod,
+		scheme:         mgr.GetScheme(),
+		reporter:       ctrlmutators.NewStatsReporter(),
+		cache:          ctrlmutators.NewMutationCache(),
+		gvk:            mutationsv1alpha1.GroupVersion.WithKind(kind),
+		newMutationObj: newMutationObj,
+		mutatorFor:     mutatorFor,
+		log:            logf.Log.WithName("controller").WithValues(logging.Process, fmt.Sprintf("%s_controller", strings.ToLower(kind))),
+		events:         events,
 	}
 	if getPod == nil {
 		r.getPod = r.defaultGetPod
@@ -92,8 +91,6 @@ type Reconciler struct {
 	log      logr.Logger
 
 	events chan event.GenericEvent
-
-	podOwnershipMode statusv1beta1.PodOwnershipMode
 }
 
 // +kubebuilder:rbac:groups=mutations.gatekeeper.sh,resources=*,verbs=get;list;watch;create;update;patch;delete
@@ -195,7 +192,7 @@ func (r *Reconciler) getOrCreatePodStatus(ctx context.Context, mutatorID types.I
 		return statusObj, nil
 	}
 
-	statusObj, err = statusv1beta1.NewMutatorStatusForPod(pod, r.podOwnershipMode, mutatorID, r.scheme)
+	statusObj, err = statusv1beta1.NewMutatorStatusForPod(pod, mutatorID, r.scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/mutators/core/reconciler_test.go
+++ b/pkg/controller/mutators/core/reconciler_test.go
@@ -302,12 +302,16 @@ func newFakeReconciler(t *testing.T, c client.Client, events chan event.GenericE
 		},
 		system: mutation.NewSystem(mutation.SystemOpts{}),
 		getPod: func(ctx context.Context) (*corev1.Pod, error) {
-			return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: "gatekeeper-system"}}, nil
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      podName,
+					Namespace: "gatekeeper-system",
+				},
+			}, nil
 		},
-		scheme:           s,
-		podOwnershipMode: statusv1beta1.PodOwnershipEnabled,
-		gvk:              mutationsv1alpha1.GroupVersion.WithKind("fake"),
-		events:           events,
+		scheme: s,
+		gvk:    mutationsv1alpha1.GroupVersion.WithKind("fake"),
+		events: events,
 	}
 }
 

--- a/pkg/controller/mutators/core/reconciler_test.go
+++ b/pkg/controller/mutators/core/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
 	statusv1beta1 "github.com/open-policy-agent/gatekeeper/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/mutators"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
 	mutationschema "github.com/open-policy-agent/gatekeeper/pkg/mutation/schema"
@@ -302,12 +303,12 @@ func newFakeReconciler(t *testing.T, c client.Client, events chan event.GenericE
 		},
 		system: mutation.NewSystem(mutation.SystemOpts{}),
 		getPod: func(ctx context.Context) (*corev1.Pod, error) {
-			return &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: "gatekeeper-system",
-				},
-			}, nil
+			return fakes.Pod(
+				fakes.WithNamespace("gatekeeper-system"),
+				fakes.WithName(podName),
+				// These tests do not depend on UID and validating this is annoying.
+				fakes.WithUID(""),
+			), nil
 		},
 		scheme: s,
 		gvk:    mutationsv1alpha1.GroupVersion.WithKind("fake"),

--- a/pkg/fakes/doc.go
+++ b/pkg/fakes/doc.go
@@ -1,0 +1,8 @@
+// Package fakes defines methods for instantiating objects which act like
+// resources on a Kubernetes cluster, but are not intended to actually be
+// instantiated on a real, production cluster.
+//
+// The primary purpose of these objects is to aid writing tests, but that is not
+// this package's only purpose. These objects are also used in debugging logic
+// which is compiled in to production code.
+package fakes

--- a/pkg/fakes/opts.go
+++ b/pkg/fakes/opts.go
@@ -1,0 +1,76 @@
+package fakes
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// Name is the default name given to fake objects.
+	Name = "foo"
+
+	// Namespace is the default namespace given to fake namespace-scoped objects.
+	Namespace = "bar"
+
+	// UID is the default UID given to fake objects.
+	UID = "abcd"
+)
+
+var (
+	// defaultOpts are automatically applied to all fake objects to ensure they
+	// are reasonably usable out-of-the-box.
+	defaultOpts = []Opt{
+		// Nearly all functionality which operates on client.Objects requires that
+		// metadata.name be set.
+		WithName(Name),
+
+		// Setting an object as an OwnerReference fails validation if the referenced
+		// object is missing a UID. This causes confusing test behavior, so we set
+		// this by default.
+		WithUID(UID),
+	}
+
+	// defaultNamespacedOpts are applied to fake objects of namespace-scoped Kinds.
+	defaultNamespacedOpts = append(defaultOpts,
+		// Some of our functionality relies on namespace-scoped objects always
+		// having a defined Namespace. While in a cluster Kubernetes will correctly
+		// set metadata.namespace if it is undefined, our logic is not robust to
+		// fake namespace-scoped objects without metadata.namespace.
+		WithNamespace(Namespace),
+	)
+)
+
+// Opt modifies a client.Object during object instantiation.
+// Generally, if there are conflicting opts (such as two WithName calls), the
+// latter should win. This allows objects to have defaults which can easily be
+// overridden.
+type Opt func(client.Object)
+
+// WithName sets the metadata.name of the object.
+func WithName(name string) Opt {
+	return func(object client.Object) {
+		object.SetName(name)
+	}
+}
+
+// WithNamespace sets the metadata.namespace of the object.
+func WithNamespace(namespace string) Opt {
+	return func(object client.Object) {
+		object.SetNamespace(namespace)
+	}
+}
+
+// WithUID sets the metadata.uid of the object.
+func WithUID(uid types.UID) Opt {
+	return func(object client.Object) {
+		object.SetUID(uid)
+	}
+}
+
+// WithLabels sets the metadata.labels of the object.
+// Overwrites any existing labels on the object.
+func WithLabels(labels map[string]string) Opt {
+	return func(object client.Object) {
+		object.SetLabels(labels)
+	}
+}

--- a/pkg/fakes/pod.go
+++ b/pkg/fakes/pod.go
@@ -1,0 +1,23 @@
+package fakes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Pod creates a Pod for use in testing or debugging logic.
+func Pod(opts ...Opt) *corev1.Pod {
+	result := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+		},
+	}
+
+	opts = append(defaultNamespacedOpts, opts...)
+	for _, opt := range opts {
+		opt(result)
+	}
+
+	return result
+}

--- a/pkg/mutation/mutators/assign/assign_mutator_test.go
+++ b/pkg/mutation/mutators/assign/assign_mutator_test.go
@@ -12,7 +12,7 @@ import (
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/match"
 	path "github.com/open-policy-agent/gatekeeper/pkg/mutation/path/tester"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,7 +82,7 @@ func newFoo(spec map[string]interface{}) *unstructured.Unstructured {
 	return &unstructured.Unstructured{Object: data}
 }
 
-func newPod(pod *v1.Pod) *unstructured.Unstructured {
+func newPod(pod *corev1.Pod) *unstructured.Unstructured {
 	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pod)
 	if err != nil {
 		panic(fmt.Sprintf("converting pod to unstructured: %v", err))
@@ -784,7 +784,7 @@ func TestApplyTo(t *testing.T) {
 	}
 }
 
-var testPod = &v1.Pod{
+var testPod = &corev1.Pod{
 	TypeMeta: metav1.TypeMeta{
 		APIVersion: "v1",
 		Kind:       "Pod",
@@ -794,8 +794,8 @@ var testPod = &v1.Pod{
 		Namespace: "production",
 		Labels:    map[string]string{"owner": "me.agilebank.demo"},
 	},
-	Spec: v1.PodSpec{
-		Containers: []v1.Container{
+	Spec: corev1.PodSpec{
+		Containers: []corev1.Container{
 			{
 				Name:  "opa",
 				Image: "openpolicyagent/opa:0.9.2",
@@ -804,7 +804,7 @@ var testPod = &v1.Pod{
 					"--server",
 					"--addr=localhost:8080",
 				},
-				Ports: []v1.ContainerPort{
+				Ports: []corev1.ContainerPort{
 					{
 						ContainerPort: 8080,
 						Name:          "out-of-scope",
@@ -835,7 +835,7 @@ func TestAssign(t *testing.T) {
 			},
 			obj: newPod(testPod),
 			fn: func(u *unstructured.Unstructured) error {
-				var pod v1.Pod
+				var pod corev1.Pod
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
 				if err != nil {
 					return err
@@ -867,7 +867,7 @@ func TestAssign(t *testing.T) {
 			},
 			obj: newPod(testPod),
 			fn: func(u *unstructured.Unstructured) error {
-				var pod v1.Pod
+				var pod corev1.Pod
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
 				if err != nil {
 					return err
@@ -899,7 +899,7 @@ func TestAssign(t *testing.T) {
 			},
 			obj: newPod(testPod),
 			fn: func(u *unstructured.Unstructured) error {
-				var pod v1.Pod
+				var pod corev1.Pod
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
 				if err != nil {
 					return err
@@ -933,7 +933,7 @@ func TestAssign(t *testing.T) {
 			},
 			obj: newPod(testPod),
 			fn: func(u *unstructured.Unstructured) error {
-				var pod v1.Pod
+				var pod corev1.Pod
 				err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &pod)
 				if err == nil {
 					return errors.New("expected type mismatch when deserializing mutated pod")

--- a/pkg/mutation/mutators/core/mutation_function_test.go
+++ b/pkg/mutation/mutators/core/mutation_function_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	TestValue          = "testValue"
 	ParameterTestValue = "\"testValue\""
+	podUID             = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 )
 
 func prepareTestPod(t *testing.T) *unstructured.Unstructured {
@@ -27,6 +28,7 @@ func prepareTestPod(t *testing.T) *unstructured.Unstructured {
 			Name:      "testpod1",
 			Namespace: "foo",
 			Labels:    map[string]string{"a": "b"},
+			UID:       podUID,
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/pkg/mutation/mutators/core/mutation_function_test.go
+++ b/pkg/mutation/mutators/core/mutation_function_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/apis/mutations/v1alpha1"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/match"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/testhelpers"
@@ -19,40 +20,38 @@ import (
 const (
 	TestValue          = "testValue"
 	ParameterTestValue = "\"testValue\""
-	podUID             = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 )
 
 func prepareTestPod(t *testing.T) *unstructured.Unstructured {
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testpod1",
-			Namespace: "foo",
-			Labels:    map[string]string{"a": "b"},
-			UID:       podUID,
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:  "testname1",
-					Image: "image",
-					Ports: []corev1.ContainerPort{{Name: "portName1"}},
+	pod := fakes.Pod(
+		fakes.WithNamespace("foo"),
+		fakes.WithName("test-pod"),
+		fakes.WithLabels(map[string]string{"a": "b"}),
+	)
+
+	pod.Spec = corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "testname1",
+				Image: "image",
+				Ports: []corev1.ContainerPort{{Name: "portName1"}},
+			},
+			{
+				Name:  "testname2",
+				Image: "image",
+				Ports: []corev1.ContainerPort{
+					{Name: "portName2A"},
+					{Name: "portName2B"},
 				},
-				{
-					Name:  "testname2",
-					Image: "image",
-					Ports: []corev1.ContainerPort{
-						{Name: "portName2A"},
-						{Name: "portName2B"},
-					},
-				},
-				{
-					Name:  "testname3",
-					Image: "image",
-					Ports: []corev1.ContainerPort{{Name: "portName3"}},
-				},
+			},
+			{
+				Name:  "testname3",
+				Image: "image",
+				Ports: []corev1.ContainerPort{{Name: "portName3"}},
 			},
 		},
 	}
+
 	podObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pod)
 	if err != nil {
 		t.Errorf("Failed to convert pod to unstructured %v", err)

--- a/pkg/mutation/system_test.go
+++ b/pkg/mutation/system_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
 	mutationschema "github.com/open-policy-agent/gatekeeper/pkg/mutation/schema"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
@@ -17,8 +18,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 
 // Leverage existing resource types to create custom mutators to validate
 // the cache.
@@ -185,13 +184,10 @@ func TestMutation(t *testing.T) {
 	}
 	for _, tc := range table {
 		t.Run(tc.name, func(t *testing.T) {
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "foo",
-					UID:       podUID,
-				},
-			}
+			pod := fakes.Pod(
+				fakes.WithNamespace("foo"),
+				fakes.WithName("test-pod"),
+			)
 
 			converted, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pod)
 			if err != nil {
@@ -475,13 +471,10 @@ func TestSystem_ReportingInjection(t *testing.T) {
 	}
 
 	// Prepare a mutate-able object
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-pod",
-			Namespace: "foo",
-			UID:       podUID,
-		},
-	}
+	pod := fakes.Pod(
+		fakes.WithNamespace("foo"),
+		fakes.WithName("test-pod"),
+	)
 
 	converted, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pod)
 	if err != nil {

--- a/pkg/mutation/system_test.go
+++ b/pkg/mutation/system_test.go
@@ -18,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
+
 // Leverage existing resource types to create custom mutators to validate
 // the cache.
 type fakeMutator struct {
@@ -187,6 +189,7 @@ func TestMutation(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-pod",
 					Namespace: "foo",
+					UID:       podUID,
 				},
 			}
 
@@ -476,6 +479,7 @@ func TestSystem_ReportingInjection(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
 			Namespace: "foo",
+			UID:       podUID,
 		},
 	}
 

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local"
-	podstatus "github.com/open-policy-agent/gatekeeper/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
@@ -49,6 +48,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) (manager.Manager, *watch.Manager) {
@@ -109,6 +110,7 @@ func setupController(mgr manager.Manager, wm *watch.Manager, opa *opa.Client, mu
 	pod := &corev1.Pod{}
 	pod.Name = "no-pod"
 	pod.Namespace = "gatekeeper-system"
+	pod.UID = podUID
 
 	processExcluder := process.Get()
 
@@ -140,11 +142,13 @@ func Test_AssignMetadata(t *testing.T) {
 	mutationEnabled := true
 	mutation.MutationEnabled = &mutationEnabled
 
-	os.Setenv("POD_NAME", "no-pod")
-	podstatus.DisablePodOwnership()
+	err := os.Setenv("POD_NAME", "no-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Apply fixtures *before* the controllers are setup.
-	err := applyFixtures("testdata")
+	err = applyFixtures("testdata")
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
 
 	// Wire up the rest.
@@ -189,11 +193,13 @@ func Test_ModifySet(t *testing.T) {
 	mutationEnabled := true
 	mutation.MutationEnabled = &mutationEnabled
 
-	os.Setenv("POD_NAME", "no-pod")
-	podstatus.DisablePodOwnership()
+	err := os.Setenv("POD_NAME", "no-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Apply fixtures *before* the controllers are setup.
-	err := applyFixtures("testdata")
+	err = applyFixtures("testdata")
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
 
 	// Wire up the rest.
@@ -238,11 +244,13 @@ func Test_Assign(t *testing.T) {
 	mutationEnabled := true
 	mutation.MutationEnabled = &mutationEnabled
 
-	os.Setenv("POD_NAME", "no-pod")
-	podstatus.DisablePodOwnership()
+	err := os.Setenv("POD_NAME", "no-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Apply fixtures *before* the controllers are setup.
-	err := applyFixtures("testdata")
+	err = applyFixtures("testdata")
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
 
 	// Wire up the rest.
@@ -286,11 +294,13 @@ func Test_Assign(t *testing.T) {
 func Test_Tracker(t *testing.T) {
 	g := gomega.NewWithT(t)
 
-	os.Setenv("POD_NAME", "no-pod")
-	podstatus.DisablePodOwnership()
+	err := os.Setenv("POD_NAME", "no-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Apply fixtures *before* the controllers are setup.
-	err := applyFixtures("testdata")
+	err = applyFixtures("testdata")
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
 
 	// Wire up the rest.

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
 	mutationtypes "github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
 	"github.com/open-policy-agent/gatekeeper/pkg/readiness"
@@ -48,8 +49,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
-
-const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) (manager.Manager, *watch.Manager) {
@@ -107,10 +106,10 @@ func setupController(mgr manager.Manager, wm *watch.Manager, opa *opa.Client, mu
 	// avoiding conflicts in finalizer cleanup.
 	sw := watch.NewSwitch()
 
-	pod := &corev1.Pod{}
-	pod.Name = "no-pod"
-	pod.Namespace = "gatekeeper-system"
-	pod.UID = podUID
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
 
 	processExcluder := process.Get()
 

--- a/pkg/watch/manager_integration_test.go
+++ b/pkg/watch/manager_integration_test.go
@@ -53,6 +53,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
+
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) (manager.Manager, *watch.Manager) {
 	t.Helper()
@@ -148,7 +150,9 @@ func Test_ReconcileErrorDoesNotBlockController(t *testing.T) {
 	// via the registrar below.
 	errObj := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "error",
+			Name:      "error",
+			Namespace: "gatekeeper-system",
+			UID:       podUID,
 		},
 	}
 	events := make(chan event.GenericEvent, 1024)

--- a/pkg/watch/manager_integration_test.go
+++ b/pkg/watch/manager_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/pkg/watch"
 	testclient "github.com/open-policy-agent/gatekeeper/test/clients"
@@ -52,8 +53,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
-
-const podUID = "ead351c9d-42bf-21d8-a674-3d8de271b701"
 
 // setupManager sets up a controller-runtime manager with registered watch manager.
 func setupManager(t *testing.T) (manager.Manager, *watch.Manager) {
@@ -148,13 +147,11 @@ func Test_ReconcileErrorDoesNotBlockController(t *testing.T) {
 
 	// Events will be used to receive events from dynamic watches registered
 	// via the registrar below.
-	errObj := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "error",
-			Namespace: "gatekeeper-system",
-			UID:       podUID,
-		},
-	}
+	errObj := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("error"),
+	)
+
 	events := make(chan event.GenericEvent, 1024)
 	events <- event.GenericEvent{
 		Object: errObj,


### PR DESCRIPTION
This was introduced for tests, but is unnecessary. All that is needed
for setting ownerreferences to work properly is to set the UID of fake
Pods used in testing.

This is because ownerreference validation requires that UID be set on
the reference (to deduplicate objects with identical names/namespaces
which existed at different points in time).

This raises the point that we should probably have a general-purpose
method for instantiating a fake Pod for use in testing and debugging. It
isn't obvious to me where that is. Feel free to suggest a location. Do
note that it would be in production code since the debug setting is
compiled in non-test files.

Note: the fake Pod UID I've added for tests is arbitrary - it just has to be
*something*, but the specific value is meaningless.

This PR is a follow-up based on suggestions ritazh and julianKatz made on #1569

Signed-off-by: Will Beason <willbeason@google.com>