### PR TITLE
Remove internal error handling coupling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/onsi/gomega v1.16.0
 	github.com/open-policy-agent/cert-controller v0.2.0
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20211123155909-217139c4a6bd
-	github.com/open-policy-agent/opa v0.29.4
+	github.com/open-policy-agent/opa v0.29.4 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.30.0 // indirect

--- a/pkg/controller/constrainttemplate/constants.go
+++ b/pkg/controller/constrainttemplate/constants.go
@@ -1,0 +1,4 @@
+package constrainttemplate
+
+// ErrCreateCode indicates a problem creating a ConstraintTemplate.
+const ErrCreateCode = "create_error"


### PR DESCRIPTION
Gatekeeper relies on frameworks adding no new information to errors
returned by OPA - directly testing that the error type returned by
client.CreateCRD is the type given by the underlying OPA library.

This coupling means the implementation of error handling in
frameworks breaks gatekeeper tests.

This PR removes the coupling, instead always using a generic
"create_error" for problems creating CRDs. While this means the error code in
the CreateCRDError type provided by frameworks/ will always be set to
"create_error" - rendering it unhelpful - it would be better for
frameworks/ to provide an API for this as then such logic would not be
split across two repositories.

Fortunately the only behavior that changes because of this PR is the code
shown in the CreateCRDError, which doesn't appear to be consumed by
other code.

If we want to maintain this behavior, I can re-introduce it in the go113
errors PR (which is out for review in frameworks/), and then send a PR
to update the frameworks/ version used by gatekeeper/. (This would be a
trivial addition to that PR)

Also, this PR exit early in the "invalidrego" reconcile test to reduce
nesting.

Signed-off-by: Will Beason <willbeason@google.com>