### PR TITLE
add token permissions for actions

### DIFF
--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -8,6 +8,9 @@ on:
     paths:
       - "manifest_staging/charts/**"
 
+permissions:
+  contents: read
+
 env:
   BASE_RELEASE: 3.4.0
   BASE_BRANCH: release-3.4

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/website.yaml"
       - "website/**"
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -33,6 +33,8 @@ jobs:
     name: "Lint"
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v2
       # source: https://github.com/golangci/golangci-lint-action
@@ -46,6 +48,8 @@ jobs:
     name: "Unit test"
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - name: Set up Go 1.17
         uses: actions/setup-go@v2
@@ -75,6 +79,8 @@ jobs:
     name: "Build and Test"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     strategy:
       matrix:
         KUBERNETES_VERSION: ["1.20.7", "1.21.1", "1.22.0"]
@@ -119,6 +125,8 @@ jobs:
     name: "[Helm] Build and Test"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     strategy:
       matrix:
         HELM_VERSION: ["3.4.2"]
@@ -157,6 +165,8 @@ jobs:
     name: "[External Data] Build and Test"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     strategy:
       matrix:
         KUBERNETES_VERSION: ["1.22.0"]
@@ -204,6 +214,8 @@ jobs:
     if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')) && github.event_name == 'push' && github.repository == 'open-policy-agent/gatekeeper'
     needs: [lint, test, build_test, helm_build_test]
     timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -237,6 +249,8 @@ jobs:
   tagged-release:
     name: "Tagged Release"
     runs-on: "ubuntu-latest"
+    permissions:
+      contents: write
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-policy-agent/gatekeeper'
     needs: [lint, test, build_test, helm_build_test]
     timeout-minutes: 30


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:

By default `GITHUB_TOKEN` has write-all access. Scoping permissions to least required access.
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: