### PR TITLE
Print skipped tests in verbose mode

### DIFF
--- a/pkg/gktest/printer_go.go
+++ b/pkg/gktest/printer_go.go
@@ -71,6 +71,14 @@ func (p PrinterGo) PrintSuite(w StringWriter, r *SuiteResult, verbose bool) erro
 
 func (p PrinterGo) PrintTest(w StringWriter, r *TestResult, verbose bool) error {
 	if verbose {
+		if r.Skipped {
+			_, err := w.WriteString(fmt.Sprintf("=== SKIP  %s\n", r.Name))
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrWritingString, err)
+			}
+			return nil
+		}
+
 		_, err := w.WriteString(fmt.Sprintf("=== RUN   %s\n", r.Name))
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrWritingString, err)
@@ -106,6 +114,14 @@ func (p PrinterGo) PrintTest(w StringWriter, r *TestResult, verbose bool) error 
 
 func (p PrinterGo) PrintCase(w StringWriter, r *CaseResult, verbose bool) error {
 	if verbose {
+		if r.Skipped {
+			_, err := w.WriteString(fmt.Sprintf("    === SKIP  %s\n", r.Name))
+			if err != nil {
+				return fmt.Errorf("%w: %v", ErrWritingString, err)
+			}
+			return nil
+		}
+
 		_, err := w.WriteString(fmt.Sprintf("    === RUN   %s\n", r.Name))
 		if err != nil {
 			return fmt.Errorf("%w: %v", ErrWritingString, err)

--- a/pkg/gktest/printer_go_test.go
+++ b/pkg/gktest/printer_go_test.go
@@ -91,6 +91,52 @@ PASS
 `,
 		},
 		{
+			name: "skipped test",
+			result: []SuiteResult{{
+				Path: "tests.go",
+				TestResults: []TestResult{{
+					Name:    "forbid-labels",
+					Skipped: true,
+				}},
+			}},
+			want: `ok	tests.go	0.000s
+PASS
+`,
+			wantVerbose: `=== SKIP  forbid-labels
+ok	tests.go	0.000s
+PASS
+`,
+		},
+		{
+			name: "skipped case",
+			result: []SuiteResult{{
+				Path:    "tests.go",
+				Runtime: Duration(230 * time.Millisecond),
+				TestResults: []TestResult{{
+					Name:    "forbid-labels",
+					Runtime: Duration(230 * time.Millisecond),
+					CaseResults: []CaseResult{{
+						Name:    "forbid-labels/with label",
+						Skipped: true,
+					}, {
+						Name:    "forbid-labels/without label",
+						Runtime: Duration(230 * time.Millisecond),
+					}},
+				}},
+			}},
+			want: `ok	tests.go	0.230s
+PASS
+`,
+			wantVerbose: `=== RUN   forbid-labels
+    === SKIP  forbid-labels/with label
+    === RUN   forbid-labels/without label
+    --- PASS: forbid-labels/without label	(0.230s)
+--- PASS: forbid-labels	(0.230s)
+ok	tests.go	0.230s
+PASS
+`,
+		},
+		{
 			name: "constraint test failure",
 			result: []SuiteResult{{
 				Path:    "tests.go",


### PR DESCRIPTION
This keeps the test runner from confusingly printing that it "ran" tests when really it ignored them.

Fixes #1537

Signed-off-by: Will Beason <willbeason@google.com>