### PR TITLE
refactor: Change `gator test` to `gator verify`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test-e2e:
 	bats -t ${BATS_TESTS_FILE}
 
 test-gator: bin/gator-${GOOS}-${GOARCH}
-	./bin/gator-${GOOS}-${GOARCH} test test/gator/suite.yaml
+	./bin/gator-${GOOS}-${GOARCH} verify test/gator/suite.yaml
 
 KIND_NODE_VERSION := kindest/node:v$(KUBERNETES_VERSION)
 e2e-bootstrap:

--- a/cmd/gator/gator.go
+++ b/cmd/gator/gator.go
@@ -3,14 +3,14 @@ package main
 import (
 	"os"
 
-	"github.com/open-policy-agent/gatekeeper/cmd/gator/test"
+	"github.com/open-policy-agent/gatekeeper/cmd/gator/verify"
 	"github.com/spf13/cobra"
 )
 
 const version = "alpha"
 
 func init() {
-	rootCmd.AddCommand(test.Cmd)
+	rootCmd.AddCommand(verify.Cmd)
 }
 
 var rootCmd = &cobra.Command{

--- a/cmd/gator/verify/verify.go
+++ b/cmd/gator/verify/verify.go
@@ -1,4 +1,4 @@
-package test
+package verify
 
 import (
 	"context"
@@ -16,20 +16,20 @@ import (
 
 const (
 	examples = `  # Run all tests in label-tests.yaml
-  gator test label-tests.yaml
+  gator verify label-tests.yaml
 
   # Run all tests whose names contain "forbid-labels".
-  gator test tests/... --run forbid-labels//
+  gator verify tests/... --run forbid-labels//
 
   # Run all cases whose names contain "nginx-deployment".
-  gator test tests/... --run //nginx-deployment
+  gator verify tests/... --run //nginx-deployment
 
   # Run all cases whose names exactly match "nginx-deployment".
-  gator test tests/... --run '//^nginx-deployment$'
+  gator verify tests/... --run '//^nginx-deployment$'
 
   # Run all cases that are either named "forbid-labels" or are
   # in tests named "forbid-labels".
-  gator test tests/... --run '^forbid-labels$'`
+  gator verify tests/... --run '^forbid-labels$'`
 )
 
 var (
@@ -44,10 +44,10 @@ func init() {
 		`print extended test output`)
 }
 
-// Cmd is the gator test subcommand.
+// Cmd is the gator verify subcommand.
 var Cmd = &cobra.Command{
-	Use:     "test path [--run=name]",
-	Short:   "test runs suites of tests on Gatekeeper Constraints",
+	Use:     "verify path [--run=name]",
+	Short:   "verify runs suites of tests on Gatekeeper Constraints",
 	Example: examples,
 	Args:    cobra.ExactArgs(1),
 	RunE:    runE,


### PR DESCRIPTION
In this week's community meeting, we discussed naming that would
differentiate the current `gator test` from a new command that validates
entire manifests against sets of policies (#1786).  We decided to align
gator's commands with the verbs used in conftest.

Accordingly, what has previously been known as `gator test` will be
henceforth called:

`gator verify`

This PR changes package names and the name of the command.  The
aforementioned PR will rebase on this PR to include the name changes.

Signed-off-by: juliankatz <juliankatz@google.com>
