### PR TITLE
refactor: Rename 'gktest' to 'gator'

### DIFF
--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -10,7 +10,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/open-policy-agent/gatekeeper/pkg/gktest"
+	"github.com/open-policy-agent/gatekeeper/pkg/gator"
 	"github.com/spf13/cobra"
 )
 
@@ -89,11 +89,11 @@ func runE(cmd *cobra.Command, args []string) error {
 	}
 	targetPath = strings.Trim(targetPath, "/")
 
-	suites, err := gktest.ReadSuites(fileSystem, targetPath, recursive)
+	suites, err := gator.ReadSuites(fileSystem, targetPath, recursive)
 	if err != nil {
 		return fmt.Errorf("listing test files: %w", err)
 	}
-	filter, err := gktest.NewFilter(run)
+	filter, err := gator.NewFilter(run)
 	if err != nil {
 		return fmt.Errorf("compiling filter: %w", err)
 	}
@@ -101,15 +101,15 @@ func runE(cmd *cobra.Command, args []string) error {
 	return runSuites(cmd.Context(), fileSystem, suites, filter)
 }
 
-func runSuites(ctx context.Context, fileSystem fs.FS, suites []*gktest.Suite, filter gktest.Filter) error {
+func runSuites(ctx context.Context, fileSystem fs.FS, suites []*gator.Suite, filter gator.Filter) error {
 	isFailure := false
 
-	runner, err := gktest.NewRunner(fileSystem, gktest.NewOPAClient)
+	runner, err := gator.NewRunner(fileSystem, gator.NewOPAClient)
 	if err != nil {
 		return err
 	}
 
-	results := make([]gktest.SuiteResult, len(suites))
+	results := make([]gator.SuiteResult, len(suites))
 	i := 0
 
 	for _, suite := range suites {
@@ -129,7 +129,7 @@ func runSuites(ctx context.Context, fileSystem fs.FS, suites []*gktest.Suite, fi
 		i++
 	}
 	w := &strings.Builder{}
-	printer := gktest.PrinterGo{}
+	printer := gator.PrinterGo{}
 	err = printer.Print(w, results, verbose)
 	if err != nil {
 		return err

--- a/pkg/gator/assertion.go
+++ b/pkg/gator/assertion.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"fmt"

--- a/pkg/gator/assertion_test.go
+++ b/pkg/gator/assertion_test.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"errors"

--- a/pkg/gator/client.go
+++ b/pkg/gator/client.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"context"

--- a/pkg/gator/errors.go
+++ b/pkg/gator/errors.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import "errors"
 

--- a/pkg/gator/filter.go
+++ b/pkg/gator/filter.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"fmt"

--- a/pkg/gator/filter_test.go
+++ b/pkg/gator/filter_test.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"errors"

--- a/pkg/gator/intstr.go
+++ b/pkg/gator/intstr.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import "k8s.io/apimachinery/pkg/util/intstr"
 

--- a/pkg/gator/opa.go
+++ b/pkg/gator/opa.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	opaclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"

--- a/pkg/gator/printer.go
+++ b/pkg/gator/printer.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 // Printer knows how to print the results of running a Suite.
 type Printer interface {

--- a/pkg/gator/printer_go.go
+++ b/pkg/gator/printer_go.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"errors"

--- a/pkg/gator/printer_go_test.go
+++ b/pkg/gator/printer_go_test.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"errors"

--- a/pkg/gator/read_constraints.go
+++ b/pkg/gator/read_constraints.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"encoding/json"

--- a/pkg/gator/read_suites.go
+++ b/pkg/gator/read_suites.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"encoding/json"

--- a/pkg/gator/read_suites_test.go
+++ b/pkg/gator/read_suites_test.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"errors"

--- a/pkg/gator/result.go
+++ b/pkg/gator/result.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"fmt"

--- a/pkg/gator/runner.go
+++ b/pkg/gator/runner.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"context"

--- a/pkg/gator/runner_integer_test.go
+++ b/pkg/gator/runner_integer_test.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"context"

--- a/pkg/gator/runner_test.go
+++ b/pkg/gator/runner_test.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	"context"

--- a/pkg/gator/suite.go
+++ b/pkg/gator/suite.go
@@ -1,4 +1,4 @@
-package gktest
+package gator
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Since the `gator` CLI now has a name and will do more than just `gator test`, it's a good idea that we rename `pkg/gktest` to `pkg/gator` to accommodate the other subcommands we'll want to add. Since there's no open PRs against `gator`, now is a great time to make this change.

Fixes #1722

Signed-off-by: Will Beason <willbeason@google.com>
