### PR TITLE
fix: Allow to set affinity, nodeSelector and tolerations for upgradeCRDs

### DIFF
--- a/charts/gatekeeper/templates/upgrade-crds-hook.yaml
+++ b/charts/gatekeeper/templates/upgrade-crds-hook.yaml
@@ -98,7 +98,11 @@ spec:
           runAsGroup: 65532
           runAsNonRoot: true
           runAsUser: 65532
+      affinity:
+        {{- toYaml .Values.upgradeCRDs.affinity | nindent 8 }}
       nodeSelector:
-        kubernetes.io/os: linux
+        {{- toYaml .Values.upgradeCRDs.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.upgradeCRDs.tolerations | nindent 8 }}
 
 {{- end }}

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -94,6 +94,7 @@ disabledBuiltins:
 psp:
   enabled: true
 upgradeCRDs:
+  nodeSelector: { kubernetes.io/os: linux }
   enabled: true
 rbac:
   create: true


### PR DESCRIPTION
**What this PR does / why we need it**:

It wasn't possible to set affinity, nodeSelector and tolerations for upgradeCRDs through the values file. This leads to a deployment error. The modifications I've made fix that issue.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:

I'm currently using a local copy of this chart, would be nice if we could get this merged, so I can switch to the official chart again.