### PR TITLE
Document ModifySet and assign.fromMetadata

### DIFF
--- a/website/docs/mutation.md
+++ b/website/docs/mutation.md
@@ -42,7 +42,7 @@ Each mutation CRD can be divided into 3 distinct sections:
 #### Extent of changes
 
 The extent of changes section describes which resources will be mutated.
-It allows selecting resources to be mutated using the same match critia
+It allows selecting resources to be mutated using the same match criteria
 as constraints.
 
 An example of the extent of changes section.
@@ -63,8 +63,8 @@ match:
 ```
 
 Note that the `applyTo` field is required for `Assign` and `ModifySet` mutators, and does not exist for `AssignMetadata` mutators.
-It allows Gatekeeper to understand the schema of the objects being modified, so that it can detect when two mutators disagree as
-to a kind's schema, which can cause non-convegent mutations. Also, the `applyTo` section does not accept globs.
+`applyTo` allows Gatekeeper to understand the schema of the objects being modified, so that it can detect when two mutators disagree as
+to a kind's schema, which can cause non-convergent mutations. Also, the `applyTo` section does not accept globs.
 
 The `match` section is common to all mutators. It supports the following match criteria:
 - scope - the scope (Namespaced | Cluster) of the mutated resource

--- a/website/versioned_docs/version-v3.7.x/mutation.md
+++ b/website/versioned_docs/version-v3.7.x/mutation.md
@@ -42,7 +42,7 @@ Each mutation CRD can be divided into 3 distinct sections:
 #### Extent of changes
 
 The extent of changes section describes which resources will be mutated.
-It allows selecting resources to be mutated using the same match critia
+It allows selecting resources to be mutated using the same match criteria
 as constraints.
 
 An example of the extent of changes section.
@@ -63,8 +63,8 @@ match:
 ```
 
 Note that the `applyTo` field is required for `Assign` and `ModifySet` mutators, and does not exist for `AssignMetadata` mutators.
-It allows Gatekeeper to understand the schema of the objects being modified, so that it can detect when two mutators disagree as
-to a kind's schema, which can cause non-convegent mutations. Also, the `applyTo` section does not accept globs.
+`applyTo` allows Gatekeeper to understand the schema of the objects being modified, so that it can detect when two mutators disagree as
+to a kind's schema, which can cause non-convergent mutations. Also, the `applyTo` section does not accept globs.
 
 The `match` section is common to all mutators. It supports the following match criteria:
 - scope - the scope (Namespaced | Cluster) of the mutated resource


### PR DESCRIPTION
Fixes #1702
Fixes #1700

Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
