### PR TITLE
fix: helm upgrade test

### DIFF
--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 env:
-  BASE_RELEASE: 3.4.0
-  BASE_BRANCH: release-3.4
+  BASE_RELEASE: 3.5.0
+  BASE_BRANCH: release-3.5
 
 jobs:
   helm_upgrade:


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
#1739 bumped k8s version of helm upgrade test from v1.21 to v1.23, which doesn't support CRD v1beta1 anymore
bumping GK base version to 3.5 which support v1 CRDs

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
