### PR TITLE
fix: Support nodeSelector, affinity, tolerations with labelNamespace job

### DIFF
--- a/charts/gatekeeper/templates/namespace-post-install.yaml
+++ b/charts/gatekeeper/templates/namespace-post-install.yaml
@@ -26,8 +26,12 @@ spec:
       {{- .Values.postInstall.labelNamespace.image.pullSecrets | toYaml | nindent 12 }}
       {{- end }}
       serviceAccount: gatekeeper-update-namespace-label
+      affinity:
+        {{- toYaml .Values.postInstall.labelNamespace.affinity | nindent 8 }}
       nodeSelector:
-        kubernetes.io/os: linux
+        {{- toYaml .Values.postInstall.labelNamespace.nodeSelector | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.postInstall.labelNamespace.tolerations | nindent 8 }}
       containers:
         - name: kubectl-label
           image: "{{ .Values.postInstall.labelNamespace.image.repository }}:{{ .Values.postInstall.labelNamespace.image.tag }}"

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -21,6 +21,7 @@ resourceQuota: true
 postInstall:
   labelNamespace:
     enabled: true
+    nodeSelector: { kubernetes.io/os: linux }
     image:
       repository: openpolicyagent/gatekeeper-crds
       tag: v3.7.0
@@ -97,3 +98,4 @@ upgradeCRDs:
   enabled: true
 rbac:
   create: true
+


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously it wasn't possible to add nodeSelector/affinity/tolerations to the labelNamespace job. This PR will add support to customize these settings.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1686

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
