### PR TITLE
update apiKey for website search

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -9,7 +9,8 @@ module.exports = {
   projectName: 'gatekeeper',
   themeConfig: {
     algolia: {
-      apiKey: '8fe2f10b6a869179c50b6f0c1bf015d9',
+      appId: 'PT2IX43ZFM',
+      apiKey: '9e442eec9ecd30ad131824f9738db98d',
       indexName: 'gatekeeper',
     },
     colorMode: {


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
Algolia is migrating to a new search platform, updating apikey.
This key is not a secret: https://docusaurus.io/docs/2.0.0-beta.8/search#connecting-algolia

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
