### PR TITLE
Use IsUnrecognizedConstraintError

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
 	github.com/open-policy-agent/cert-controller v0.2.0
-	github.com/open-policy-agent/frameworks/constraint v0.0.0-20211025234246-f478d8a555b5
+	github.com/open-policy-agent/frameworks/constraint v0.0.0-20211123155909-217139c4a6bd
 	github.com/open-policy-agent/opa v0.29.4
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -609,6 +609,8 @@ github.com/open-policy-agent/cert-controller v0.2.0 h1:Z+IPOYDor28l6cjEo2WvTZY6B
 github.com/open-policy-agent/cert-controller v0.2.0/go.mod h1:SWS7Ame8oKHF11cDsQCFlULrrOMV5Z59FIGEAF/M6YI=
 github.com/open-policy-agent/frameworks/constraint v0.0.0-20211025234246-f478d8a555b5 h1:v5CdVF+Gk0OGPZM+6g0CKjaUWjehnf5e/sezx1Qp7vw=
 github.com/open-policy-agent/frameworks/constraint v0.0.0-20211025234246-f478d8a555b5/go.mod h1:sxECOn2E9o4DIK6ttinq1frfiErxi0Z8oIgtz7VDVBc=
+github.com/open-policy-agent/frameworks/constraint v0.0.0-20211123155909-217139c4a6bd h1:x46e4lltbwfLNPb4hbV8J1G6ePPJVc5fgvnCmg6CrKk=
+github.com/open-policy-agent/frameworks/constraint v0.0.0-20211123155909-217139c4a6bd/go.mod h1:+bl0qvti36VO3K7FO8nSxhKVrAbBVAWuvGEMTDSSH+k=
 github.com/open-policy-agent/opa v0.29.4 h1:rNa/Gd3Fs0xWgL0aZoyblRwCZLJsSLDQOhnck6DWpaA=
 github.com/open-policy-agent/opa v0.29.4/go.mod h1:ZCOTD3yyFR8JvF8ETdWdiSPn9WcF1dXeQWOv7VoPorU=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=

--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -307,7 +307,7 @@ func (r *ReconcileConstraint) Reconcile(ctx context.Context, request reconcile.R
 	} else {
 		r.log.Info("handling constraint delete", "instance", instance)
 		if _, err := r.opa.RemoveConstraint(ctx, instance); err != nil {
-			if _, ok := err.(*opa.UnrecognizedConstraintError); !ok {
+			if opa.IsUnrecognizedConstraintError(err) {
 				return reconcile.Result{}, err
 			}
 		}

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local/errors.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local/errors.go
@@ -1,0 +1,15 @@
+package local
+
+import "errors"
+
+var (
+	ErrModuleName   = errors.New("invalid module name")
+	ErrParse        = errors.New("unable to parse module")
+	ErrCompile      = errors.New("unable to compile modules")
+	ErrModulePrefix = errors.New("invalid module prefix")
+	ErrPathInvalid  = errors.New("invalid data path")
+	ErrPathConflict = errors.New("conflicting path")
+	ErrWrite        = errors.New("error writing data")
+	ErrRead         = errors.New("error reading data")
+	ErrTransaction  = errors.New("error committing data")
+)

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local/local.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local/local.go
@@ -18,9 +18,9 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
-	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/topdown"
 	opatypes "github.com/open-policy-agent/opa/types"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -38,66 +38,23 @@ type insertParam map[string]*module
 func (i insertParam) add(name string, src string) error {
 	m, err := ast.ParseModule(name, src)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %q: %v", ErrParse, name, err)
 	}
+
 	i[name] = &module{text: src, parsed: m}
 	return nil
 }
 
-type Arg func(*driver)
-
-func Tracing(enabled bool) Arg {
-	return func(d *driver) {
-		d.traceEnabled = enabled
-	}
-}
-
-func DisableBuiltins(builtins ...string) Arg {
-	return func(d *driver) {
-		if d.capabilities == nil {
-			d.capabilities = ast.CapabilitiesForThisVersion()
-		}
-		disableBuiltins := make(map[string]bool)
-		for _, b := range builtins {
-			disableBuiltins[b] = true
-		}
-		var nb []*ast.Builtin
-		builtins := d.capabilities.Builtins
-		for i, b := range builtins {
-			if !disableBuiltins[b.Name] {
-				nb = append(nb, builtins[i])
-			}
-		}
-		d.capabilities.Builtins = nb
-	}
-}
-
-func AddExternalDataProviderCache(providerCache *externaldata.ProviderCache) Arg {
-	return func(d *driver) {
-		d.providerCache = providerCache
-	}
-}
-
 func New(args ...Arg) drivers.Driver {
-	d := &driver{
-		compiler:     ast.NewCompiler(),
-		modules:      make(map[string]*ast.Module),
-		storage:      inmem.New(),
-		capabilities: ast.CapabilitiesForThisVersion(),
-	}
+	d := &driver{}
 	for _, arg := range args {
 		arg(d)
 	}
 
-	// adding externaldata builtin otherwise capabilities get overridden
-	// if a capability, like http.send, is disabled
-	if d.providerCache != nil {
-		d.capabilities.Builtins = append(d.capabilities.Builtins, &ast.Builtin{
-			Name: "external_data",
-			Decl: opatypes.NewFunction(opatypes.Args(opatypes.A), opatypes.A),
-		})
-	}
+	Defaults()(d)
+
 	d.compiler.WithCapabilities(d.capabilities)
+
 	return d
 }
 
@@ -169,12 +126,9 @@ func (d *driver) Init(ctx context.Context) error {
 	return nil
 }
 
-func copyModules(modules map[string]*ast.Module, filter string) map[string]*ast.Module {
+func copyModules(modules map[string]*ast.Module) map[string]*ast.Module {
 	m := make(map[string]*ast.Module, len(modules))
 	for k, v := range modules {
-		if filter != "" && k == filter {
-			continue
-		}
 		m[k] = v
 	}
 	return m
@@ -182,38 +136,51 @@ func copyModules(modules map[string]*ast.Module, filter string) map[string]*ast.
 
 func (d *driver) checkModuleName(name string) error {
 	if name == "" {
-		return fmt.Errorf("module name cannot be empty")
+		return fmt.Errorf("%w: module %q has no name",
+			ErrModuleName, name)
 	}
+
 	if strings.HasPrefix(name, moduleSetPrefix) {
-		return fmt.Errorf("single modules not allowed to use name prefix %q", moduleSetPrefix)
+		return fmt.Errorf("%w: module %q has forbidden prefix %q",
+			ErrModuleName, name, moduleSetPrefix)
 	}
+
 	return nil
 }
 
 func (d *driver) checkModuleSetName(name string) error {
 	if name == "" {
-		return fmt.Errorf("modules name prefix cannot be empty")
+		return fmt.Errorf("%w: modules name prefix cannot be empty", ErrModulePrefix)
 	}
+
 	if strings.Contains(name, moduleSetSep) {
-		return fmt.Errorf("modules name prefix not allowed to contain the sequence n%s", moduleSetSep)
+		return fmt.Errorf("%w: modules name prefix not allowed to contain the sequence %q", ErrModulePrefix, moduleSetSep)
 	}
+
 	return nil
 }
 
-func (d *driver) moduleSetPrefix(namePrefix string) string {
-	return fmt.Sprintf("%s%s%s", moduleSetPrefix, namePrefix, moduleSetSep)
+func toModuleSetPrefix(prefix string) string {
+	return fmt.Sprintf("%s%s%s", moduleSetPrefix, prefix, moduleSetSep)
+}
+
+func toModuleSetName(prefix string, idx int) string {
+	return fmt.Sprintf("%s%d", toModuleSetPrefix(prefix), idx)
 }
 
 func (d *driver) PutModule(ctx context.Context, name string, src string) error {
 	if err := d.checkModuleName(name); err != nil {
 		return err
 	}
+
 	insert := insertParam{}
 	if err := insert.add(name, src); err != nil {
 		return err
 	}
+
 	d.modulesMux.Lock()
 	defer d.modulesMux.Unlock()
+
 	_, err := d.alterModules(ctx, insert, nil)
 	return err
 }
@@ -224,10 +191,10 @@ func (d *driver) PutModules(ctx context.Context, namePrefix string, srcs []strin
 		return err
 	}
 
-	prefix := d.moduleSetPrefix(namePrefix)
 	insert := insertParam{}
+
 	for idx, src := range srcs {
-		name := fmt.Sprintf("%s%d", prefix, idx)
+		name := toModuleSetName(namePrefix, idx)
 		if err := insert.add(name, src); err != nil {
 			return err
 		}
@@ -235,28 +202,34 @@ func (d *driver) PutModules(ctx context.Context, namePrefix string, srcs []strin
 
 	d.modulesMux.Lock()
 	defer d.modulesMux.Unlock()
+
 	var remove []string
 	for _, name := range d.listModuleSet(namePrefix) {
 		if _, found := insert[name]; !found {
 			remove = append(remove, name)
 		}
 	}
+
 	_, err := d.alterModules(ctx, insert, remove)
 	return err
 }
 
-// DeleteModule deletes a rule from OPA and returns true if a rule was found and deleted, false
+// DeleteModule deletes a rule from OPA. Returns true if a rule was found and deleted, false
 // if a rule was not found, and any errors.
 func (d *driver) DeleteModule(ctx context.Context, name string) (bool, error) {
 	if err := d.checkModuleName(name); err != nil {
 		return false, err
 	}
+
 	d.modulesMux.Lock()
 	defer d.modulesMux.Unlock()
+
 	if _, found := d.modules[name]; !found {
 		return false, nil
 	}
+
 	count, err := d.alterModules(ctx, nil, []string{name})
+
 	return count == 1, err
 }
 
@@ -264,10 +237,11 @@ func (d *driver) DeleteModule(ctx context.Context, name string) (bool, error) {
 // the provided modules then returns the count of modules removed.
 // alterModules expects that the caller is holding the modulesMux lock.
 func (d *driver) alterModules(ctx context.Context, insert insertParam, remove []string) (int, error) {
-	updatedModules := copyModules(d.modules, "")
+	updatedModules := copyModules(d.modules)
 	for _, name := range remove {
 		delete(updatedModules, name)
 	}
+
 	for name, mod := range insert {
 		updatedModules[name] = mod.parsed
 	}
@@ -286,9 +260,10 @@ func (d *driver) alterModules(ctx context.Context, insert insertParam, remove []
 
 	c := ast.NewCompiler().WithPathConflictsCheck(storage.NonEmpty(ctx, d.storage, txn)).
 		WithCapabilities(d.capabilities)
+
 	if c.Compile(updatedModules); c.Failed() {
 		d.storage.Abort(ctx, txn)
-		return 0, c.Errors
+		return 0, fmt.Errorf("%w: %v", ErrCompile, c.Errors)
 	}
 
 	for name, mod := range insert {
@@ -297,11 +272,14 @@ func (d *driver) alterModules(ctx context.Context, insert insertParam, remove []
 			return 0, err
 		}
 	}
+
 	if err := d.storage.Commit(ctx, txn); err != nil {
 		return 0, err
 	}
+
 	d.compiler = c
 	d.modules = updatedModules
+
 	return len(remove), nil
 }
 
@@ -313,61 +291,80 @@ func (d *driver) DeleteModules(ctx context.Context, namePrefix string) (int, err
 
 	d.modulesMux.Lock()
 	defer d.modulesMux.Unlock()
+
 	return d.alterModules(ctx, nil, d.listModuleSet(namePrefix))
 }
 
 // listModuleSet returns the list of names corresponding to a given module
 // prefix.
 func (d *driver) listModuleSet(namePrefix string) []string {
-	prefix := d.moduleSetPrefix(namePrefix)
+	prefix := toModuleSetPrefix(namePrefix)
+
 	var names []string
 	for name := range d.modules {
 		if strings.HasPrefix(name, prefix) {
 			names = append(names, name)
 		}
 	}
+
 	return names
 }
 
 func parsePath(path string) ([]string, error) {
 	p, ok := storage.ParsePathEscaped(path)
 	if !ok {
-		return nil, fmt.Errorf("bad data path: %q", path)
+		return nil, fmt.Errorf("%w: path must begin with '/': %q", ErrPathInvalid, path)
 	}
+	if len(p) == 0 {
+		return nil, fmt.Errorf("%w: path must contain at least one path element: %q", ErrPathInvalid, path)
+	}
+
 	return p, nil
 }
 
 func (d *driver) PutData(ctx context.Context, path string, data interface{}) error {
 	d.modulesMux.RLock()
 	defer d.modulesMux.RUnlock()
+
 	p, err := parsePath(path)
 	if err != nil {
 		return err
 	}
+
 	txn, err := d.storage.NewTransaction(ctx, storage.WriteParams)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %v", ErrTransaction, err)
 	}
-	if _, err := d.storage.Read(ctx, txn, p); err != nil {
+
+	if _, err = d.storage.Read(ctx, txn, p); err != nil {
 		if storage.IsNotFound(err) {
-			if err := storage.MakeDir(ctx, d.storage, txn, p[:len(p)-1]); err != nil {
-				return err
+			if err = storage.MakeDir(ctx, d.storage, txn, p[:len(p)-1]); err != nil {
+				return fmt.Errorf("%w: unable to make directory: %v", ErrWrite, err)
 			}
 		} else {
 			d.storage.Abort(ctx, txn)
-			return err
+			return fmt.Errorf("%w: %v", ErrRead, err)
 		}
 	}
-	if err := d.storage.Write(ctx, txn, storage.AddOp, p, data); err != nil {
+
+	if err = d.storage.Write(ctx, txn, storage.AddOp, p, data); err != nil {
 		d.storage.Abort(ctx, txn)
-		return err
-	}
-	if err := ast.CheckPathConflicts(d.compiler, storage.NonEmpty(ctx, d.storage, txn)); len(err) > 0 {
-		d.storage.Abort(ctx, txn)
-		return err
+		return fmt.Errorf("%w: unable to write data: %v", ErrWrite, err)
 	}
 
-	return d.storage.Commit(ctx, txn)
+	// TODO: Determine if this can be removed. No tests exercise this path, and
+	//  as far as I can tell storage.MakeDir fails where this might return an error.
+	if errs := ast.CheckPathConflicts(d.compiler, storage.NonEmpty(ctx, d.storage, txn)); len(errs) > 0 {
+		d.storage.Abort(ctx, txn)
+		return fmt.Errorf("%w: %q conflicts with existing path: %v",
+			ErrPathConflict, path, errs)
+	}
+
+	err = d.storage.Commit(ctx, txn)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrTransaction, err)
+	}
+	return nil
 }
 
 // DeleteData deletes data from OPA and returns true if data was found and deleted, false
@@ -375,50 +372,59 @@ func (d *driver) PutData(ctx context.Context, path string, data interface{}) err
 func (d *driver) DeleteData(ctx context.Context, path string) (bool, error) {
 	d.modulesMux.RLock()
 	defer d.modulesMux.RUnlock()
+
 	p, err := parsePath(path)
 	if err != nil {
 		return false, err
 	}
+
 	txn, err := d.storage.NewTransaction(ctx, storage.WriteParams)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("%w: %v", ErrTransaction, err)
 	}
-	if err := d.storage.Write(ctx, txn, storage.RemoveOp, p, interface{}(nil)); err != nil {
+
+	if err = d.storage.Write(ctx, txn, storage.RemoveOp, p, interface{}(nil)); err != nil {
 		d.storage.Abort(ctx, txn)
 		if storage.IsNotFound(err) {
 			return false, nil
 		}
-		return false, err
+		return false, fmt.Errorf("%w: unable to write data: %v", ErrWrite, err)
 	}
-	if err := d.storage.Commit(ctx, txn); err != nil {
-		return false, err
+
+	if err = d.storage.Commit(ctx, txn); err != nil {
+		return false, fmt.Errorf("%w: %v", ErrTransaction, err)
 	}
+
 	return true, nil
 }
 
 func (d *driver) eval(ctx context.Context, path string, input interface{}, cfg *drivers.QueryCfg) (rego.ResultSet, *string, error) {
 	d.modulesMux.RLock()
 	defer d.modulesMux.RUnlock()
+
 	args := []func(*rego.Rego){
 		rego.Compiler(d.compiler),
 		rego.Store(d.storage),
 		rego.Input(input),
 		rego.Query(path),
 	}
+
+	buf := topdown.NewBufferTracer()
 	if d.traceEnabled || cfg.TracingEnabled {
-		buf := topdown.NewBufferTracer()
 		args = append(args, rego.QueryTracer(buf))
-		r := rego.New(args...)
-		res, err := r.Eval(ctx)
-		b := &bytes.Buffer{}
-		topdown.PrettyTrace(b, *buf)
-		t := b.String()
-		return res, &t, err
 	}
 
 	r := rego.New(args...)
 	res, err := r.Eval(ctx)
-	return res, nil, err
+
+	var t *string
+	if d.traceEnabled || cfg.TracingEnabled {
+		b := &bytes.Buffer{}
+		topdown.PrettyTrace(b, *buf)
+		t = pointer.StringPtr(b.String())
+	}
+
+	return res, t, err
 }
 
 func (d *driver) Query(ctx context.Context, path string, input interface{}, opts ...drivers.QueryOpt) (*types.Response, error) {
@@ -426,16 +432,15 @@ func (d *driver) Query(ctx context.Context, path string, input interface{}, opts
 	for _, opt := range opts {
 		opt(cfg)
 	}
-	inp, err := json.MarshalIndent(input, "", "   ")
-	if err != nil {
-		return nil, err
-	}
-	// Add a variable binding to the path
+
+	// Add a variable binding to the path.
 	path = fmt.Sprintf("data.%s[result]", path)
+
 	rs, trace, err := d.eval(ctx, path, input, cfg)
 	if err != nil {
 		return nil, err
 	}
+
 	var results []*types.Result
 	for _, r := range rs {
 		result := &types.Result{}
@@ -448,45 +453,58 @@ func (d *driver) Query(ctx context.Context, path string, input interface{}, opts
 		}
 		results = append(results, result)
 	}
-	i := string(inp)
+
+	inp, err := json.MarshalIndent(input, "", "   ")
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.Response{
 		Trace:   trace,
 		Results: results,
-		Input:   &i,
+		Input:   pointer.StringPtr(string(inp)),
 	}, nil
 }
 
 func (d *driver) Dump(ctx context.Context) (string, error) {
 	d.modulesMux.RLock()
 	defer d.modulesMux.RUnlock()
+
 	mods := make(map[string]string, len(d.modules))
 	for k, v := range d.modules {
 		mods[k] = v.String()
 	}
+
 	data, _, err := d.eval(ctx, "data", nil, &drivers.QueryCfg{})
 	if err != nil {
 		return "", err
 	}
+
 	var dt interface{}
 	// There should be only 1 or 0 expression values
 	if len(data) > 1 {
 		return "", errors.New("too many dump results")
 	}
+
 	for _, da := range data {
 		if len(data) > 1 {
 			return "", errors.New("too many expressions results")
 		}
+
 		for _, e := range da.Expressions {
 			dt = e.Value
 		}
 	}
+
 	resp := map[string]interface{}{
 		"modules": mods,
 		"data":    dt,
 	}
+
 	b, err := json.MarshalIndent(resp, "", "   ")
 	if err != nil {
 		return "", err
 	}
+
 	return string(b), nil
 }

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/errors.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/errors.go
@@ -38,6 +38,11 @@ func (e *UnrecognizedConstraintError) Error() string {
 	return fmt.Sprintf("Constraint kind %s is not recognized", e.s)
 }
 
+func IsUnrecognizedConstraintError(e error) bool {
+	_, ok := e.(*UnrecognizedConstraintError)
+	return ok
+}
+
 func NewUnrecognizedConstraintError(text string) error {
 	return &UnrecognizedConstraintError{text}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -159,7 +159,7 @@ github.com/onsi/gomega/types
 # github.com/open-policy-agent/cert-controller v0.2.0
 ## explicit
 github.com/open-policy-agent/cert-controller/pkg/rotator
-# github.com/open-policy-agent/frameworks/constraint v0.0.0-20211025234246-f478d8a555b5
+# github.com/open-policy-agent/frameworks/constraint v0.0.0-20211123155909-217139c4a6bd
 ## explicit
 github.com/open-policy-agent/frameworks/constraint/deploy
 github.com/open-policy-agent/frameworks/constraint/pkg/apis


### PR DESCRIPTION
This is to decouple Gatekeeper from the error implementation in
frameworks. With this change, frameworks can swap out the implementation
without Gatekeeper caring. Gatekeeper doesn't use any of the fields of
this error type, so it shouldn't rely on the specific type.

Signed-off-by: Will Beason <willbeason@google.com>