### PR TITLE
Update golangci-lint to v1.43.0

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -42,7 +42,7 @@ jobs:
       uses: golangci/golangci-lint-action@v2
       with:
         # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.42.1
+        version: v1.43.0
 
   test:
     name: "Unit test"

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ GATEKEEPER_NAMESPACE ?= gatekeeper-system
 
 # When updating this, make sure to update the corresponding action in
 # workflow.yaml
-GOLANGCI_LINT_VERSION := v1.42.1
+GOLANGCI_LINT_VERSION := v1.43.0
 
 # Detects the location of the user golangci-lint cache.
 GOLANGCI_LINT_CACHE := $(shell pwd)/.tmp/golangci-lint

--- a/pkg/audit/stats_reporter_test.go
+++ b/pkg/audit/stats_reporter_test.go
@@ -38,22 +38,23 @@ func TestReportTotalViolations(t *testing.T) {
 }
 
 func TestReportLatency(t *testing.T) {
-	const expectedLatencyValueMin = time.Duration(100 * time.Second)
-	const expectedLatencyValueMax = time.Duration(500 * time.Second)
+	const minLatency = time.Duration(100 * time.Second)
+	const maxLatency = time.Duration(500 * time.Second)
+
 	const expectedLatencyCount int64 = 2
 	const expectedLatencyMin float64 = 100
 	const expectedLatencyMax float64 = 500
-	const expectedRowLength = 1
+	const expectedRowLength int = 1
 
 	r, err := newStatsReporter()
 	if err != nil {
 		t.Errorf("newStatsReporter() error %v", err)
 	}
-	err = r.reportLatency(expectedLatencyValueMin)
+	err = r.reportLatency(minLatency)
 	if err != nil {
 		t.Errorf("ReportLatency error %v", err)
 	}
-	err = r.reportLatency(expectedLatencyValueMax)
+	err = r.reportLatency(maxLatency)
 	if err != nil {
 		t.Errorf("ReportLatency error %v", err)
 	}

--- a/pkg/audit/stats_reporter_test.go
+++ b/pkg/audit/stats_reporter_test.go
@@ -8,108 +8,123 @@ import (
 )
 
 func TestReportTotalViolations(t *testing.T) {
-	const expectedValue int64 = 10
-	const expectedRowLength = 1
-	expectedTags := map[string]string{
+	const wantValue = 10
+	const wantRowLength = 1
+	wantTags := map[string]string{
 		"enforcement_action": "deny",
 	}
 
 	r, err := newStatsReporter()
 	if err != nil {
-		t.Errorf("newStatsReporter() error %v", err)
+		t.Fatalf("newStatsReporter() error %v", err)
 	}
-	err = r.reportTotalViolations("deny", expectedValue)
+
+	err = r.reportTotalViolations("deny", wantValue)
 	if err != nil {
-		t.Errorf("ReportTotalViolations error %v", err)
+		t.Fatalf("ReportTotalViolations error %v", err)
 	}
-	row := checkData(t, violationsMetricName, expectedRowLength)
-	value, ok := row.Data.(*view.LastValueData)
+
+	row := checkData(t, violationsMetricName, wantRowLength)
+	got, ok := row.Data.(*view.LastValueData)
 	if !ok {
 		t.Error("ReportTotalViolations should have aggregation LastValue()")
 	}
+
 	for _, tag := range row.Tags {
-		if tag.Value != expectedTags[tag.Key.Name()] {
+		if tag.Value != wantTags[tag.Key.Name()] {
 			t.Errorf("ReportTotalViolations tags does not match for %v", tag.Key.Name())
 		}
 	}
-	if int64(value.Value) != expectedValue {
-		t.Errorf("Metric: %v - Expected %v, got %v", violationsMetricName, value.Value, expectedValue)
+
+	if int64(got.Value) != wantValue {
+		t.Errorf("got %q = %v, want %v", violationsMetricName, got.Value, wantValue)
 	}
 }
 
 func TestReportLatency(t *testing.T) {
-	const minLatency = time.Duration(100 * time.Second)
-	const maxLatency = time.Duration(500 * time.Second)
+	const minLatency = 100 * time.Second
+	const maxLatency = 500 * time.Second
 
-	const expectedLatencyCount int64 = 2
-	const expectedLatencyMin float64 = 100
-	const expectedLatencyMax float64 = 500
-	const expectedRowLength int = 1
+	const wantLatencyCount int64 = 2
+	const wantLatencyMin float64 = 100
+	const wantLatencyMax float64 = 500
+	const wantRowLength int = 1
 
 	r, err := newStatsReporter()
 	if err != nil {
-		t.Errorf("newStatsReporter() error %v", err)
+		t.Fatalf("got newStatsReporter() error %v", err)
 	}
+
 	err = r.reportLatency(minLatency)
 	if err != nil {
-		t.Errorf("ReportLatency error %v", err)
+		t.Fatalf("got reportLatency error %v", err)
 	}
+
 	err = r.reportLatency(maxLatency)
 	if err != nil {
-		t.Errorf("ReportLatency error %v", err)
+		t.Fatalf("got reportLatency error %v", err)
 	}
-	row := checkData(t, auditDurationMetricName, expectedRowLength)
-	latencyValue, ok := row.Data.(*view.DistributionData)
+
+	row := checkData(t, auditDurationMetricName, wantRowLength)
+	gotLatency, ok := row.Data.(*view.DistributionData)
 	if !ok {
-		t.Error("ReportLatency should have aggregation type Distribution")
+		t.Fatalf("got reportLatency() type %T, want %T", row.Data, &view.DistributionData{})
 	}
-	if latencyValue.Count != expectedLatencyCount {
-		t.Errorf("Metric: %v - Expected %v, got %v", auditDurationMetricName, latencyValue.Count, expectedLatencyCount)
+
+	if gotLatency.Count != wantLatencyCount {
+		t.Errorf("got %q = %v, want %v", auditDurationMetricName, gotLatency.Count, wantLatencyCount)
 	}
-	if latencyValue.Min != expectedLatencyMin {
-		t.Errorf("Metric: %v - Expected %v, got %v", auditDurationMetricName, latencyValue.Min, expectedLatencyMin)
+
+	if gotLatency.Min != wantLatencyMin {
+		t.Errorf("got %q = %v, want %v", auditDurationMetricName, gotLatency.Min, wantLatencyMin)
 	}
-	if latencyValue.Max != expectedLatencyMax {
-		t.Errorf("Metric: %v - Expected %v, got %v", auditDurationMetricName, latencyValue.Max, expectedLatencyMax)
+
+	if gotLatency.Max != wantLatencyMax {
+		t.Errorf("got %q = %v, want %v", auditDurationMetricName, gotLatency.Max, wantLatencyMax)
 	}
 }
 
-func checkData(t *testing.T, name string, expectedRowLength int) *view.Row {
+func checkData(t *testing.T, name string, wantRowLength int) *view.Row {
 	row, err := view.RetrieveData(name)
 	if err != nil {
-		t.Errorf("Error when retrieving data: %v from %v", err, name)
+		t.Fatalf("got RetrieveData error: %v from %v", err, name)
 	}
-	if len(row) != expectedRowLength {
-		t.Errorf("Expected length %v, got %v", expectedRowLength, len(row))
+
+	if len(row) != wantRowLength {
+		t.Fatalf("got row length %v, want %v", len(row), wantRowLength)
 	}
+
 	if row[0].Data == nil {
-		t.Errorf("Expected row data not to be nil")
+		t.Fatalf("got row[0].Data = nil, want non-nil: %+v", row)
 	}
 	return row[0]
 }
 
 func TestLastRestartCheck(t *testing.T) {
-	expectedTime := time.Now()
-	expectedTs := float64(expectedTime.UnixNano()) / 1e9
-	const expectedRowLength = 1
+	wantTime := time.Now()
+	wantTs := float64(wantTime.UnixNano()) / 1e9
+	const wantRowLength = 1
 
 	r, err := newStatsReporter()
 	if err != nil {
-		t.Errorf("newStatsReporter() error %v", err)
+		t.Fatalf("got newStatsReporter() error %v", err)
 	}
-	err = r.reportRunStart(expectedTime)
+
+	err = r.reportRunStart(wantTime)
 	if err != nil {
-		t.Errorf("reportRunStart error %v", err)
+		t.Fatalf("reportRunStart error %v", err)
 	}
-	row := checkData(t, lastRunTimeMetricName, expectedRowLength)
-	value, ok := row.Data.(*view.LastValueData)
+	row := checkData(t, lastRunTimeMetricName, wantRowLength)
+	got, ok := row.Data.(*view.LastValueData)
 	if !ok {
 		t.Error("lastRunTimeMetricName should have aggregation LastValue()")
 	}
+
 	if len(row.Tags) != 0 {
-		t.Errorf("lastRunTimeMetricName tags is non-empty, got: %v", row.Tags)
+		t.Errorf("got %q tags %v, want empty", lastRunTimeMetricName, row.Tags)
 	}
-	if value.Value != expectedTs {
-		t.Errorf("Metric: %v - Expected %v, got %v", lastRunTimeMetricName, expectedTs, value.Value)
+
+	if got.Value != wantTs {
+		t.Errorf("got %q = %v, want %v", lastRunTimeMetricName, got.Value, wantTs)
 	}
 }

--- a/pkg/controller/constraint/stats_reporter_test.go
+++ b/pkg/controller/constraint/stats_reporter_test.go
@@ -42,13 +42,15 @@ func TestReportConstraints(t *testing.T) {
 func checkData(t *testing.T, name string, expectedRowLength int) *view.Row {
 	row, err := view.RetrieveData(name)
 	if err != nil {
-		t.Errorf("Error when retrieving data: %v from %v", err, name)
+		t.Fatalf("got RetrieveData(%q) error %v, want nil", name, err)
 	}
+
 	if len(row) != expectedRowLength {
-		t.Errorf("Expected length %v, got %v", expectedRowLength, len(row))
+		t.Fatalf("got row length %v, want %v", len(row), expectedRowLength)
 	}
+
 	if row[0].Data == nil {
-		t.Errorf("Expected row data not to be nil")
+		t.Fatalf("got row[0].Data = nil, want non-nil")
 	}
 	return row[0]
 }

--- a/pkg/controller/constrainttemplate/stats_reporter_test.go
+++ b/pkg/controller/constrainttemplate/stats_reporter_test.go
@@ -11,71 +11,82 @@ import (
 
 func TestReportIngestion(t *testing.T) {
 	if err := reset(); err != nil {
-		t.Errorf("Could not reset stats: %v", err)
+		t.Fatalf("Could not reset stats: %v", err)
 	}
-	expectedTags := map[string]string{
+	wantTags := map[string]string{
 		"status": "active",
 	}
 
 	const (
-		minIngestDuration = time.Duration(1 * time.Second)
-		maxIngestDuration = time.Duration(5 * time.Second)
+		minIngestDuration = 1 * time.Second
+		maxIngestDuration = 5 * time.Second
 
-		wantMinIngestDurationSeconds float64 = 1
-		wantMaxIngestDurationSeconds float64 = 5
+		wantMinIngestDurationSeconds = 1.0
+		wantMaxIngestDurationSeconds = 5.0
 
-		expectedCount     int64 = 2
-		expectedRowLength int   = 1
+		wantCount     = 2
+		wantRowLength = 1
 	)
 
 	r := newStatsReporter()
 	ctx := context.Background()
 	err := r.reportIngestDuration(ctx, metrics.ActiveStatus, minIngestDuration)
 	if err != nil {
-		t.Errorf("reportIngestDuration error %v", err)
+		t.Fatalf("got reportIngestDuration() error %v, want nil", err)
 	}
+
 	err = r.reportIngestDuration(ctx, metrics.ActiveStatus, maxIngestDuration)
 	if err != nil {
-		t.Errorf("reportIngestDuration error %v", err)
+		t.Fatalf("got reportIngestDuration() error %v, want nil", err)
 	}
 
 	// count test
-	row := checkData(t, ingestCount, expectedRowLength)
-	count, ok := row.Data.(*view.CountData)
+	row := checkData(t, ingestCount, wantRowLength)
+	gotCount, ok := row.Data.(*view.CountData)
 	if !ok {
-		t.Error("ingestCount should have aggregation Count()")
+		t.Fatalf("got %q type %T, want %T", ingestCount, row.Data, &view.CountData{})
 	}
+
 	for _, tag := range row.Tags {
-		if tag.Value != expectedTags[tag.Key.Name()] {
-			t.Errorf("ingestCount tags does not match for %v", tag.Key.Name())
+		name := tag.Key.Name()
+		wantValue := wantTags[name]
+		if tag.Value != wantValue {
+			t.Errorf("got ingestCount tag %q =  %q, want %q", name, tag.Value, wantValue)
 		}
 	}
-	if count.Value != expectedCount {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", ingestCount, expectedCount, count.Value)
+
+	if gotCount.Value != wantCount {
+		t.Errorf("got %q = %v, want %v", ingestCount, gotCount.Value, wantCount)
 	}
 
 	// Duration test
-	row = checkData(t, ingestDuration, expectedRowLength)
-	durationValue, ok := row.Data.(*view.DistributionData)
+	row = checkData(t, ingestDuration, wantRowLength)
+	gotDuration, ok := row.Data.(*view.DistributionData)
 	if !ok {
-		t.Error("ingestDuration should have aggregation Distribution()")
+		t.Fatalf("got %q type %T, want %T", ingestDuration, row.Data, &view.DistributionData{})
 	}
+
 	for _, tag := range row.Tags {
-		if tag.Value != expectedTags[tag.Key.Name()] {
-			t.Errorf("ingestDuration tags does not match for %v", tag.Key.Name())
+		name := tag.Key.Name()
+		wantValue := wantTags[name]
+		if tag.Value != wantValue {
+			t.Errorf("got tag %q = %q, want %q", name, tag.Value, wantValue)
 		}
 	}
-	if durationValue.Min != wantMinIngestDurationSeconds {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", ingestDuration, durationValue.Min, wantMinIngestDurationSeconds)
+
+	if gotDuration.Min != wantMinIngestDurationSeconds {
+		t.Errorf("got %q = %v, want %v", ingestDuration, gotDuration.Min, wantMinIngestDurationSeconds)
 	}
-	if durationValue.Max != wantMaxIngestDurationSeconds {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", ingestDuration, durationValue.Max, wantMaxIngestDurationSeconds)
+
+	if gotDuration.Max != wantMaxIngestDurationSeconds {
+		t.Errorf("got %q = %v, want %v", ingestDuration, gotDuration.Max, wantMaxIngestDurationSeconds)
 	}
 }
 
 func TestGauges(t *testing.T) {
 	r := newStatsReporter()
-	tc := []struct {
+
+	tcs := []struct {
 		name string
 		fn   func(context.Context, metrics.Status, int64) error
 	}{
@@ -84,50 +95,59 @@ func TestGauges(t *testing.T) {
 			fn:   r.reportCtMetric,
 		},
 	}
-	for _, tt := range tc {
-		t.Run(tt.name, func(t *testing.T) {
-			const expectedValue int64 = 10
-			const expectedRowLength = 1
-			expectedTags := map[string]string{
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			const wantValue = 10
+			const wantRowLength = 1
+			wantTags := map[string]string{
 				"status": "active",
 			}
 
 			ctx := context.Background()
-			err := tt.fn(ctx, metrics.ActiveStatus, expectedValue)
+			err := tc.fn(ctx, metrics.ActiveStatus, wantValue)
 			if err != nil {
-				t.Errorf("function error %v", err)
+				t.Fatalf("function error %v", err)
 			}
-			row := checkData(t, tt.name, expectedRowLength)
-			value, ok := row.Data.(*view.LastValueData)
+
+			row := checkData(t, tc.name, wantRowLength)
+			got, ok := row.Data.(*view.LastValueData)
 			if !ok {
-				t.Errorf("metric %s should have aggregation LastValue()", tt.name)
+				t.Fatalf("got metric %q type %T, want %T", wantRowLength, row.Data, &view.LastValueData{})
 			}
 
 			if len(row.Tags) != 1 {
-				t.Errorf("%s expected %v tags, got: %v", tt.name, len(expectedTags), len(row.Tags))
+				t.Errorf("got %v tags, want: %v", len(row.Tags), len(wantTags))
 			}
+
 			for _, tag := range row.Tags {
-				if tag.Value != expectedTags[tag.Key.Name()] {
-					t.Errorf("%v tags does not match for %v", tt.name, tag.Key.Name())
+				name := tag.Key.Name()
+				wantTagValue := wantTags[name]
+				if tag.Value != wantTagValue {
+					t.Errorf("got tag %q = %q, want %q", name, tag.Value, wantValue)
 				}
 			}
-			if int64(value.Value) != expectedValue {
-				t.Errorf("Metric: %v - Expected %v, got %v", tt.name, expectedValue, value.Value)
+
+			if int(got.Value) != wantValue {
+				t.Errorf("got %v = %v, want %v", tc.name, got.Value, wantValue)
 			}
 		})
 	}
 }
 
-func checkData(t *testing.T, name string, expectedRowLength int) *view.Row {
+func checkData(t *testing.T, name string, wantRowLength int) *view.Row {
 	row, err := view.RetrieveData(name)
 	if err != nil {
-		t.Errorf("Error when retrieving data: %v from %v", err, name)
+		t.Fatalf("Error when retrieving data: %v from %v", err, name)
 	}
-	if len(row) != expectedRowLength {
-		t.Errorf("Expected length %v, got %v", expectedRowLength, len(row))
+
+	if len(row) != wantRowLength {
+		t.Fatalf("got length %v, want %v", len(row), wantRowLength)
 	}
+
 	if row[0].Data == nil {
-		t.Errorf("Expected row data not to be nil")
+		t.Fatalf("got row[0].Data = nil, want non-nil")
 	}
+
 	return row[0]
 }

--- a/pkg/controller/constrainttemplate/stats_reporter_test.go
+++ b/pkg/controller/constrainttemplate/stats_reporter_test.go
@@ -16,20 +16,25 @@ func TestReportIngestion(t *testing.T) {
 	expectedTags := map[string]string{
 		"status": "active",
 	}
-	const expectedDurationValueMin = time.Duration(1 * time.Second)
-	const expectedDurationValueMax = time.Duration(5 * time.Second)
-	const expectedDurationMin float64 = 1
-	const expectedDurationMax float64 = 5
-	const expectedCount int64 = 2
-	const expectedRowLength = 1
+
+	const (
+		minIngestDuration = time.Duration(1 * time.Second)
+		maxIngestDuration = time.Duration(5 * time.Second)
+
+		wantMinIngestDurationSeconds float64 = 1
+		wantMaxIngestDurationSeconds float64 = 5
+
+		expectedCount     int64 = 2
+		expectedRowLength int   = 1
+	)
 
 	r := newStatsReporter()
 	ctx := context.Background()
-	err := r.reportIngestDuration(ctx, metrics.ActiveStatus, expectedDurationValueMin)
+	err := r.reportIngestDuration(ctx, metrics.ActiveStatus, minIngestDuration)
 	if err != nil {
 		t.Errorf("reportIngestDuration error %v", err)
 	}
-	err = r.reportIngestDuration(ctx, metrics.ActiveStatus, expectedDurationValueMax)
+	err = r.reportIngestDuration(ctx, metrics.ActiveStatus, maxIngestDuration)
 	if err != nil {
 		t.Errorf("reportIngestDuration error %v", err)
 	}
@@ -60,11 +65,11 @@ func TestReportIngestion(t *testing.T) {
 			t.Errorf("ingestDuration tags does not match for %v", tag.Key.Name())
 		}
 	}
-	if durationValue.Min != expectedDurationMin {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", ingestDuration, durationValue.Min, expectedDurationMin)
+	if durationValue.Min != wantMinIngestDurationSeconds {
+		t.Errorf("Metric: %v - Expected %v, got %v. ", ingestDuration, durationValue.Min, wantMinIngestDurationSeconds)
 	}
-	if durationValue.Max != expectedDurationMax {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", ingestDuration, durationValue.Max, expectedDurationMax)
+	if durationValue.Max != wantMaxIngestDurationSeconds {
+		t.Errorf("Metric: %v - Expected %v, got %v. ", ingestDuration, durationValue.Max, wantMaxIngestDurationSeconds)
 	}
 }
 

--- a/pkg/controller/mutators/stats_reporter_test.go
+++ b/pkg/controller/mutators/stats_reporter_test.go
@@ -15,19 +15,21 @@ func TestReportMutatorIngestionRequest(t *testing.T) {
 	}
 
 	const (
-		expectedDurationValueMin = time.Duration(1 * time.Second)
-		expectedDurationValueMax = time.Duration(5 * time.Second)
-		expectedDurationMin      = 1.0
-		expectedDurationMax      = 5.0
-		expectedRowLength        = 1
+		minIngestionDuration = time.Duration(1 * time.Second)
+		maxIngestionDuration = time.Duration(5 * time.Second)
+
+		wantMinIngestionDuration = 1.0
+		wantMaxIngestionDuration = 5.0
+
+		expectedRowLength = 1
 	)
 
 	r := NewStatsReporter()
-	err := r.ReportMutatorIngestionRequest(MutatorStatusActive, expectedDurationValueMin)
+	err := r.ReportMutatorIngestionRequest(MutatorStatusActive, minIngestionDuration)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
-	err = r.ReportMutatorIngestionRequest(MutatorStatusActive, expectedDurationValueMax)
+	err = r.ReportMutatorIngestionRequest(MutatorStatusActive, maxIngestionDuration)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
@@ -56,11 +58,11 @@ func TestReportMutatorIngestionRequest(t *testing.T) {
 	if !ok {
 		t.Error("ReportRequest should have aggregation Distribution()")
 	}
-	if durationValue.Min != expectedDurationMin {
-		t.Errorf("got tag '%v' min %v, want %v", mutatorIngestionDurationMetricName, durationValue.Min, expectedDurationMin)
+	if durationValue.Min != wantMinIngestionDuration {
+		t.Errorf("got tag '%v' min %v, want %v", mutatorIngestionDurationMetricName, durationValue.Min, wantMinIngestionDuration)
 	}
-	if durationValue.Max != expectedDurationMax {
-		t.Errorf("got tag '%v' max %v, want %v", mutatorIngestionDurationMetricName, durationValue.Max, expectedDurationMax)
+	if durationValue.Max != wantMaxIngestionDuration {
+		t.Errorf("got tag '%v' max %v, want %v", mutatorIngestionDurationMetricName, durationValue.Max, wantMaxIngestionDuration)
 	}
 
 	verifyTags(t, expectedTags, row.Tags)

--- a/pkg/controller/sync/stats_reporter_test.go
+++ b/pkg/controller/sync/stats_reporter_test.go
@@ -44,23 +44,24 @@ func TestReportSync(t *testing.T) {
 }
 
 func TestReportSyncLatency(t *testing.T) {
-	const expectedLatencyValueMin = time.Duration(100 * time.Second)
-	const expectedLatencyValueMax = time.Duration(500 * time.Second)
+	const minLatency = time.Duration(100 * time.Second)
+	const maxLatency = time.Duration(500 * time.Second)
+
 	const expectedLatencyCount int64 = 2
 	const expectedLatencyMin float64 = 100
 	const expectedLatencyMax float64 = 500
-	const expectedRowLength = 1
+	const expectedRowLength int = 1
 
 	r, err := NewStatsReporter()
 	if err != nil {
 		t.Errorf("newStatsReporter() error %v", err)
 	}
 
-	err = r.reportSyncDuration(expectedLatencyValueMin)
+	err = r.reportSyncDuration(minLatency)
 	if err != nil {
 		t.Errorf("ReportLatency error %v", err)
 	}
-	err = r.reportSyncDuration(expectedLatencyValueMax)
+	err = r.reportSyncDuration(maxLatency)
 	if err != nil {
 		t.Errorf("ReportLatency error %v", err)
 	}

--- a/pkg/operations/operrations_test.go
+++ b/pkg/operations/operrations_test.go
@@ -39,7 +39,7 @@ func Test_Flags(t *testing.T) {
 
 			err := flagSet.Parse(tc.input)
 			if err != nil {
-				t.Errorf("parsing: %w", err)
+				t.Errorf("parsing: %v", err)
 				return
 			}
 			if diff := cmp.Diff(tc.expected, ops.assignedOperations); diff != "" {

--- a/pkg/webhook/stats_reporter_test.go
+++ b/pkg/webhook/stats_reporter_test.go
@@ -9,107 +9,120 @@ import (
 )
 
 const (
-	minValidationDuration = time.Duration(1 * time.Second)
-	maxValidationDuration = time.Duration(5 * time.Second)
+	minValidationDuration = 1 * time.Second
+	maxValidationDuration = 5 * time.Second
 
 	wantMinValidationSeconds float64 = 1
 	wantMaxValidationSeconds float64 = 5
 
-	expectedCount     int64 = 2
-	expectedRowLength int   = 1
+	wantCount     int64 = 2
+	wantRowLength int   = 1
 )
 
 func TestValidationReportRequest(t *testing.T) {
-	expectedTags := map[string]string{
+	wantTags := map[string]string{
 		"admission_status": "allow",
 	}
 
 	ctx := context.Background()
 	r, err := newStatsReporter()
 	if err != nil {
-		t.Errorf("newStatsReporter() error %v", err)
+		t.Fatalf("got newStatsReporter() error %v, want nil", err)
 	}
+
 	err = r.ReportValidationRequest(ctx, allowResponse, minValidationDuration)
 	if err != nil {
-		t.Errorf("ReportRequest error %v", err)
+		t.Fatalf("got ReportValidationRequest() error = %v, want nil", err)
 	}
+
 	err = r.ReportValidationRequest(ctx, allowResponse, maxValidationDuration)
 	if err != nil {
-		t.Errorf("ReportRequest error %v", err)
+		t.Fatalf("got ReportValidationRequest() error = %v, want nil", err)
 	}
-	check(t, expectedTags, validationRequestCountMetricName, validationRequestDurationMetricName)
+
+	check(t, wantTags, validationRequestCountMetricName, validationRequestDurationMetricName)
 }
 
 func TestMutationReportRequest(t *testing.T) {
-	expectedTags := map[string]string{
+	wantTags := map[string]string{
 		"mutation_status": "success",
 	}
 
 	ctx := context.Background()
 	r, err := newStatsReporter()
 	if err != nil {
-		t.Errorf("newStatsReporter() error %v", err)
+		t.Fatalf("got newStatsReporter() error %v, want nil", err)
 	}
+
 	err = r.ReportMutationRequest(ctx, successResponse, minValidationDuration)
 	if err != nil {
-		t.Errorf("ReportRequest error %v", err)
+		t.Fatalf("got ReportMutationRequest error %v, want nil", err)
 	}
+
 	err = r.ReportMutationRequest(ctx, successResponse, maxValidationDuration)
 	if err != nil {
-		t.Errorf("ReportRequest error %v", err)
+		t.Fatalf("got ReportRequest error %v, want nil", err)
 	}
 
-	check(t, expectedTags, mutationRequestCountMetricName, mutationRequestDurationMetricName)
+	check(t, wantTags, mutationRequestCountMetricName, mutationRequestDurationMetricName)
 }
 
-func check(t *testing.T, expectedTags map[string]string, requestCountMetricName string, requestDurationMetricName string) {
+func check(t *testing.T, wantTags map[string]string, requestCountMetricName string, requestDurationMetricName string) {
 	// count test
-	row := checkData(t, requestCountMetricName, expectedRowLength)
+	row := checkData(t, requestCountMetricName, wantRowLength)
 
-	count, ok := row.Data.(*view.CountData)
+	gotCount, ok := row.Data.(*view.CountData)
 	if !ok {
-		t.Error("ReportRequest should have aggregation Count()")
+		t.Fatalf("got %q type %T, want %T", requestCountMetricName, row.Data, &view.CountData{})
 	}
-	for _, tag := range row.Tags {
-		if tag.Value != expectedTags[tag.Key.Name()] {
-			t.Errorf("ReportRequest tags does not match for %v", tag.Key.Name())
+	for _, gotTag := range row.Tags {
+		tagName := gotTag.Key.Name()
+		want := wantTags[tagName]
+		if gotTag.Value != want {
+			t.Errorf("got tag %q value %q, want %q", tagName, gotTag.Value, want)
 		}
 	}
-	if count.Value != expectedCount {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", requestCountMetricName, expectedCount, count.Value)
+
+	if gotCount.Value != wantCount {
+		t.Errorf("got %q = %v, want %v", requestCountMetricName, gotCount.Value, wantCount)
 	}
 
 	// Duration test
-	row = checkData(t, requestDurationMetricName, expectedRowLength)
-	durationValue, ok := row.Data.(*view.DistributionData)
+	row = checkData(t, requestDurationMetricName, wantRowLength)
+	gotDuration, ok := row.Data.(*view.DistributionData)
 	if !ok {
-		t.Error("ReportRequest should have aggregation Distribution()")
+		t.Fatalf("got %q type %T, want %T", requestDurationMetricName, row.Data, &view.DistributionData{})
 	}
-	for _, tag := range row.Tags {
-		if tag.Value != expectedTags[tag.Key.Name()] {
-			t.Errorf("ReportRequest tags does not match for %v", tag.Key.Name())
+
+	for _, gotTag := range row.Tags {
+		tagName := gotTag.Key.Name()
+		want := wantTags[tagName]
+		if gotTag.Value != want {
+			t.Errorf("got tag %q value %q, want %q", tagName, gotTag.Value, want)
 		}
 	}
 
-	if durationValue.Min != wantMinValidationSeconds {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", requestDurationMetricName, wantMinValidationSeconds, durationValue.Min)
+	if gotDuration.Min != wantMinValidationSeconds {
+		t.Errorf("got %q min = %v, want %v", requestDurationMetricName, gotDuration.Min, wantMinValidationSeconds)
 	}
 
-	if durationValue.Max != wantMaxValidationSeconds {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", requestDurationMetricName, wantMaxValidationSeconds, durationValue.Max)
+	if gotDuration.Max != wantMaxValidationSeconds {
+		t.Errorf("got %q max = %v, want %v", requestDurationMetricName, gotDuration.Max, wantMaxValidationSeconds)
 	}
 }
 
-func checkData(t *testing.T, name string, expectedRowLength int) *view.Row {
+func checkData(t *testing.T, name string, wantRowLength int) *view.Row {
 	row, err := view.RetrieveData(name)
 	if err != nil {
-		t.Errorf("Error when retrieving data: %v from %v", err, name)
+		t.Fatalf("got RetrieveData(%q) error %v, want nil", name, err)
 	}
-	if len(row) != expectedRowLength {
-		t.Errorf("Expected length %v, got %v", expectedRowLength, len(row))
+
+	if len(row) != wantRowLength {
+		t.Fatalf("got row length %v, want %v", len(row), wantRowLength)
 	}
+
 	if row[0].Data == nil {
-		t.Errorf("Expected row data not to be nil")
+		t.Fatalf("got row[0].Data = nil, want non-nil")
 	}
 	return row[0]
 }

--- a/pkg/webhook/stats_reporter_test.go
+++ b/pkg/webhook/stats_reporter_test.go
@@ -9,12 +9,14 @@ import (
 )
 
 const (
-	expectedDurationValueMin         = time.Duration(1 * time.Second)
-	expectedDurationValueMax         = time.Duration(5 * time.Second)
-	expectedDurationMin      float64 = 1
-	expectedDurationMax      float64 = 5
-	expectedCount            int64   = 2
-	expectedRowLength                = 1
+	minValidationDuration = time.Duration(1 * time.Second)
+	maxValidationDuration = time.Duration(5 * time.Second)
+
+	wantMinValidationSeconds float64 = 1
+	wantMaxValidationSeconds float64 = 5
+
+	expectedCount     int64 = 2
+	expectedRowLength int   = 1
 )
 
 func TestValidationReportRequest(t *testing.T) {
@@ -27,11 +29,11 @@ func TestValidationReportRequest(t *testing.T) {
 	if err != nil {
 		t.Errorf("newStatsReporter() error %v", err)
 	}
-	err = r.ReportValidationRequest(ctx, allowResponse, expectedDurationValueMin)
+	err = r.ReportValidationRequest(ctx, allowResponse, minValidationDuration)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
-	err = r.ReportValidationRequest(ctx, allowResponse, expectedDurationValueMax)
+	err = r.ReportValidationRequest(ctx, allowResponse, maxValidationDuration)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
@@ -48,11 +50,11 @@ func TestMutationReportRequest(t *testing.T) {
 	if err != nil {
 		t.Errorf("newStatsReporter() error %v", err)
 	}
-	err = r.ReportMutationRequest(ctx, successResponse, expectedDurationValueMin)
+	err = r.ReportMutationRequest(ctx, successResponse, minValidationDuration)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
-	err = r.ReportMutationRequest(ctx, successResponse, expectedDurationValueMax)
+	err = r.ReportMutationRequest(ctx, successResponse, maxValidationDuration)
 	if err != nil {
 		t.Errorf("ReportRequest error %v", err)
 	}
@@ -88,11 +90,13 @@ func check(t *testing.T, expectedTags map[string]string, requestCountMetricName 
 			t.Errorf("ReportRequest tags does not match for %v", tag.Key.Name())
 		}
 	}
-	if durationValue.Min != expectedDurationMin {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", requestDurationMetricName, expectedDurationMin, durationValue.Min)
+
+	if durationValue.Min != wantMinValidationSeconds {
+		t.Errorf("Metric: %v - Expected %v, got %v. ", requestDurationMetricName, wantMinValidationSeconds, durationValue.Min)
 	}
-	if durationValue.Max != expectedDurationMax {
-		t.Errorf("Metric: %v - Expected %v, got %v. ", requestDurationMetricName, expectedDurationMax, durationValue.Max)
+
+	if durationValue.Max != wantMaxValidationSeconds {
+		t.Errorf("Metric: %v - Expected %v, got %v. ", requestDurationMetricName, wantMaxValidationSeconds, durationValue.Max)
 	}
 }
 


### PR DESCRIPTION
The new golangci-lint is more strict about variable naming reqiurements.
It has false negatives on some of our duration variables, so I've
renamed them.

We _could_ suppress the linter in these cases, but it's easier to just
rename the variables.

The other fixes are making all variables in a block of declarations have
explicit types if one does. This seems reasonable since not everyone is
familiar with the convention (which is dependent on the type of
declaration).

Signed-off-by: Will Beason <willbeason@google.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
