### PR TITLE
Allow mutation to run as a standalone pod

### DIFF
--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -494,7 +494,7 @@ func getViolationRef(gkNamespace, rkind, rname, rnamespace, ckind, cname, cnames
 }
 
 func AppendValidationWebhookIfEnabled(webhooks []rotator.WebhookInfo) []rotator.WebhookInfo {
-	if operations.IsAssigned(operations.MutationWebhook) {
+	if operations.IsAssigned(operations.Webhook) {
 		return append(webhooks, rotator.WebhookInfo{
 			Name: VwhName,
 			Type: rotator.Validating,


### PR DESCRIPTION
We missed some switching code in main.go
that turns webhooks on/off when a webhook is
enabled. As-written, webhooks are only enabled
if the validating webhook is enabled, this fixes that.

Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
