### PR TITLE
Gomega

### DIFF
--- a/apis/status/v1beta1/constrainttemplatepodstatus_types_test.go
+++ b/apis/status/v1beta1/constrainttemplatepodstatus_types_test.go
@@ -3,7 +3,7 @@ package v1beta1
 import (
 	"testing"
 
-	. "github.com/onsi/gomega"
+	"github.com/google/go-cmp/cmp"
 	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/operations"
 	"github.com/open-policy-agent/gatekeeper/test/testutils"
@@ -13,7 +13,6 @@ import (
 )
 
 func TestNewConstraintTemplateStatusForPod(t *testing.T) {
-	g := NewGomegaWithT(t)
 	podName := "some-gk-pod"
 	podNS := "a-gk-namespace"
 	templateName := "a-template"
@@ -55,10 +54,14 @@ func TestNewConstraintTemplateStatusForPod(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	g.Expect(status).To(Equal(expectedStatus))
+	if diff := cmp.Diff(expectedStatus, status); diff != "" {
+		t.Fatal(diff)
+	}
 	n, err := KeyForConstraintTemplate(podName, templateName)
 	if err != nil {
 		t.Fatal(err)
 	}
-	g.Expect(status.Name).To(Equal(n))
+	if status.Name != n {
+		t.Fatal("got status.Name != n, want equal")
+	}
 }

--- a/apis/status/v1beta1/constrainttemplatepodstatus_types_test.go
+++ b/apis/status/v1beta1/constrainttemplatepodstatus_types_test.go
@@ -21,8 +21,15 @@ func TestNewConstraintTemplateStatusForPod(t *testing.T) {
 	testutils.Setenv(t, "POD_NAMESPACE", podNS)
 
 	scheme := runtime.NewScheme()
-	g.Expect(AddToScheme(scheme)).NotTo(HaveOccurred())
-	g.Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
+	err := AddToScheme(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	pod := fakes.Pod(
 		fakes.WithNamespace(podNS),
@@ -38,12 +45,20 @@ func TestNewConstraintTemplateStatusForPod(t *testing.T) {
 		ConstraintTemplateNameLabel: templateName,
 		PodLabel:                    podName,
 	})
-	g.Expect(controllerutil.SetOwnerReference(pod, expectedStatus, scheme)).NotTo(HaveOccurred())
+
+	err = controllerutil.SetOwnerReference(pod, expectedStatus, scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	status, err := NewConstraintTemplateStatusForPod(pod, templateName, scheme)
-	g.Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 	g.Expect(status).To(Equal(expectedStatus))
 	n, err := KeyForConstraintTemplate(podName, templateName)
-	g.Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 	g.Expect(status.Name).To(Equal(n))
 }

--- a/apis/status/v1beta1/mutatorpodstatus_types_test.go
+++ b/apis/status/v1beta1/mutatorpodstatus_types_test.go
@@ -21,8 +21,15 @@ func TestNewMutatorStatusForPod(t *testing.T) {
 	testutils.Setenv(t, "POD_NAMESPACE", podNS)
 
 	scheme := runtime.NewScheme()
-	g.Expect(AddToScheme(scheme)).NotTo(HaveOccurred())
-	g.Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
+	err := AddToScheme(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	pod := fakes.Pod(
 		fakes.WithNamespace(podNS),
@@ -40,12 +47,22 @@ func TestNewMutatorStatusForPod(t *testing.T) {
 			MutatorKindLabel: "DummyMutator",
 			PodLabel:         podName,
 		})
-	g.Expect(controllerutil.SetOwnerReference(pod, expectedStatus, scheme)).NotTo(HaveOccurred())
+
+	err = controllerutil.SetOwnerReference(pod, expectedStatus, scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	status, err := NewMutatorStatusForPod(pod, mutator.ID(), scheme)
-	g.Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	g.Expect(status).To(Equal(expectedStatus))
 	cmVal, err := KeyForMutatorID(podName, mutator.ID())
-	g.Expect(err).NotTo(HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	g.Expect(status.Name).To(Equal(cmVal))
 }

--- a/apis/status/v1beta1/mutatorpodstatus_types_test.go
+++ b/apis/status/v1beta1/mutatorpodstatus_types_test.go
@@ -3,7 +3,7 @@ package v1beta1
 import (
 	"testing"
 
-	. "github.com/onsi/gomega"
+	"github.com/google/go-cmp/cmp"
 	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/testhelpers"
 	"github.com/open-policy-agent/gatekeeper/pkg/operations"
@@ -14,7 +14,6 @@ import (
 )
 
 func TestNewMutatorStatusForPod(t *testing.T) {
-	g := NewGomegaWithT(t)
 	podName := "some-gk-pod-m"
 	podNS := "a-gk-namespace-m"
 	mutator := testhelpers.NewDummyMutator("a-mutator", "spec.value", nil)
@@ -58,11 +57,15 @@ func TestNewMutatorStatusForPod(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	g.Expect(status).To(Equal(expectedStatus))
+	if diff := cmp.Diff(expectedStatus, status); diff != "" {
+		t.Fatal(diff)
+	}
 	cmVal, err := KeyForMutatorID(podName, mutator.ID())
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	g.Expect(status.Name).To(Equal(cmVal))
+	if status.Name != cmVal {
+		t.Fatalf("got status name %q, want %q", status.Name, cmVal)
+	}
 }

--- a/apis/status/v1beta1/util_test.go
+++ b/apis/status/v1beta1/util_test.go
@@ -3,7 +3,7 @@ package v1beta1
 import (
 	"testing"
 
-	. "github.com/onsi/gomega"
+	"github.com/google/go-cmp/cmp"
 )
 
 var dashingTestCases = []struct {
@@ -89,19 +89,25 @@ var dashingTestCases = []struct {
 }
 
 func TestDashPacker(t *testing.T) {
-	g := NewGomegaWithT(t)
 	for _, tc := range dashingTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g.Expect(dashPacker(tc.extracted...)).To(Equal(tc.packed))
+			gotPacked, err := dashPacker(tc.extracted...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tc.packed, gotPacked); diff != "" {
+				t.Fatal("got dashPacker(tc.extracted...) != tc.packed, want equal")
+			}
 		})
 	}
 }
 
 func TestDashExtractor(t *testing.T) {
-	g := NewGomegaWithT(t)
 	for _, tc := range dashingTestCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g.Expect(dashExtractor(tc.packed)).To(Equal(tc.extracted))
+			if diff := cmp.Diff(tc.extracted, dashExtractor(tc.packed)); diff != "" {
+				t.Fatal(diff)
+			}
 		})
 	}
 }

--- a/pkg/controller/config/config_controller_suite_test.go
+++ b/pkg/controller/config/config_controller_suite_test.go
@@ -20,10 +20,8 @@ import (
 	stdlog "log"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
-	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -31,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/open-policy-agent/gatekeeper/apis"
@@ -74,17 +71,6 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 		return result, err
 	})
 	return fn, requests
-}
-
-// StartTestManager adds recFn.
-func StartTestManager(ctx context.Context, mgr manager.Manager, g *gomega.GomegaWithT) *sync.WaitGroup {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		g.Expect(mgr.Start(ctx)).NotTo(gomega.HaveOccurred())
-	}()
-	return wg
 }
 
 // Bootstrap the gatekeeper-system namespace for use in tests.

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -479,12 +479,16 @@ func TestConfig_CacheContents(t *testing.T) {
 	cm := unstructuredFor(configMapGVK, "config-test-1")
 	cm.SetNamespace("default")
 	err = c.Create(ctx, cm)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "creating configMap config-test-1")
+	if err != nil {
+		t.Fatalf("creating configMap config-test-1: %v", err)
+	}
 
 	cm2 := unstructuredFor(configMapGVK, "config-test-2")
 	cm2.SetNamespace("kube-system")
 	err = c.Create(ctx, cm2)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "creating configMap config-test-2")
+	if err != nil {
+		t.Fatalf("creating configMap config-test-2: %v", err)
+	}
 
 	defer func() {
 		err = c.Delete(ctx, cm)
@@ -507,7 +511,9 @@ func TestConfig_CacheContents(t *testing.T) {
 	}, 10*time.Second).Should(gomega.BeTrue(), "checking initial opa cache contents")
 
 	// Sanity
-	g.Expect(opaClient.HasGVK(nsGVK)).To(gomega.BeTrue())
+	if !opaClient.HasGVK(nsGVK) {
+		t.Fatal("want opaClient.HasGVK(nsGVK) to be true but got false")
+	}
 
 	// Reconfigure to drop the namespace watches
 	instance = configFor([]schema.GroupVersionKind{configMapGVK})
@@ -659,7 +665,9 @@ func TestConfig_Retries(t *testing.T) {
 
 	// Wipe the opa cache, we want to see it repopulate despite transient replay errors below.
 	_, err = opaClient.RemoveData(ctx, target.WipeData{})
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "wiping opa cache")
+	if err != nil {
+		t.Fatalf("wiping opa cache: %v", err)
+	}
 	if opaClient.Contains(expected) {
 		t.Fatal("wipe failed")
 	}

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -522,7 +522,9 @@ func TestConfig_CacheContents(t *testing.T) {
 		forUpdate.Spec = instance.Spec
 		return nil
 	})
-	g.Expect(err).ToNot(gomega.HaveOccurred(), "updating Config resource")
+	if err != nil {
+		t.Fatalf("updating Config resource: %v", err)
+	}
 
 	// Expect namespaces to go away from cache
 	g.Eventually(func() bool {
@@ -554,7 +556,9 @@ func TestConfig_CacheContents(t *testing.T) {
 	// Delete the config resource - expect opa to empty out.
 	g.Expect(opaClient.Len()).ToNot(gomega.BeZero(), "sanity")
 	err = c.Delete(ctx, instance)
-	g.Expect(err).ToNot(gomega.HaveOccurred(), "deleting Config resource")
+	if err != nil {
+		t.Fatalf("deleting Config resource: %v", err)
+	}
 
 	// The cache will be cleared out.
 	g.Eventually(func() int {
@@ -682,7 +686,9 @@ func TestConfig_Retries(t *testing.T) {
 		forUpdate.Spec = instance.Spec
 		return nil
 	})
-	g.Expect(err).ToNot(gomega.HaveOccurred(), "updating Config resource")
+	if err != nil {
+		t.Fatalf("updating Config resource: %v", err)
+	}
 
 	// Despite the transient error, we expect the cache to eventually be repopulated.
 	g.Eventually(func() bool {

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -554,7 +554,9 @@ func TestConfig_CacheContents(t *testing.T) {
 	}, 10*time.Second).Should(gomega.BeTrue(), "kube-system namespace is excluded. kube-system/config-test-2 should not be in opa cache")
 
 	// Delete the config resource - expect opa to empty out.
-	g.Expect(opaClient.Len()).ToNot(gomega.BeZero(), "sanity")
+	if opaClient.Len() == 0 {
+		t.Fatal("sanity")
+	}
 	err = c.Delete(ctx, instance)
 	if err != nil {
 		t.Fatalf("deleting Config resource: %v", err)

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -660,7 +660,9 @@ func TestConfig_Retries(t *testing.T) {
 	// Wipe the opa cache, we want to see it repopulate despite transient replay errors below.
 	_, err = opaClient.RemoveData(ctx, target.WipeData{})
 	g.Expect(err).NotTo(gomega.HaveOccurred(), "wiping opa cache")
-	g.Expect(opaClient.Contains(expected)).To(gomega.BeFalse(), "wipe failed")
+	if opaClient.Contains(expected) {
+		t.Fatal("wipe failed")
+	}
 
 	// Make List fail once for ConfigMaps as the replay occurs following the reconfig below.
 	failPlease <- "ConfigMapList"

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -184,9 +184,15 @@ violation[{"msg": "denied!"}] {
 			t.Fatal(err)
 		}
 
-		g.Expect(deleteObjectAndConfirm(ctx, c, cstr, timeout)).To(gomega.BeNil())
-		g.Expect(deleteObjectAndConfirm(ctx, c, crd, timeout)).To(gomega.BeNil())
-		g.Expect(deleteObjectAndConfirm(ctx, c, instance, timeout)).To(gomega.BeNil())
+		if err := deleteObjectAndConfirm(ctx, c, cstr, timeout); err != nil {
+			t.Fatalf("want deleteObjectAndConfirm(ctx, c, cstr, timeout) error = nil, got %v", err)
+		}
+		if err := deleteObjectAndConfirm(ctx, c, crd, timeout); err != nil {
+			t.Fatalf("want deleteObjectAndConfirm(ctx, c, crd, timeout) error = nil, got %v", err)
+		}
+		if err := deleteObjectAndConfirm(ctx, c, instance, timeout); err != nil {
+			t.Fatalf("want deleteObjectAndConfirm(ctx, c, instance, timeout) error = nil, got %v", err)
+		}
 	})
 
 	logger.Info("Running test: CRD Gets Created")
@@ -245,11 +251,13 @@ violation[{"msg": "denied!"}] {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(resp.Results()) != 1 {
+
+		gotResults := resp.Results()
+		if len(gotResults) != 1 {
 			fmt.Println(resp.TraceDump())
 			fmt.Println(opaClient.Dump(ctx))
+			t.Fatalf("want 1 result, got %v", gotResults)
 		}
-		g.Expect(len(resp.Results())).Should(gomega.Equal(1))
 	})
 
 	logger.Info("Running test: Deleted constraint CRDs are recreated")
@@ -471,7 +479,9 @@ violation[{"msg": "denied!"}] {
 	// Install constraint CRD
 	crd := makeCRD(gvk, "denyall")
 	err = applyCRD(ctx, g, c, gvk, crd)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying CRD")
+	if err != nil {
+		t.Fatalf("applying CRD: %v", err)
+	}
 
 	// Create the constraint for constraint template
 	cstr := newDenyAllCstr()

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -401,12 +401,19 @@ violation[{"msg": "denied!"}] {
 		if err != nil {
 			t.Fatal(err)
 		}
+
+		gotResults := resp.Results()
 		if len(resp.Results()) != 1 {
 			fmt.Println(resp.TraceDump())
 			fmt.Println(opaClient.Dump(ctx))
+			t.Fatalf("did not get 1 result: %v", gotResults)
 		}
-		g.Expect(len(resp.Results())).Should(gomega.Equal(1))
-		g.Expect(c.Delete(ctx, instance.DeepCopy())).Should(gomega.BeNil())
+
+		err = c.Delete(ctx, instance.DeepCopy())
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		g.Eventually(func() error {
 			resp, err := opaClient.Review(ctx, req)
 			if err != nil {

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
@@ -120,7 +120,9 @@ violation[{"msg": "denied!"}] {
 
 	cs := watch.NewSwitch()
 	tracker, err := readiness.SetupTracker(mgr, false, false)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 	pod := fakes.Pod(
 		fakes.WithNamespace("gatekeeper-system"),
 		fakes.WithName("no-pod"),
@@ -133,7 +135,10 @@ violation[{"msg": "denied!"}] {
 		Tracker:          tracker,
 		GetPod:           func(context.Context) (*corev1.Pod, error) { return pod, nil },
 	}
-	g.Expect(adder.Add(mgr)).NotTo(gomega.HaveOccurred())
+	err = adder.Add(mgr)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	ctx := context.Background()
 	testutils.StartManager(ctx, t, mgr)
@@ -145,7 +150,10 @@ violation[{"msg": "denied!"}] {
 	templateCpy := template.DeepCopy()
 	t.Run("Constraint template status gets created and reported", func(t *testing.T) {
 		g.Eventually(verifyTStatusCount(ctx, c, 0), timeout).Should(gomega.BeNil())
-		g.Expect(c.Create(ctx, templateCpy)).NotTo(gomega.HaveOccurred())
+		err := c.Create(ctx, templateCpy)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyTStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyTByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 	})
@@ -153,7 +161,10 @@ violation[{"msg": "denied!"}] {
 	constraint := newDenyAllConstraint()
 	t.Run("Constraint status gets created and reported", func(t *testing.T) {
 		g.Eventually(verifyCStatusCount(ctx, c, 0), timeout).Should(gomega.BeNil())
-		g.Expect(c.Create(ctx, constraint)).NotTo(gomega.HaveOccurred())
+		err := c.Create(ctx, constraint)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyCStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyCByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 	})
@@ -169,9 +180,15 @@ violation[{"msg": "denied!"}] {
 		// https://github.com/open-policy-agent/gatekeeper/pull/1595#discussion_r722819552
 		t.Cleanup(testutils.DeleteObject(t, c, fakeTStatus))
 
-		g.Expect(c.Create(ctx, fakeTStatus)).NotTo(gomega.HaveOccurred())
+		err = c.Create(ctx, fakeTStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyTByPodStatusCount(ctx, c, 2), timeout).Should(gomega.BeNil())
-		g.Expect(c.Delete(ctx, fakeTStatus)).NotTo(gomega.HaveOccurred())
+		err = c.Delete(ctx, fakeTStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyTByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 	})
 
@@ -180,50 +197,77 @@ violation[{"msg": "denied!"}] {
 		g.Expect(err).To(gomega.BeNil())
 		fakeCStatus.Status.ConstraintUID = constraint.GetUID()
 		g.Expect(err).To(gomega.BeNil())
-		g.Expect(c.Create(ctx, fakeCStatus)).NotTo(gomega.HaveOccurred())
+		err = c.Create(ctx, fakeCStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// TODO: Test if this removal is necessary.
 		// https://github.com/open-policy-agent/gatekeeper/pull/1595#discussion_r722819552
 		t.Cleanup(testutils.DeleteObject(t, c, fakeCStatus))
 
 		g.Eventually(verifyCByPodStatusCount(ctx, c, 2), timeout).Should(gomega.BeNil())
-		g.Expect(c.Delete(ctx, fakeCStatus)).NotTo(gomega.HaveOccurred())
+		err = c.Delete(ctx, fakeCStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyCByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 	})
 
 	t.Run("Deleting a constraint deletes its status", func(t *testing.T) {
-		g.Expect(c.Delete(ctx, constraint)).NotTo(gomega.HaveOccurred())
+		err := c.Delete(ctx, constraint)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyCStatusCount(ctx, c, 0), timeout).Should(gomega.BeNil())
 		constraint = newDenyAllConstraint()
-		g.Expect(c.Create(ctx, constraint)).NotTo(gomega.HaveOccurred())
+		err = c.Create(ctx, constraint)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyCStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyCByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 	})
 
 	t.Run("Deleting a constraint template deletes all statuses", func(t *testing.T) {
-		g.Expect(c.Delete(ctx, template.DeepCopy())).NotTo(gomega.HaveOccurred())
+		err := c.Delete(ctx, template.DeepCopy())
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyTStatusCount(ctx, c, 0), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyCStatusCount(ctx, c, 0), timeout).Should(gomega.BeNil())
 		// need to manually delete constraint currently as garbage collection does not run on the test API server
-		g.Expect(c.Delete(ctx, newDenyAllConstraint())).NotTo(gomega.HaveOccurred())
+		err = c.Delete(ctx, newDenyAllConstraint())
+		if err != nil {
+			t.Fatal(err)
+		}
 	})
 
 	templateCpy = template.DeepCopy()
 	constraint = newDenyAllConstraint()
 	t.Run("Deleting a constraint template deletes all statuses for the current pod", func(t *testing.T) {
 		g.Eventually(verifyTStatusCount(ctx, c, 0), timeout).Should(gomega.BeNil())
-		g.Expect(c.Create(ctx, templateCpy)).NotTo(gomega.HaveOccurred())
+		err := c.Create(ctx, templateCpy)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyTStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyTByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyCStatusCount(ctx, c, 0), timeout).Should(gomega.BeNil())
-		g.Expect(c.Create(ctx, constraint)).NotTo(gomega.HaveOccurred())
+		err = c.Create(ctx, constraint)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyCStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyCByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 
 		fakeTStatus, err := podstatus.NewConstraintTemplateStatusForPod(fakePod, "denyall", mgr.GetScheme())
 		g.Expect(err).To(gomega.BeNil())
 		fakeTStatus.Status.TemplateUID = templateCpy.UID
-		g.Expect(c.Create(ctx, fakeTStatus)).NotTo(gomega.HaveOccurred())
+		err = c.Create(ctx, fakeTStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// TODO: Test if this removal is necessary.
 		// https://github.com/open-policy-agent/gatekeeper/pull/1595#discussion_r722819552
@@ -232,7 +276,10 @@ violation[{"msg": "denied!"}] {
 		fakeCStatus, err := podstatus.NewConstraintStatusForPod(fakePod, newDenyAllConstraint(), mgr.GetScheme())
 		g.Expect(err).To(gomega.BeNil())
 		fakeCStatus.Status.ConstraintUID = constraint.GetUID()
-		g.Expect(c.Create(ctx, fakeCStatus)).NotTo(gomega.HaveOccurred())
+		err = c.Create(ctx, fakeCStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		// TODO: Test if this removal is necessary.
 		// https://github.com/open-policy-agent/gatekeeper/pull/1595#discussion_r722819552
@@ -240,7 +287,10 @@ violation[{"msg": "denied!"}] {
 
 		g.Eventually(verifyTByPodStatusCount(ctx, c, 2), 30*timeout).Should(gomega.BeNil())
 		g.Eventually(verifyCByPodStatusCount(ctx, c, 2), timeout).Should(gomega.BeNil())
-		g.Expect(c.Delete(ctx, template.DeepCopy())).NotTo(gomega.HaveOccurred())
+		err = c.Delete(ctx, template.DeepCopy())
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyTStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyCStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 	})

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
@@ -103,7 +103,9 @@ violation[{"msg": "denied!"}] {
 
 	// creating the gatekeeper-system namespace is necessary because that's where
 	// status resources live by default
-	g.Expect(createGatekeeperNamespace(mgr.GetConfig())).To(gomega.BeNil())
+	if err := createGatekeeperNamespace(mgr.GetConfig()); err != nil {
+		t.Fatalf("want createGatekeeperNamespace(mgr.GetConfig()) error = nil, got %v", err)
+	}
 
 	// initialize OPA
 	driver := local.New(local.Tracing(true))

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
@@ -173,7 +173,9 @@ violation[{"msg": "denied!"}] {
 	fakePod.SetName("fake-pod")
 	t.Run("Multiple constraint template statuses are reported", func(t *testing.T) {
 		fakeTStatus, err := podstatus.NewConstraintTemplateStatusForPod(fakePod, "denyall", mgr.GetScheme())
-		g.Expect(err).To(gomega.BeNil())
+		if err != nil {
+			t.Fatal(err)
+		}
 		fakeTStatus.Status.TemplateUID = templateCpy.UID
 
 		// TODO: Test if this removal is necessary.
@@ -194,9 +196,13 @@ violation[{"msg": "denied!"}] {
 
 	t.Run("Multiple constraint statuses are reported", func(t *testing.T) {
 		fakeCStatus, err := podstatus.NewConstraintStatusForPod(fakePod, newDenyAllConstraint(), mgr.GetScheme())
-		g.Expect(err).To(gomega.BeNil())
+		if err != nil {
+			t.Fatal(err)
+		}
 		fakeCStatus.Status.ConstraintUID = constraint.GetUID()
-		g.Expect(err).To(gomega.BeNil())
+		if err != nil {
+			t.Fatal(err)
+		}
 		err = c.Create(ctx, fakeCStatus)
 		if err != nil {
 			t.Fatal(err)
@@ -262,7 +268,9 @@ violation[{"msg": "denied!"}] {
 		g.Eventually(verifyCByPodStatusCount(ctx, c, 1), timeout).Should(gomega.BeNil())
 
 		fakeTStatus, err := podstatus.NewConstraintTemplateStatusForPod(fakePod, "denyall", mgr.GetScheme())
-		g.Expect(err).To(gomega.BeNil())
+		if err != nil {
+			t.Fatal(err)
+		}
 		fakeTStatus.Status.TemplateUID = templateCpy.UID
 		err = c.Create(ctx, fakeTStatus)
 		if err != nil {
@@ -274,7 +282,9 @@ violation[{"msg": "denied!"}] {
 		t.Cleanup(testutils.DeleteObject(t, c, fakeTStatus))
 
 		fakeCStatus, err := podstatus.NewConstraintStatusForPod(fakePod, newDenyAllConstraint(), mgr.GetScheme())
-		g.Expect(err).To(gomega.BeNil())
+		if err != nil {
+			t.Fatal(err)
+		}
 		fakeCStatus.Status.ConstraintUID = constraint.GetUID()
 		err = c.Create(ctx, fakeCStatus)
 		if err != nil {

--- a/pkg/controller/externaldata/externaldata_controller_suite_test.go
+++ b/pkg/controller/externaldata/externaldata_controller_suite_test.go
@@ -20,15 +20,12 @@ import (
 	stdlog "log"
 	"os"
 	"path/filepath"
-	"sync"
 	"testing"
 
-	"github.com/onsi/gomega"
 	"github.com/open-policy-agent/gatekeeper/apis"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -58,17 +55,6 @@ func TestMain(m *testing.M) {
 		stdlog.Printf("error while trying to stop server: %v", err)
 	}
 	os.Exit(code)
-}
-
-// StartTestManager adds recFn.
-func StartTestManager(ctx context.Context, mgr manager.Manager, g *gomega.GomegaWithT) *sync.WaitGroup {
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		g.Expect(mgr.Start(ctx)).NotTo(gomega.HaveOccurred())
-	}()
-	return wg
 }
 
 // SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and

--- a/pkg/controller/externaldata/externaldata_controller_test.go
+++ b/pkg/controller/externaldata/externaldata_controller_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	externaldatav1alpha1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/v1alpha1"
 	opa "github.com/open-policy-agent/frameworks/constraint/pkg/client"
@@ -127,10 +128,14 @@ func TestReconcile(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		g.Expect(entry.Spec).Should(gomega.Equal(externaldatav1alpha1.ProviderSpec{
+
+		want := externaldatav1alpha1.ProviderSpec{
 			URL:     "http://my-provider:8080",
 			Timeout: 10,
-		}))
+		}
+		if diff := cmp.Diff(want, entry.Spec); diff != "" {
+			t.Fatal(diff)
+		}
 	})
 
 	t.Run("Can update a Provider object", func(t *testing.T) {

--- a/pkg/controller/externaldata/externaldata_controller_test.go
+++ b/pkg/controller/externaldata/externaldata_controller_test.go
@@ -152,10 +152,14 @@ func TestReconcile(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		g.Expect(entry.Spec).Should(gomega.Equal(externaldatav1alpha1.ProviderSpec{
+
+		wantSpec := externaldatav1alpha1.ProviderSpec{
 			URL:     "http://my-provider:8080",
 			Timeout: 20,
-		}))
+		}
+		if diff := cmp.Diff(wantSpec, entry.Spec); diff != "" {
+			t.Fatal(diff)
+		}
 	})
 
 	t.Run("Can delete a Provider object", func(t *testing.T) {

--- a/pkg/controller/externaldata/externaldata_controller_test.go
+++ b/pkg/controller/externaldata/externaldata_controller_test.go
@@ -161,7 +161,12 @@ func TestReconcile(t *testing.T) {
 		g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
 
 		_, err = pc.Get("my-provider")
-		g.Expect(err.Error()).Should(gomega.Equal("key is not found in provider cache"))
+		// TODO(willbeason): Make an error in frameworks for this test to check against
+		//  so we don't rely on exact string matching.
+		wantErr := "key is not found in provider cache"
+		if err.Error() != wantErr {
+			t.Fatalf("got error %v, want %v", err.Error(), wantErr)
+		}
 	})
 
 	testMgrStopped()

--- a/pkg/controller/mutators/core/controller_test.go
+++ b/pkg/controller/mutators/core/controller_test.go
@@ -215,10 +215,12 @@ func TestReconcile(t *testing.T) {
 		g.Eventually(func() error {
 			u := &unstructured.Unstructured{}
 			u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
-			g.Expect(func() error {
-				_, err := mSys.Mutate(u, nil)
-				return err
-			}()).NotTo(gomega.HaveOccurred())
+
+			_, err := mSys.Mutate(u, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			_, exists, err := unstructured.NestedString(u.Object, "spec", "test")
 			if err != nil {
 				return err

--- a/pkg/controller/mutators/core/controller_test.go
+++ b/pkg/controller/mutators/core/controller_test.go
@@ -190,23 +190,21 @@ func TestReconcile(t *testing.T) {
 	t.Run("System mutates a resource", func(t *testing.T) {
 		u := &unstructured.Unstructured{}
 		u.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"})
-		g.Expect(func() error {
-			_, err := mSys.Mutate(u, nil)
-			return err
-		}()).NotTo(gomega.HaveOccurred())
-		g.Expect(func() error {
-			v, exists, err := unstructured.NestedString(u.Object, "spec", "test")
-			if err != nil {
-				return err
-			}
-			if !exists {
-				return errors.New("mutated value is missing")
-			}
-			if v != "works" {
-				return errors.Errorf(`value = %s, expected "works"`, v)
-			}
-			return nil
-		}()).NotTo(gomega.HaveOccurred())
+		_, err := mSys.Mutate(u, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		v, exists, err := unstructured.NestedString(u.Object, "spec", "test")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !exists {
+			t.Fatal("mutated value is missing")
+		}
+		if v != "works" {
+			t.Fatalf(`value = %s, expected "works"`, v)
+		}
 	})
 
 	t.Run("Mutation deletion is honored", func(t *testing.T) {

--- a/pkg/controller/mutators/core/controller_test.go
+++ b/pkg/controller/mutators/core/controller_test.go
@@ -117,7 +117,9 @@ func TestReconcile(t *testing.T) {
 
 	// creating the gatekeeper-system namespace is necessary because that's where
 	// status resources live by default
-	g.Expect(createGatekeeperNamespace(mgr.GetConfig())).To(gomega.BeNil())
+	if err := createGatekeeperNamespace(mgr.GetConfig()); err != nil {
+		t.Fatalf("want createGatekeeperNamespace(mgr.GetConfig()) error = nil, got %v", err)
+	}
 
 	mSys := mutation.NewSystem(mutation.SystemOpts{})
 

--- a/pkg/readiness/object_tracker_test.go
+++ b/pkg/readiness/object_tracker_test.go
@@ -194,7 +194,6 @@ func Test_ObjectTracker_CancelBeforeExpect(t *testing.T) {
 // Verify that the allSatisfied circuit breaker keeps Satisfied==true and
 // no other operations have any impact.
 func Test_ObjectTracker_CircuitBreaker(t *testing.T) {
-	g := gomega.NewWithT(t)
 	ot := newObjTracker(schema.GroupVersionKind{}, nil)
 
 	const count = 10
@@ -246,10 +245,18 @@ func Test_ObjectTracker_CircuitBreaker(t *testing.T) {
 	// Peek at internals - we should not be accruing memory from the post-circuit-breaker operations
 	ot.mu.RLock()
 	defer ot.mu.RUnlock()
-	g.Expect(ot.canceled).To(gomega.BeEmpty())
-	g.Expect(ot.expect).To(gomega.BeEmpty())
-	g.Expect(ot.seen).To(gomega.BeEmpty())
-	g.Expect(ot.satisfied).To(gomega.BeEmpty())
+	if len(ot.canceled) != 0 {
+		t.Fatalf("want ot.canceled to be empty but got %v", ot.canceled)
+	}
+	if len(ot.expect) != 0 {
+		t.Fatalf("want ot.expect to be empty but got %v", ot.expect)
+	}
+	if len(ot.seen) != 0 {
+		t.Fatalf("want ot.seen to be empty but got %v", ot.seen)
+	}
+	if len(ot.satisfied) != 0 {
+		t.Fatalf("want ot.satisfied to be empty but got %v", ot.satisfied)
+	}
 }
 
 // Verifies the kinds internal method and that it retains it values even after

--- a/pkg/readiness/object_tracker_test.go
+++ b/pkg/readiness/object_tracker_test.go
@@ -51,10 +51,11 @@ func Test_ObjectTracker_Unpopulated_Is_Unsatisfied(t *testing.T) {
 
 // Verify that an populated tracker with no expectations is satisfied.
 func Test_ObjectTracker_No_Expectations(t *testing.T) {
-	g := gomega.NewWithT(t)
 	ot := newObjTracker(schema.GroupVersionKind{}, nil)
 	ot.ExpectationsDone()
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "populated tracker with no expectations should be satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("populated tracker with no expectations should be satisfied")
+	}
 }
 
 // Verify that that multiple expectations are tracked correctly.
@@ -75,7 +76,9 @@ func Test_ObjectTracker_Multiple_Expectations(t *testing.T) {
 		g.Expect(ot.Satisfied()).NotTo(gomega.BeTrue(), "should not be satisfied before observations are done")
 		ot.Observe(ct[i])
 	}
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("should be satisfied")
+	}
 }
 
 // Verify that observations can precede expectations.
@@ -88,19 +91,22 @@ func Test_ObjectTracker_Seen_Before_Expect(t *testing.T) {
 	ot.Expect(ct)
 
 	ot.ExpectationsDone()
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should have been satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("should have been satisfied")
+	}
 }
 
 // Verify that terminated resources are ignored when calling Expect.
 func Test_ObjectTracker_Terminated_Expect(t *testing.T) {
-	g := gomega.NewWithT(t)
 	ot := newObjTracker(schema.GroupVersionKind{}, nil)
 	ct := makeCT("test-ct")
 	now := metav1.Now()
 	ct.ObjectMeta.DeletionTimestamp = &now
 	ot.Expect(ct)
 	ot.ExpectationsDone()
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("should be satisfied")
+	}
 }
 
 // Verify that that expectations can be canceled.
@@ -127,7 +133,9 @@ func Test_ObjectTracker_Canceled_Expectations(t *testing.T) {
 	g.Expect(ot.Satisfied()).NotTo(gomega.BeTrue(), "one expectation remains")
 
 	ot.CancelExpect(ct[1])
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("should be satisfied")
+	}
 }
 
 // Verify that that duplicate expectations only need a single observation.
@@ -148,7 +156,9 @@ func Test_ObjectTracker_Duplicate_Expectations(t *testing.T) {
 		g.Expect(ot.Satisfied()).NotTo(gomega.BeTrue(), "should not be satisfied before observations are done")
 		ot.Observe(ct[i])
 	}
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("should be satisfied")
+	}
 }
 
 // Verify that an expectation can be canceled before it's first expected.
@@ -271,7 +281,9 @@ func Test_ObjectTracker_TryCancelExpect_Default(t *testing.T) {
 	g.Expect(ot.Satisfied()).NotTo(gomega.BeTrue(), "one expectation remains")
 
 	ot.TryCancelExpect(ct[1])
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("should be satisfied")
+	}
 }
 
 // Verify that TryCancelExpect must be called multiple times before an expectation is canceled.
@@ -303,7 +315,9 @@ func Test_ObjectTracker_TryCancelExpect_WithRetries(t *testing.T) {
 	g.Expect(ot.Satisfied()).NotTo(gomega.BeTrue(), "one expectation remains with zero retries")
 
 	ot.TryCancelExpect(ct[0])
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("should be satisfied")
+	}
 }
 
 // Verify that TryCancelExpect can be called many times without the tracker ever being satisfied,
@@ -357,7 +371,9 @@ func Test_ObjectTracker_TryCancelExpect_CancelBeforeExpected(t *testing.T) {
 
 	ot.TryCancelExpect(ct) // 0 retries --> DELETE
 
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "should be satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("should be satisfied")
+	}
 }
 
 // Verify that unexpected observations do not prevent the tracker from reaching its satisfied state.
@@ -373,5 +389,7 @@ func Test_ObjectTracker_Unexpected_Does_Not_Prevent_Satisfied(t *testing.T) {
 	// ** Do not expect the above observation **
 
 	ot.ExpectationsDone()
-	g.Expect(ot.Satisfied()).To(gomega.BeTrue(), "Nothing expected and ExpectationsDone(): should have been satisfied")
+	if !ot.Satisfied() {
+		t.Fatal("Nothing expected and ExpectationsDone(): should have been satisfied")
+	}
 }

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -448,7 +448,9 @@ func Test_CollectDeleted(t *testing.T) {
 
 	client := mgr.GetClient()
 
-	g.Expect(tracker.Satisfied()).To(gomega.BeFalse(), "checking the overall tracker is unsatisfied")
+	if tracker.Satisfied() {
+		t.Fatal("checking the overall tracker is unsatisfied")
+	}
 
 	// set up expected GVKs for tests
 	cgvk := schema.GroupVersionKind{

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/onsi/gomega"
 	externaldatav1alpha1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/v1alpha1"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
@@ -214,7 +215,9 @@ func Test_ModifySet(t *testing.T) {
 	for _, am := range testModifySet {
 		id := mutationtypes.MakeID(am)
 		expectedMutator := mutationSystem.Get(id)
-		g.Expect(expectedMutator).NotTo(gomega.BeNil(), "expected mutator was not found")
+		if expectedMutator == nil {
+			t.Fatal("want expectedMutator != nil but got nil")
+		}
 	}
 }
 
@@ -252,7 +255,9 @@ func Test_Assign(t *testing.T) {
 	for _, am := range testAssign {
 		id := mutationtypes.MakeID(am)
 		expectedMutator := mutationSystem.Get(id)
-		g.Expect(expectedMutator).NotTo(gomega.BeNil(), "expected mutator was not found")
+		if expectedMutator == nil {
+			t.Fatal("want expectedMutator != nil but got nil")
+		}
 	}
 }
 
@@ -302,10 +307,14 @@ func Test_Provider(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		g.Expect(instance.Spec).Should(gomega.Equal(externaldatav1alpha1.ProviderSpec{
+
+		want := externaldatav1alpha1.ProviderSpec{
 			URL:     "http://demo",
 			Timeout: 1,
-		}))
+		}
+		if diff := cmp.Diff(want, instance.Spec); diff != "" {
+			t.Fatal(diff)
+		}
 	}
 }
 

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -187,7 +187,9 @@ func Test_ModifySet(t *testing.T) {
 
 	// Apply fixtures *before* the controllers are setup.
 	err := applyFixtures("testdata")
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
+	if err != nil {
+		t.Fatalf("applying fixtures: %v", err)
+	}
 
 	// Wire up the rest.
 	mgr, wm := setupManager(t)
@@ -223,7 +225,9 @@ func Test_Assign(t *testing.T) {
 
 	// Apply fixtures *before* the controllers are setup.
 	err := applyFixtures("testdata")
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
+	if err != nil {
+		t.Fatalf("applying fixtures: %v", err)
+	}
 
 	// Wire up the rest.
 	mgr, wm := setupManager(t)
@@ -271,7 +275,9 @@ func Test_Provider(t *testing.T) {
 	}
 	// Apply fixtures *before* the controllers are setup.
 	err = applyFixtures("testdata")
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
+	if err != nil {
+		t.Fatalf("applying fixtures: %v", err)
+	}
 
 	// Wire up the rest.
 	mgr, wm := setupManager(t)
@@ -317,7 +323,9 @@ func Test_Tracker(t *testing.T) {
 
 	// Apply fixtures *before* the controllers are setup.
 	err := applyFixtures("testdata")
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
+	if err != nil {
+		t.Fatalf("applying fixtures: %v", err)
+	}
 
 	// Wire up the rest.
 	mgr, wm := setupManager(t)
@@ -332,7 +340,9 @@ func Test_Tracker(t *testing.T) {
 
 	// creating the gatekeeper-system namespace is necessary because that's where
 	// status resources live by default
-	g.Expect(createGatekeeperNamespace(mgr.GetConfig())).To(gomega.BeNil())
+	if err := createGatekeeperNamespace(mgr.GetConfig()); err != nil {
+		t.Fatalf("want createGatekeeperNamespace(mgr.GetConfig()) error = nil, got %v", err)
+	}
 
 	g.Eventually(func() (bool, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -343,21 +353,28 @@ func Test_Tracker(t *testing.T) {
 	// Verify cache (tracks testdata fixtures)
 	for _, ct := range testTemplates {
 		_, err := opaClient.GetTemplate(ct)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "checking cache for template")
+		if err != nil {
+			t.Fatalf("checking cache for template: %v", err)
+		}
 	}
 	for _, c := range testConstraints {
 		_, err := opaClient.GetConstraint(c)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "checking cache for constraint")
+		if err != nil {
+			t.Fatalf("checking cache for constraint: %v", err)
+		}
 	}
 	// TODO: Verify data if we add the corresponding API to opa.Client.
 	// for _, d := range testData {
 	// 	_, err := opaClient.GetData(ctx, c)
-	// 	g.Expect(err).NotTo(gomega.HaveOccurred(), "checking cache for constraint")
+	// 	if err != nil {
+	// t.Fatalf("checking cache for constraint: %v", err)
 	// }
 
 	// Add additional templates/constraints and verify that we remain satisfied
 	err = applyFixtures("testdata/post")
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying post fixtures")
+	if err != nil {
+		t.Fatalf("applying post fixtures: %v", err)
+	}
 
 	g.Eventually(func() (bool, error) {
 		// Verify cache (tracks testdata/post fixtures)
@@ -390,11 +407,15 @@ func Test_Tracker_UnregisteredCachedData(t *testing.T) {
 
 	// Apply fixtures *before* the controllers are setup.
 	err := applyFixtures("testdata")
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
+	if err != nil {
+		t.Fatalf("applying fixtures: %v", err)
+	}
 
 	// Apply config resource with bogus GVK reference
 	err = applyFixtures("testdata/bogus-config")
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying config")
+	if err != nil {
+		t.Fatalf("applying config: %v", err)
+	}
 
 	// Wire up the rest.
 	mgr, wm := setupManager(t)
@@ -428,7 +449,9 @@ func Test_CollectDeleted(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	err := applyFixtures("testdata")
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying fixtures")
+	if err != nil {
+		t.Fatalf("applying fixtures: %v", err)
+	}
 
 	mgr, _ := setupManager(t)
 
@@ -441,7 +464,9 @@ func Test_CollectDeleted(t *testing.T) {
 	err = mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		return tracker.Run(ctx)
 	}))
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "setting up tracker")
+	if err != nil {
+		t.Fatalf("setting up tracker: %v", err)
+	}
 
 	ctx := context.Background()
 	testutils.StartManager(ctx, t, mgr)
@@ -461,12 +486,16 @@ func Test_CollectDeleted(t *testing.T) {
 
 	cm := &corev1.ConfigMap{}
 	cmgvk, err := apiutil.GVKForObject(cm, mgr.GetScheme())
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "retrieving ConfigMap GVK")
+	if err != nil {
+		t.Fatalf("retrieving ConfigMap GVK: %v", err)
+	}
 	cmtracker := tracker.ForData(cmgvk)
 
 	ct := &v1beta1.ConstraintTemplate{}
 	ctgvk, err := apiutil.GVKForObject(ct, mgr.GetScheme())
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "retrieving ConstraintTemplate GVK")
+	if err != nil {
+		t.Fatalf("retrieving ConstraintTemplate GVK: %v", err)
+	}
 
 	// note: state can leak between these test cases because we do not reset the environment
 	// between them to keep the test short. Trackers are mostly independent per GVK.
@@ -494,12 +523,16 @@ func Test_CollectDeleted(t *testing.T) {
 		ul := &unstructured.UnstructuredList{}
 		ul.SetGroupVersionKind(tc.gvk)
 		err = lister.List(ctx, ul)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "deleting all %s", tc.description)
+		if err != nil {
+			t.Fatalf("deleting all %s", tc.description)
+		}
 		g.Expect(len(ul.Items)).To(gomega.BeNumerically(">=", 1), "expecting nonzero %s", tc.description)
 
 		for index := range ul.Items {
 			err = client.Delete(ctx, &ul.Items[index])
-			g.Expect(err).NotTo(gomega.HaveOccurred(), "deleting %s %s", tc.description, ul.Items[index].GetName())
+			if err != nil {
+				t.Fatalf("deleting %s %s", tc.description, ul.Items[index].GetName())
+			}
 		}
 
 		g.Eventually(func() (bool, error) {

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -293,7 +293,9 @@ func Test_Provider(t *testing.T) {
 	// Verify that the Provider is present in the cache
 	for _, tp := range testProvider {
 		instance, err := providerCache.Get(tp.Name)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Expect(instance.Spec).Should(gomega.Equal(externaldatav1alpha1.ProviderSpec{
 			URL:     "http://demo",
 			Timeout: 1,

--- a/pkg/readiness/ready_tracker_unit_test.go
+++ b/pkg/readiness/ready_tracker_unit_test.go
@@ -102,7 +102,9 @@ func Test_ReadyTracker_TryCancelTemplate_No_Retries(t *testing.T) {
 
 	rt.TryCancelTemplate(&testConstraintTemplate) // 0 retries --> DELETE
 
-	g.Expect(rt.Satisfied()).To(gomega.BeTrue(), "tracker with 0 retries and cancellation should be satisfied")
+	if !rt.Satisfied() {
+		t.Fatal("tracker with 0 retries and cancellation should be satisfied")
+	}
 }
 
 // Verify that TryCancelTemplate must be called enough times to remove all retries before canceling a template.
@@ -148,5 +150,7 @@ func Test_ReadyTracker_TryCancelTemplate_Retries(t *testing.T) {
 
 	rt.TryCancelTemplate(&testConstraintTemplate) // 0 retries --> DELETE
 
-	g.Expect(rt.Satisfied()).To(gomega.BeTrue(), "tracker with 0 retries and cancellation should be satisfied")
+	if !rt.Satisfied() {
+		t.Fatal("tracker with 0 retries and cancellation should be satisfied")
+	}
 }

--- a/pkg/readiness/ready_tracker_unit_test.go
+++ b/pkg/readiness/ready_tracker_unit_test.go
@@ -98,7 +98,9 @@ func Test_ReadyTracker_TryCancelTemplate_No_Retries(t *testing.T) {
 		return rt.Populated()
 	}, "10s").Should(gomega.BeTrue())
 
-	g.Expect(rt.Satisfied()).NotTo(gomega.BeTrue(), "tracker with 0 retries should not be satisfied")
+	if rt.Satisfied() {
+		t.Fatal("tracker with 0 retries should not be satisfied")
+	}
 
 	rt.TryCancelTemplate(&testConstraintTemplate) // 0 retries --> DELETE
 
@@ -138,15 +140,21 @@ func Test_ReadyTracker_TryCancelTemplate_Retries(t *testing.T) {
 		return rt.Populated()
 	}, "10s").Should(gomega.BeTrue())
 
-	g.Expect(rt.Satisfied()).NotTo(gomega.BeTrue(), "tracker with 2 retries should not be satisfied")
+	if rt.Satisfied() {
+		t.Fatal("tracker with 2 retries should not be satisfied")
+	}
 
 	rt.TryCancelTemplate(&testConstraintTemplate) // 2 --> 1 retries
 
-	g.Expect(rt.Satisfied()).NotTo(gomega.BeTrue(), "tracker with 1 retries should not be satisfied")
+	if rt.Satisfied() {
+		t.Fatal("tracker with 1 retries should not be satisfied")
+	}
 
 	rt.TryCancelTemplate(&testConstraintTemplate) // 1 --> 0 retries
 
-	g.Expect(rt.Satisfied()).NotTo(gomega.BeTrue(), "tracker with 0 retries should not be satisfied")
+	if rt.Satisfied() {
+		t.Fatal("tracker with 0 retries should not be satisfied")
+	}
 
 	rt.TryCancelTemplate(&testConstraintTemplate) // 0 retries --> DELETE
 

--- a/pkg/util/selfLink_test.go
+++ b/pkg/util/selfLink_test.go
@@ -3,13 +3,11 @@ package util
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestGetUniqueKey(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
 	gvk := schema.GroupVersionKind{
 		Group:   "constraints.gatekeeper.sh",
 		Version: "v1beta1",
@@ -26,5 +24,8 @@ func TestGetUniqueKey(t *testing.T) {
 		kind:     "myTemplate",
 		resource: "myConstraint",
 	}
-	g.Expect(key).To(gomega.Equal(expected))
+
+	if key != expected {
+		t.Fatalf("got key %q, want %q", key, expected)
+	}
 }

--- a/pkg/watch/manager_integration_test.go
+++ b/pkg/watch/manager_integration_test.go
@@ -133,7 +133,6 @@ func TestRegistrar_AddUnknown(t *testing.T) {
 // Verifies that controller-runtime interleaves reconcile errors in backoff and
 // other events within the same work queue.
 func Test_ReconcileErrorDoesNotBlockController(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
 	mgr, _ := setupManager(t)
 	ctrl.SetLogger(logf.NullLogger{})
 
@@ -183,7 +182,9 @@ func Test_ReconcileErrorDoesNotBlockController(t *testing.T) {
 		},
 		&handler.EnqueueRequestForObject{},
 	)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Wait for the error resource to reconcile
 	// before setting up another watch.
@@ -195,7 +196,9 @@ func Test_ReconcileErrorDoesNotBlockController(t *testing.T) {
 		&source.Kind{Type: &corev1.Namespace{}},
 		&handler.EnqueueRequestForObject{},
 	)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	expectNames := map[string]bool{"error": true, "default": true, "kube-system": true}
 loop:
@@ -338,10 +341,14 @@ func Test_Registrar_Replay(t *testing.T) {
 			},
 			&handler.EnqueueRequestForObject{},
 		)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		err = r.AddWatch(gvk)
-		g.Expect(err).NotTo(gomega.HaveOccurred())
+		if err != nil {
+			t.Fatal(err)
+		}
 
 		return requests
 	}

--- a/pkg/watch/manager_integration_test.go
+++ b/pkg/watch/manager_integration_test.go
@@ -104,7 +104,6 @@ func setupController(mgr manager.Manager, r reconcile.Reconciler, events chan ev
 
 // Verify that an unknown resource will return an error when adding a watch.
 func TestRegistrar_AddUnknown(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
 	mgr, wm := setupManager(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -117,14 +116,18 @@ func TestRegistrar_AddUnknown(t *testing.T) {
 
 	events := make(chan event.GenericEvent)
 	r, err := wm.NewRegistrar("test", events)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "creating registrar")
+	if err != nil {
+		t.Fatalf("creating registrar: %v", err)
+	}
 
 	err = r.AddWatch(schema.GroupVersionKind{
 		Group:   "i",
 		Version: "donot",
 		Kind:    "exist",
 	})
-	g.Expect(err).To(gomega.HaveOccurred(), "AddWatch should have failed due to unknown GVK")
+	if err == nil {
+		t.Fatalf("AddWatch should have failed due to unknown GVK")
+	}
 
 	cancel()
 	_ = grp.Wait()
@@ -240,7 +243,9 @@ func TestRegistrar_Reconnect(t *testing.T) {
 
 	events := make(chan event.GenericEvent)
 	r, err := wm.NewRegistrar("test", events)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "creating registrar")
+	if err != nil {
+		t.Fatalf("creating registrar: %v", err)
+	}
 
 	req := make(chan reconcile.Request)
 	rec := reconcile.Func(func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -251,7 +256,9 @@ func TestRegistrar_Reconnect(t *testing.T) {
 		return reconcile.Result{}, nil
 	})
 	err = setupController(mgr, rec, events)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "creating controller")
+	if err != nil {
+		t.Fatalf("creating controller: %v", err)
+	}
 
 	gvk := schema.GroupVersionKind{
 		Group:   "com.tests",
@@ -261,41 +268,58 @@ func TestRegistrar_Reconnect(t *testing.T) {
 	const plural = "testresources"
 	crd := makeCRD(gvk, plural)
 	err = applyCRD(ctx, g, c, gvk, crd)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "applying CRD")
+	if err != nil {
+		t.Fatalf("applying CRD: %v", err)
+	}
 
 	err = r.AddWatch(gvk)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "adding watch")
+	if err != nil {
+		t.Fatalf("adding watch: %v", err)
+	}
 
 	// Create watched resources
 	u := unstructuredFor(gvk, "test-add")
 	err = c.Create(ctx, u)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "creating watched resource")
+	if err != nil {
+		t.Fatalf("creating watched resource: %v", err)
+	}
 
 	// Wait for create event
 	<-req
 
 	// Delete the CRD with an active watch still enabled
 	err = c.Delete(ctx, crd)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "deleting CRD")
+	if err != nil {
+		t.Fatalf("deleting CRD: %v", err)
+	}
 
 	// We'll get a delete event for the resource (cascade delete from the parent CRD). Consume it.
 	<-req
 
 	// Verify the CRD is gone
 	err = waitForCRDToUnregister(ctx, mgr.GetConfig(), gvk, plural)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "waiting for CRD to unregister")
+	if err != nil {
+		t.Fatalf("waiting for CRD to unregister: %v", err)
+	}
 
 	// Create the CRD and resource again, expect our previous watch to pick them up automatically.
 	crd = makeCRD(gvk, plural)
 	err = applyCRD(ctx, g, c, gvk, crd)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "reapplying CRD")
+	if err != nil {
+		t.Fatalf("reapplying CRD: %v", err)
+	}
 	u = unstructuredFor(gvk, "test-add-again")
 	err = c.Create(ctx, u)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "recreating watched resource")
+	if err != nil {
+		t.Fatalf("recreating watched resource: %v", err)
+	}
 
 	// Wait for create event picked, up by our previous watch.
 	result := <-req
-	g.Expect(result.Name).Should(gomega.ContainSubstring("test-add-again"))
+	wantSubstr := "test-add-again"
+	if !strings.Contains(result.Name, wantSubstr) {
+		t.Fatalf("got result.Name = %q but want to contain %q", result, wantSubstr)
+	}
 
 	cancel()
 	_ = grp.Wait()
@@ -303,7 +327,6 @@ func TestRegistrar_Reconnect(t *testing.T) {
 
 // Verifies joined watches receive replayed events.
 func Test_Registrar_Replay(t *testing.T) {
-	g := gomega.NewGomegaWithT(t)
 	mgr, wm := setupManager(t)
 	c := testclient.NewRetryClient(mgr.GetClient())
 
@@ -317,7 +340,9 @@ func Test_Registrar_Replay(t *testing.T) {
 		events := make(chan event.GenericEvent, 1024)
 
 		r, err := wm.NewRegistrar(name, events)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "creating registrar")
+		if err != nil {
+			t.Fatalf("creating registrar: %v", err)
+		}
 
 		requests := make(chan reconcile.Request)
 		rec := func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -373,7 +398,9 @@ func Test_Registrar_Replay(t *testing.T) {
 			t.Fatalf("timout while creating fixtures")
 		}
 		err := c.Create(ctx, obj)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("creating fixture: %s", obj.GetName()))
+		if err != nil {
+			t.Fatalf("creating fixture: %s", obj.GetName())
+		}
 	}
 
 	// These should be received via watch events

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -557,7 +557,9 @@ func TestRegistrar_Duplicates_Rejected(t *testing.T) {
 	t.Cleanup(cancel)
 
 	_, err = wm.NewRegistrar("dup", make(chan event.GenericEvent, 1))
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 	_, err = wm.NewRegistrar("dup", make(chan event.GenericEvent, 1))
 	g.Expect(err).To(gomega.HaveOccurred(), "expected duplicate error")
 }
@@ -594,9 +596,13 @@ func TestRegistrar_ReplaceWatch(t *testing.T) {
 	t.Cleanup(cancel)
 
 	r1, err := wm.NewRegistrar("r1", make(chan event.GenericEvent))
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 	r2, err := wm.NewRegistrar("r2", make(chan event.GenericEvent))
-	g.Expect(err).NotTo(gomega.HaveOccurred())
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	pod := schema.GroupVersionKind{Version: "v1", Kind: "Pod"}
 	volume := schema.GroupVersionKind{Version: "v1", Kind: "Volume"}

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -546,7 +546,6 @@ func TestRegistrar_Replay_Async(t *testing.T) {
 
 // Verifies that registrar names must be unique.
 func TestRegistrar_Duplicates_Rejected(t *testing.T) {
-	g := gomega.NewWithT(t)
 	informer := &fakeCacheInformer{}
 	c := &fakeRemovableCache{informer: informer}
 	wm, cancel, err := setupWatchManager(c)
@@ -561,7 +560,9 @@ func TestRegistrar_Duplicates_Rejected(t *testing.T) {
 		t.Fatal(err)
 	}
 	_, err = wm.NewRegistrar("dup", make(chan event.GenericEvent, 1))
-	g.Expect(err).To(gomega.HaveOccurred(), "expected duplicate error")
+	if err == nil {
+		t.Fatalf("expected duplicate error")
+	}
 }
 
 // Verify ReplaceWatch replaces the set of watched resources for a registrar. New watches will be added,
@@ -612,18 +613,30 @@ func TestRegistrar_ReplaceWatch(t *testing.T) {
 	secret := schema.GroupVersionKind{Version: "v1", Kind: "Secret"}
 
 	err = r1.AddWatch(pod)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "initial pod watch")
+	if err != nil {
+		t.Fatalf("initial pod watch: %v", err)
+	}
 	err = r1.AddWatch(volume)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "initial volume watch")
+	if err != nil {
+		t.Fatalf("initial volume watch: %v", err)
+	}
 	err = r1.AddWatch(deploy)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "initial deployment watch")
+	if err != nil {
+		t.Fatalf("initial deployment watch: %v", err)
+	}
 
 	err = r2.AddWatch(volume)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "initial volume watch")
+	if err != nil {
+		t.Fatalf("initial volume watch: %v", err)
+	}
 	err = r2.AddWatch(configMap)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "initial configmap watch")
+	if err != nil {
+		t.Fatalf("initial configmap watch: %v", err)
+	}
 	err = r2.AddWatch(secret)
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "initial secret watch")
+	if err != nil {
+		t.Fatalf("initial secret watch: %v", err)
+	}
 
 	// Check initial counters
 	func() {
@@ -644,7 +657,9 @@ func TestRegistrar_ReplaceWatch(t *testing.T) {
 	// Pod overlaps between r1 and r2. Secret is retained. ConfigMap is swapped for Service.
 	// Volume originally overlapped between r1 and r2, but will be removed from r2.
 	err = r2.ReplaceWatch([]schema.GroupVersionKind{pod, service, secret})
-	g.Expect(err).NotTo(gomega.HaveOccurred(), "calling replaceWatch")
+	if err != nil {
+		t.Fatalf("calling replaceWatch: %v", err)
+	}
 
 	// Check final counters
 	func() {

--- a/pkg/watch/registrar.go
+++ b/pkg/watch/registrar.go
@@ -17,6 +17,7 @@ package watch
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -190,6 +191,10 @@ func (r *recordKeeper) GetGVK() []schema.GroupVersionKind {
 	for gvk := range g {
 		gvks = append(gvks, gvk)
 	}
+
+	sort.Slice(gvks, func(i, j int) bool {
+		return gvks[i].String() < gvks[j].String()
+	})
 	return gvks
 }
 


### PR DESCRIPTION
A lot of old test code uses gomega to do things that the standard Go testing library does well. Often this results in difficult-to-read and inconsistent tests. This PR removes the "unnecessary" uses of Gomega - calls to `g.Expect` directly within tests.

In several instances this obfuscated that some test assertions were being executed outside the thread of the test. Effectively, the test could pass while the assertion failed in the other thread as long as the test ended before the child thread ended. Normally static analysis catches this, but not when using gomega.

This makes tests simpler and more consistent across the repository, and faster.