### PR TITLE
Adding pci to labeler cops 357

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
 #This module configures the GitHub labeler to apply the “pci” label to all pci related changes automatically requiring a review.
 
 pci:
-- **/*
+- '**/*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+#This module configures the GitHub labeler to apply the “pci” label to all pci related changes automatically requiring a review.
+
+pci:
+- **/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: Pull Request Labeler
+
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Required for PCI change management. This PR will require all PRs to have a review before they are able to merge and will automatically add PCI label. 

This change is to Github actions. 
