### PR TITLE
bump node version to 16

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2.4.1
         with:
-          node-version: "12.x"
+          node-version: "16"
 
       - name: Get yarn cache
         id: yarn-cache


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:

docusaurus requires node >= 14 now, bumping to node 16 (active LTS).

`error @docusaurus/core@2.0.0-beta.9: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.7"`


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

**Special notes for your reviewer**: