### PR TITLE
Make gator test error when arguments are passed

### DIFF
--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -30,7 +30,9 @@ const (
   cat manifest.yaml | gator test
 
   # Output structured violations data
-  gator test --filename="manifest.yaml" --output=json`
+  gator test --filename="manifest.yaml" --output=json
+
+  Note: The alpha "gator test" has been renamed to "gator verify"`
 )
 
 var Cmd = &cobra.Command{
@@ -38,6 +40,7 @@ var Cmd = &cobra.Command{
 	Short:   "test evaluates resources against policies as defined by constraint templates and constraints. Note: The alpha `gator test` has been renamed to `gator verify`.",
 	Example: examples,
 	Run:     run,
+	Args:    cobra.NoArgs,
 }
 
 var allowedExtensions = []string{".yaml", ".yml", ".json"}


### PR DESCRIPTION
With the replacement of the original `gator test` with the new command
(the original `gator test` now being called `gator verify`), we have
introduced an opportunity for user confusion.  We added some information
to help our users avoid problems in a previous PR: #1836

This PR seeks to further assist users by adding some argument validation
and more --help information.  More specifically, now we forbid arguments
from being passed to the `gator test` command.  This will yield an error
and the "help" message will be printed.  That help message now also
contains a reference to the renaming.

This is useful b/c the usage of `gator verify` _requires_ the use of
positional arguments, where `gator test` _forbids_ them.  This means
that users will fail fast and will be better guided towards the
solution.

Fix #1835

Signed-off-by: juliankatz <juliankatz@google.com>
