### PR TITLE
Forbid empty assertions

### DIFF
--- a/pkg/gktest/runner.go
+++ b/pkg/gktest/runner.go
@@ -196,19 +196,17 @@ func (r *Runner) checkCase(ctx context.Context, newClient func() (Client, error)
 		return fmt.Errorf("%w: must define object", ErrInvalidCase)
 	}
 
+	if len(tc.Assertions) == 0 {
+		// Test cases must define at least one assertion.
+		return fmt.Errorf("%w: assertions must be non-empty", ErrInvalidCase)
+	}
+
 	review, err := r.runReview(ctx, newClient, suiteDir, tc)
 	if err != nil {
 		return err
 	}
 
 	results := review.Results()
-
-	if len(tc.Assertions) == 0 {
-		// Default to assuming the object passes validation if no Assertions are
-		// defined.
-		tc.Assertions = []Assertion{{Violations: intStrFromStr("no")}}
-	}
-
 	for i := range tc.Assertions {
 		err = tc.Assertions[i].Run(results)
 		if err != nil {

--- a/pkg/gktest/runner_integer_test.go
+++ b/pkg/gktest/runner_integer_test.go
@@ -282,7 +282,8 @@ func TestRunner_Run_Integer(t *testing.T) {
 					Template:   "template.yaml",
 					Constraint: "constraint.yaml",
 					Cases: []*Case{{
-						Object: "allow.yaml",
+						Object:     "allow.yaml",
+						Assertions: []Assertion{{Violations: intStrFromInt(0)}},
 					}, {
 						Object:     "disallow.yaml",
 						Assertions: []Assertion{{Violations: intStrFromInt(1)}},
@@ -291,17 +292,18 @@ func TestRunner_Run_Integer(t *testing.T) {
 			}
 
 			result := runner.Run(ctx, &nilFilter{}, "", suite)
-
-			if result.IsFailure() {
-				sb := strings.Builder{}
-				err := PrinterGo{}.PrintSuite(&sb, &result, true)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				t.Log(sb.String())
-				t.Fatal("got failure but want success")
+			if !result.IsFailure() {
+				return
 			}
+
+			sb := strings.Builder{}
+			err = PrinterGo{}.PrintSuite(&sb, &result, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Log(sb.String())
+			t.Fatal("got failure but want success")
 		})
 	}
 }

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -513,7 +513,7 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Object: "object.yaml",
+						Object:     "object.yaml",
 						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
@@ -544,8 +544,8 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Object:    "object.yaml",
-						Inventory: []string{"inventory.yaml"},
+						Object:     "object.yaml",
+						Inventory:  []string{"inventory.yaml"},
 						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
@@ -579,7 +579,7 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Object: "object.yaml",
+						Object:     "object.yaml",
 						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
@@ -610,7 +610,7 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Object: "object.yaml",
+						Object:     "object.yaml",
 						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
@@ -641,8 +641,8 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Object:    "object.yaml",
-						Inventory: []string{"inventory.yaml"},
+						Object:     "object.yaml",
+						Inventory:  []string{"inventory.yaml"},
 						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
@@ -781,7 +781,7 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Object: "object.yaml",
+						Object:     "object.yaml",
 						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -469,16 +469,15 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Object: "object.yaml",
+						Object:     "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}, {
 					Template:   "deny-template.yaml",
 					Constraint: "deny-constraint.yaml",
 					Cases: []*Case{{
-						Object: "object.yaml",
-						Assertions: []Assertion{{
-							Violations: intStrFromStr("yes"),
-						}},
+						Object:     "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("yes")}},
 					}},
 				}},
 			},
@@ -515,6 +514,7 @@ func TestRunner_Run(t *testing.T) {
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
 						Object: "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
 			},
@@ -546,6 +546,7 @@ func TestRunner_Run(t *testing.T) {
 					Cases: []*Case{{
 						Object:    "object.yaml",
 						Inventory: []string{"inventory.yaml"},
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
 			},
@@ -579,6 +580,7 @@ func TestRunner_Run(t *testing.T) {
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
 						Object: "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
 			},
@@ -609,6 +611,7 @@ func TestRunner_Run(t *testing.T) {
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
 						Object: "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
 			},
@@ -640,6 +643,7 @@ func TestRunner_Run(t *testing.T) {
 					Cases: []*Case{{
 						Object:    "object.yaml",
 						Inventory: []string{"inventory.yaml"},
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
 			},
@@ -778,6 +782,7 @@ func TestRunner_Run(t *testing.T) {
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
 						Object: "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}},
 			},
@@ -804,10 +809,8 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Object: "object.yaml",
-						Assertions: []Assertion{{
-							Violations: intStrFromStr("yes"),
-						}},
+						Object:     "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("yes")}},
 					}},
 				}},
 			},
@@ -859,22 +862,22 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "allow-template.yaml",
 					Constraint: "allow-constraint.yaml",
 					Cases: []*Case{{
-						Name:   "allowed-1",
-						Object: "object.yaml",
+						Name:       "allowed-1",
+						Object:     "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}, {
-						Name:   "allowed-2",
-						Object: "object.yaml",
+						Name:       "allowed-2",
+						Object:     "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}},
 				}, {
 					Name:       "deny",
 					Template:   "deny-template.yaml",
 					Constraint: "deny-constraint.yaml",
 					Cases: []*Case{{
-						Name:   "denied",
-						Object: "object.yaml",
-						Assertions: []Assertion{{
-							Violations: intStrFromStr("yes"),
-						}},
+						Name:       "denied",
+						Object:     "object.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("yes")}},
 					}},
 				}},
 			},
@@ -916,16 +919,15 @@ func TestRunner_Run(t *testing.T) {
 					Template:   "template.yaml",
 					Constraint: "constraint.yaml",
 					Cases: []*Case{{
-						Name:      "allow",
-						Object:    "allow.yaml",
-						Inventory: []string{"inventory.yaml"},
+						Name:       "allow",
+						Object:     "allow.yaml",
+						Inventory:  []string{"inventory.yaml"},
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
 					}, {
-						Name:      "deny",
-						Object:    "deny.yaml",
-						Inventory: []string{"inventory.yaml"},
-						Assertions: []Assertion{{
-							Violations: intStrFromStr("yes"),
-						}},
+						Name:       "deny",
+						Object:     "deny.yaml",
+						Inventory:  []string{"inventory.yaml"},
+						Assertions: []Assertion{{Violations: intStrFromStr("yes")}},
 					}},
 				}},
 			},
@@ -1030,12 +1032,12 @@ func TestRunner_RunCase(t *testing.T) {
 	}{
 		// Validation successful
 		{
-			name:       "implicit expect allow",
+			name:       "no assertions is error",
 			template:   templateAlwaysValidate,
 			constraint: constraintAlwaysValidate,
 			object:     object,
 			assertions: nil,
-			want:       CaseResult{},
+			want:       CaseResult{Error: ErrInvalidCase},
 		},
 		{
 			name:       "explicit expect allow boolean",
@@ -1062,9 +1064,7 @@ func TestRunner_RunCase(t *testing.T) {
 			template:   templateAlwaysValidate,
 			constraint: constraintAlwaysValidate,
 			object:     object,
-			assertions: []Assertion{{
-				Violations: intStrFromStr("yes"),
-			}},
+			assertions: []Assertion{{Violations: intStrFromStr("yes")}},
 			want: CaseResult{
 				Error: ErrNumViolations,
 			},
@@ -1117,10 +1117,8 @@ func TestRunner_RunCase(t *testing.T) {
 			template:   templateNeverValidate,
 			constraint: constraintNeverValidate,
 			object:     object,
-			assertions: []Assertion{{
-				Violations: intStrFromStr("yes"),
-			}},
-			want: CaseResult{},
+			assertions: []Assertion{{Violations: intStrFromStr("yes")}},
+			want:       CaseResult{},
 		},
 		{
 			name:       "expect deny int",


### PR DESCRIPTION
Forbid empty assertions, per discussion. Empty assertions in a test case is an error. Users must explicitly specify whether a case is intended to return a violation or not.

Signed-off-by: Will Beason <willbeason@google.com>