### PR TITLE
docs: Correct slack channel name to 'opa-gatekeeper'

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See the [Gatekeeper policy library](https://www.github.com/open-policy-agent/gat
 
 Join us to help define the direction and implementation of this project!
 
-- Join the [`#kubernetes-policy`](https://openpolicyagent.slack.com/messages/CDTN970AX)
+- Join the [`#opa-gatekeeper`](https://openpolicyagent.slack.com/messages/CDTN970AX)
   channel on [OPA Slack](https://slack.openpolicyagent.org/).
 
 - Join [weekly meetings](https://docs.google.com/document/d/1A1-Q-1OMw3QODs1wT6eqfLTagcGmgzAJAjJihiO3T48/edit)


### PR DESCRIPTION
**What this PR does / why we need it**:

Minor fix on name of slack channel
Fixes #1868


**Special notes for your reviewer**:
This repo appears to be missing a contribution guide so tried to match commit message with existing ones