### PR TITLE
fix: Set namespace field in request

### DIFF
--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -160,6 +160,7 @@ kind: NeverValidate
 apiVersion: constraints.gatekeeper.sh/v1beta1
 metadata:
   name: never-validate-namespace
+spec:
   match:
     excludedNamespaces: ["excluded"]
 `

--- a/pkg/gktest/runner_test.go
+++ b/pkg/gktest/runner_test.go
@@ -155,6 +155,15 @@ metadata:
   name: always-pass
 `
 
+	constraintExcludedNamespace = `
+kind: NeverValidate
+apiVersion: constraints.gatekeeper.sh/v1beta1
+metadata:
+  name: never-validate-namespace
+  match:
+    excludedNamespaces: ["excluded"]
+`
+
 	constraintNeverValidate = `
 kind: NeverValidate
 apiVersion: constraints.gatekeeper.sh/v1beta1
@@ -200,6 +209,21 @@ kind: Object
 apiVersion: v1
 metadata:
   name: object-2
+`
+	objectIncluded = `
+kind: Object
+apiVersion: v1
+metadata:
+  name: object
+  namespace: included
+`
+
+	objectExcluded = `
+kind: Object
+apiVersion: v1
+metadata:
+  name: object
+  namespace: excluded
 `
 
 	objectInvalid = `
@@ -955,6 +979,49 @@ func TestRunner_Run(t *testing.T) {
 						Name: "allow",
 					}, {
 						Name: "deny",
+					}},
+				}},
+			},
+		},
+		{
+			name: "excluded namespace",
+			suite: Suite{
+				Tests: []Test{{
+					Name:       "excluded namespace Constraint",
+					Template:   "template.yaml",
+					Constraint: "constraint.yaml",
+					Cases: []*Case{{
+						Name:       "included",
+						Object:     "included.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("yes")}},
+					}, {
+						Name:       "excluded",
+						Object:     "excluded.yaml",
+						Assertions: []Assertion{{Violations: intStrFromStr("no")}},
+					}},
+				}},
+			},
+			f: fstest.MapFS{
+				"template.yaml": &fstest.MapFile{
+					Data: []byte(templateNeverValidate),
+				},
+				"constraint.yaml": &fstest.MapFile{
+					Data: []byte(constraintExcludedNamespace),
+				},
+				"included.yaml": &fstest.MapFile{
+					Data: []byte(objectIncluded),
+				},
+				"excluded.yaml": &fstest.MapFile{
+					Data: []byte(objectExcluded),
+				},
+			},
+			want: SuiteResult{
+				TestResults: []TestResult{{
+					Name: "excluded namespace Constraint",
+					CaseResults: []CaseResult{{
+						Name: "included",
+					}, {
+						Name: "excluded",
 					}},
 				}},
 			},

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -177,7 +177,8 @@ func unstructuredToAdmissionRequest(obj unstructured.Unstructured) (admissionv1.
 		Object: runtime.RawExtension{
 			Raw: resourceJSON,
 		},
-		Name: obj.GetName(),
+		Name:      obj.GetName(),
+		Namespace: obj.GetNamespace(),
 	}
 
 	return req, nil


### PR DESCRIPTION
Set the Namespace in requests, and add a test for `gator` that validates this behavior works as expected.