### PR TITLE
feat: Ability to use Image SHA for gatekeeper and gatekeeper-crd images

### DIFF
--- a/cmd/build/helmify/kustomization.yaml
+++ b/cmd/build/helmify/kustomization.yaml
@@ -77,6 +77,8 @@ patchesJson6902:
         path: /spec/template/metadata/annotations/container.seccomp.security.alpha.kubernetes.io~1manager
       - op: remove
         path: /spec/template/spec/nodeSelector/kubernetes.io~1os
+      - op: remove
+        path: /spec/template/spec/containers/0/image
   - target:
       kind: Deployment
       name: gatekeeper-controller-manager
@@ -91,3 +93,5 @@ patchesJson6902:
         path: /spec/template/spec/nodeSelector/kubernetes.io~1os
       - op: remove
         path: /spec/template/spec/affinity/podAntiAffinity
+      - op: remove
+        path: /spec/template/spec/containers/0/image

--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -84,7 +84,7 @@ spec:
             - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_EXEMPT_NAMESPACES
             - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_EXEMPT_NAMESPACE_PREFIXES
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-          image: "{{ .Values.image.repository }}:{{ .Values.image.release }}"
+          HELMSUBST_AUDIT_CONTROLLER_MANAGER_DEPLOYMENT_IMAGE_RELEASE: ""
           ports:
           - containerPort: HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_PORT
             name: webhook-server
@@ -145,7 +145,7 @@ spec:
             - --prometheus-port=HELMSUBST_DEPLOYMENT_AUDIT_METRICS_PORT
             - --enable-external-data={{ .Values.enableExternalData }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-          image: "{{ .Values.image.repository }}:{{ .Values.image.release }}"
+          HELMSUBST_AUDIT_CONTROLLER_MANAGER_DEPLOYMENT_IMAGE_RELEASE: ""
           ports:
           - containerPort: HELMSUBST_DEPLOYMENT_AUDIT_METRICS_PORT
             name: metrics

--- a/cmd/build/helmify/replacements.go
+++ b/cmd/build/helmify/replacements.go
@@ -74,6 +74,12 @@ var replacements = map[string]string{
 
 	"HELMSUBST_PDB_CONTROLLER_MANAGER_MINAVAILABLE": `{{ .Values.pdb.controllerManager.minAvailable }}`,
 
+	`HELMSUBST_AUDIT_CONTROLLER_MANAGER_DEPLOYMENT_IMAGE_RELEASE: ""`: `{{- if .Values.image.release }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.release }}
+        {{- else }}
+        image: {{ .Values.image.repository }}
+        {{- end }}`,
+
 	`HELMSUBST_SERVICE_TYPE: ""`: `{{- if .Values.service }}
   type: {{  .Values.service.type | default "ClusterIP" }}
     {{- if .Values.service.loadBalancerIP }}

--- a/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
+++ b/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
@@ -81,7 +81,11 @@ spec:
       {{- end }}
       containers:
       - name: crds-upgrade
+        {{- if not  .Values.image.release }}
+        image: '{{ .Values.image.crdRepository }}'
+        {{- else }}
         image: '{{ .Values.image.crdRepository }}:{{ .Values.image.release }}'
+        {{- end }}
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         args:
         - apply

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -40,7 +40,12 @@ spec:
         {{- toYaml .Values.audit.affinity | nindent 8 }}
       automountServiceAccountToken: true
       containers:
-      - args:
+      - {{- if .Values.image.release }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.release }}
+        {{- else }}
+        image: {{ .Values.image.repository }}
+        {{- end }}
+        args:
         - --audit-interval={{ .Values.auditInterval }}
         - --log-level={{ .Values.logLevel }}
         - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
@@ -67,7 +72,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         livenessProbe:
           httpGet:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -40,7 +40,12 @@ spec:
         {{- toYaml .Values.controllerManager.affinity | nindent 8 }}
       automountServiceAccountToken: true
       containers:
-      - args:
+      - {{- if .Values.image.release }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.release }}
+        {{- else }}
+        image: {{ .Values.image.repository }}
+        {{- end }}
+        args:
         - --port={{ .Values.controllerManager.port }}
         - --health-addr=:{{ .Values.controllerManager.healthPort }}
         - --prometheus-port={{ .Values.controllerManager.metricsPort }}
@@ -76,7 +81,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         livenessProbe:
           httpGet:

--- a/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
@@ -81,7 +81,11 @@ spec:
       {{- end }}
       containers:
       - name: crds-upgrade
+        {{- if not  .Values.image.release }}
+        image: '{{ .Values.image.crdRepository }}'
+        {{- else }}
         image: '{{ .Values.image.crdRepository }}:{{ .Values.image.release }}'
+        {{- end }}
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
         args:
         - apply


### PR DESCRIPTION
… Gatekeeper helm charts #1659

This commit checks if image.release is defined in the values.yaml
if not defined it will ignore the image.release field and only use the values of
image.repository and image.crdRepository to set the "image" in gatekeeper audit /controller
deployment yamls.

With the current implementation there is only one field defined "image.release" which restrics the use of
image-tag:release and not allowing SHA along with "image"(e.g image@SHA) for GK and GK-CRD repository

Signed-off-by: Priya Shet priya.shet@gmail.com

What this PR does / why we need it:

Which issue(s) this PR fixes (optional, using fixes #1659 (, fixes #1659) format, will close the issue(s) when the PR gets merged):
Fixes #1659

Special notes for your reviewer: