### PR TITLE
fix: Check resp before call resp.TraceDump to avoid panic

### DIFF
--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -476,7 +476,7 @@ func (h *validationHandler) reviewRequest(ctx context.Context, req *admission.Re
 	}
 
 	resp, err := h.opa.Review(ctx, review, opa.Tracing(trace))
-	if trace {
+	if resp != nil && trace {
 		log.Info(resp.TraceDump())
 	}
 	if dump {


### PR DESCRIPTION
**What this PR does / why we need it**:

It's not panic for now, but it's better to check value of resp to avoid may panic in feature.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
