### PR TITLE
fix uninstall version typo

### DIFF
--- a/website/versioned_docs/version-v3.7.x/install.md
+++ b/website/versioned_docs/version-v3.7.x/install.md
@@ -89,7 +89,7 @@ You can alter the variables in `charts/gatekeeper/values.yaml` to customize your
 If you used a prebuilt image to deploy Gatekeeper, then you can delete all the Gatekeeper components with the following command:
 
   ```sh
-  kubectl delete -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.5/deploy/gatekeeper.yaml
+  kubectl delete -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/release-3.7/deploy/gatekeeper.yaml
   ```
 
 ### Using make


### PR DESCRIPTION
It Fixes the typo in the uninstall command. 

Any new objects created in 3.7(compared to 3.5) will not be deleted. this addresses that.