### PR TITLE
enable external data flag for helm

### DIFF
--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -79,6 +79,7 @@ spec:
             - --exempt-namespace={{ .Release.Namespace }}
             - --operation=webhook
             - --enable-mutation={{ .Values.experimentalEnableMutation}}
+            - --enable-external-data={{ .Values.enableExternalData }}
             - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_DISABLED_BUILTIN
             - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_EXEMPT_NAMESPACES
             - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_EXEMPT_NAMESPACE_PREFIXES
@@ -141,6 +142,7 @@ spec:
             - --logtostderr
             - --health-addr=:HELMSUBST_DEPLOYMENT_AUDIT_HEALTH_PORT
             - --prometheus-port=HELMSUBST_DEPLOYMENT_AUDIT_METRICS_PORT
+            - --enable-external-data={{ .Values.enableExternalData }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           image: "{{ .Values.image.repository }}:{{ .Values.image.release }}"
           ports:

--- a/cmd/build/helmify/static/README.md
+++ b/cmd/build/helmify/static/README.md
@@ -63,10 +63,10 @@ _See [Exempting Namespaces](https://open-policy-agent.github.io/gatekeeper/websi
 ## Parameters
 
 | Parameter                                    | Description                                                                            | Default                                                                   |
-| :------------------------------------------- | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------ |
+|:---------------------------------------------|:---------------------------------------------------------------------------------------|:--------------------------------------------------------------------------|
 | postInstall.labelNamespace.enabled           | Add labels to the namespace during post install hooks                                  | `true`                                                                    |
-| postInstall.labelNamespace.image.repository  | Image with kubectl to label the namespace                                              | `openpolicyagent/gatekeeper-crds`                                                  |
-| postInstall.labelNamespace.image.tag         | Image tag                                                                              | Current release version: `v3.7.0-beta.2`                                                            |
+| postInstall.labelNamespace.image.repository  | Image with kubectl to label the namespace                                              | `openpolicyagent/gatekeeper-crds`                                         |
+| postInstall.labelNamespace.image.tag         | Image tag                                                                              | Current release version: `v3.7.0-beta.2`                                  |
 | postInstall.labelNamespace.image.pullPolicy  | Image pullPolicy                                                                       | `IfNotPresent`                                                            |
 | postInstall.labelNamespace.image.pullSecrets | Image pullSecrets                                                                      | `[]`                                                                      |
 | psp.enabled                                  | Enabled PodSecurityPolicy                                                              | `true`                                                                    |
@@ -81,6 +81,7 @@ _See [Exempting Namespaces](https://open-policy-agent.github.io/gatekeeper/websi
 | validatingWebhookFailurePolicy               | The failurePolicy for the validating webhook                                           | `Ignore`                                                                  |
 | validatingWebhookCheckIgnoreFailurePolicy    | The failurePolicy for the check-ignore-label validating webhook                        | `Fail`                                                                    |
 | enableDeleteOperations                       | Enable validating webhook for delete operations                                        | `false`                                                                   |
+| enableExternalData                           | Enable external data (alpha feature)                                                   | `false`                                                                   |
 | experimentalEnableMutation                   | Enable mutation  (alpha feature)                                                       | `false`                                                                   |
 | mutatingWebhookFailurePolicy                 | The failurePolicy for the mutating webhook                                             | `Ignore`                                                                  |
 | mutatingWebhookTimeoutSeconds                | The timeout for the mutating webhook in seconds                                        | `3`                                                                       |

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -8,6 +8,7 @@ validatingWebhookTimeoutSeconds: 3
 validatingWebhookFailurePolicy: Ignore
 validatingWebhookCheckIgnoreFailurePolicy: Fail
 enableDeleteOperations: false
+enableExternalData: false
 experimentalEnableMutation: false
 mutatingWebhookFailurePolicy: Ignore
 mutatingWebhookTimeoutSeconds: 3

--- a/manifest_staging/charts/gatekeeper/README.md
+++ b/manifest_staging/charts/gatekeeper/README.md
@@ -63,10 +63,10 @@ _See [Exempting Namespaces](https://open-policy-agent.github.io/gatekeeper/websi
 ## Parameters
 
 | Parameter                                    | Description                                                                            | Default                                                                   |
-| :------------------------------------------- | :------------------------------------------------------------------------------------- | :------------------------------------------------------------------------ |
+|:---------------------------------------------|:---------------------------------------------------------------------------------------|:--------------------------------------------------------------------------|
 | postInstall.labelNamespace.enabled           | Add labels to the namespace during post install hooks                                  | `true`                                                                    |
-| postInstall.labelNamespace.image.repository  | Image with kubectl to label the namespace                                              | `openpolicyagent/gatekeeper-crds`                                                  |
-| postInstall.labelNamespace.image.tag         | Image tag                                                                              | Current release version: `v3.7.0-beta.2`                                                            |
+| postInstall.labelNamespace.image.repository  | Image with kubectl to label the namespace                                              | `openpolicyagent/gatekeeper-crds`                                         |
+| postInstall.labelNamespace.image.tag         | Image tag                                                                              | Current release version: `v3.7.0-beta.2`                                  |
 | postInstall.labelNamespace.image.pullPolicy  | Image pullPolicy                                                                       | `IfNotPresent`                                                            |
 | postInstall.labelNamespace.image.pullSecrets | Image pullSecrets                                                                      | `[]`                                                                      |
 | psp.enabled                                  | Enabled PodSecurityPolicy                                                              | `true`                                                                    |
@@ -81,6 +81,7 @@ _See [Exempting Namespaces](https://open-policy-agent.github.io/gatekeeper/websi
 | validatingWebhookFailurePolicy               | The failurePolicy for the validating webhook                                           | `Ignore`                                                                  |
 | validatingWebhookCheckIgnoreFailurePolicy    | The failurePolicy for the check-ignore-label validating webhook                        | `Fail`                                                                    |
 | enableDeleteOperations                       | Enable validating webhook for delete operations                                        | `false`                                                                   |
+| enableExternalData                           | Enable external data (alpha feature)                                                   | `false`                                                                   |
 | experimentalEnableMutation                   | Enable mutation  (alpha feature)                                                       | `false`                                                                   |
 | mutatingWebhookFailurePolicy                 | The failurePolicy for the mutating webhook                                             | `Ignore`                                                                  |
 | mutatingWebhookTimeoutSeconds                | The timeout for the mutating webhook in seconds                                        | `3`                                                                       |

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -53,6 +53,7 @@ spec:
         - --logtostderr
         - --health-addr=:{{ .Values.audit.healthPort }}
         - --prometheus-port={{ .Values.audit.metricsPort }}
+        - --enable-external-data={{ .Values.enableExternalData }}
         command:
         - /manager
         env:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -51,6 +51,7 @@ spec:
         - --exempt-namespace={{ .Release.Namespace }}
         - --operation=webhook
         - --enable-mutation={{ .Values.experimentalEnableMutation}}
+        - --enable-external-data={{ .Values.enableExternalData }}
         
         {{- range .Values.disabledBuiltins}}
         - --disable-opa-builtin={{ . }}

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -8,6 +8,7 @@ validatingWebhookTimeoutSeconds: 3
 validatingWebhookFailurePolicy: Ignore
 validatingWebhookCheckIgnoreFailurePolicy: Fail
 enableDeleteOperations: false
+enableExternalData: false
 experimentalEnableMutation: false
 mutatingWebhookFailurePolicy: Ignore
 mutatingWebhookTimeoutSeconds: 3


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: