### PR TITLE
website/externaldata: fix rego snippet

### DIFF
--- a/website/docs/externaldata.md
+++ b/website/docs/externaldata.md
@@ -96,10 +96,10 @@ External data adds a [custom OPA built-in function](https://www.openpolicyagent.
 e.g.,
 ```rego
   # build a list of keys containing images for batching
-  my-list := [img | img = input.review.object.spec.template.spec.containers[_].image]
+  my_list := [img | img = input.review.object.spec.template.spec.containers[_].image]
 
   # send external data request
-  response := external_data({"provider": "my-provider", "keys": my-list})
+  response := external_data({"provider": "my-provider", "keys": my_list})
 ```
 
 Response example: [[`"my-key"`, `"my-value"`, `""`], [`"another-key"`, `42`, `""`], [`"bad-key"`, `""`, `"error message"`]]

--- a/website/versioned_docs/version-v3.7.x/externaldata.md
+++ b/website/versioned_docs/version-v3.7.x/externaldata.md
@@ -96,10 +96,10 @@ External data adds a [custom OPA built-in function](https://www.openpolicyagent.
 e.g.,
 ```rego
   # build a list of keys containing images for batching
-  my-list := [img | img = input.review.object.spec.template.spec.containers[_].image]
+  my_list := [img | img = input.review.object.spec.template.spec.containers[_].image]
 
   # send external data request
-  response := external_data({"provider": "my-provider", "keys": my-list})
+  response := external_data({"provider": "my-provider", "keys": my_list})
 ```
 
 Response example: [[`"my-key"`, `"my-value"`, `""`], [`"another-key"`, `42`, `""`], [`"bad-key"`, `""`, `"error message"`]]


### PR DESCRIPTION
Dashes in variable names are not allowed. `my-list` would be parsed
as `my` minus `list`.
