### PR TITLE
Fix bugs in ModifySet mutator

### DIFF
--- a/pkg/mutation/mutators/modifyset/modify_set_mutator.go
+++ b/pkg/mutation/mutators/modifyset/modify_set_mutator.go
@@ -290,17 +290,21 @@ func (s setter) setValuePrune(obj map[string]interface{}, key string) error {
 	if !ok {
 		return fmt.Errorf("%+v is not a list of values, cannot treat it as a set", val)
 	}
-outer:
-	for _, v := range s.values {
-		for i, existing := range vals {
+
+	// we are assuming order is important, otherwise this could be done
+	// more cheaply by swapping values
+	filtered := make([]interface{}, 0, len(vals))
+	for _, existing := range vals {
+		matched := false
+		for _, v := range s.values {
 			if cmp.Equal(v, existing) {
-				// we are assuming order is important, otherwise this could be done
-				// more cheaply by swapping values
-				vals = append(vals[:i], vals[i+1:]...)
-				continue outer
+				matched = true
 			}
 		}
+		if !matched {
+			filtered = append(filtered, existing)
+		}
 	}
-	obj[key] = vals
+	obj[key] = filtered
 	return nil
 }

--- a/pkg/mutation/mutators/modifyset/modify_set_test.go
+++ b/pkg/mutation/mutators/modifyset/modify_set_test.go
@@ -139,6 +139,12 @@ func TestSetterPrune(t *testing.T) {
 			existing: []interface{}{[]interface{}{"a", "b", "d"}, []interface{}{"r", "r", "r"}},
 			expected: []interface{}{[]interface{}{"r", "r", "r"}},
 		},
+		{
+			name:     "Duplicate existing",
+			vals:     []interface{}{"a"},
+			existing: []interface{}{"a", "b", "a"},
+			expected: []interface{}{"b"},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
ModifySet has the following bugs:

* It has an index error if pruning an item from the end of a list
* It assumes that the input list is a well-formed set, which may not
  be true.

Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: