### PR TITLE
test: Fix `BenchmarkValidationHandler` was broken

### DIFF
--- a/pkg/webhook/testdata/psp-all-violations/psp-templates/host-filesystem-template.yaml
+++ b/pkg/webhook/testdata/psp-all-violations/psp-templates/host-filesystem-template.yaml
@@ -10,6 +10,7 @@ spec:
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:
+          type: object
           properties:
             allowedHostPaths:
               type: array

--- a/pkg/webhook/testdata/psp-all-violations/psp-templates/host-namespace-template.yaml
+++ b/pkg/webhook/testdata/psp-all-violations/psp-templates/host-namespace-template.yaml
@@ -7,6 +7,10 @@ spec:
     spec:
       names:
         kind: K8sPSPHostNamespace
+      validation:
+        # Schema for the `parameters` field
+        openAPIV3Schema:
+          type: object
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/pkg/webhook/testdata/psp-all-violations/psp-templates/host-network-ports-template.yaml
+++ b/pkg/webhook/testdata/psp-all-violations/psp-templates/host-network-ports-template.yaml
@@ -10,6 +10,7 @@ spec:
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:
+          type: object
           properties:
             hostNetwork:
               type: boolean

--- a/pkg/webhook/testdata/psp-all-violations/psp-templates/privileged-containers-template.yaml
+++ b/pkg/webhook/testdata/psp-all-violations/psp-templates/privileged-containers-template.yaml
@@ -7,6 +7,10 @@ spec:
     spec:
       names:
         kind: K8sPSPPrivilegedContainer
+        validation:
+          # Schema for the `parameters` field
+          openAPIV3Schema:
+            type: object
   targets:
     - target: admission.k8s.gatekeeper.sh
       rego: |

--- a/pkg/webhook/testdata/psp-all-violations/psp-templates/volume-template.yaml
+++ b/pkg/webhook/testdata/psp-all-violations/psp-templates/volume-template.yaml
@@ -10,6 +10,7 @@ spec:
       validation:
         # Schema for the `parameters` field
         openAPIV3Schema:
+          type: object
           properties:
             volumes:
               type: array


### PR DESCRIPTION
**What this PR does / why we need it**:

The benchmark test `BenchmarkValidationHandler` was broken:

Before:

```
$ go test ./pkg/webhook/... -test.bench ^BenchmarkValidationHandler$
goos: darwin
goarch: amd64
pkg: github.com/open-policy-agent/gatekeeper/pkg/webhook
cpu: xxx
BenchmarkValidationHandler/psp:_100%_violations-8                   2634            443209 ns/op
BenchmarkValidationHandler/psp:_100%_violations#01-8                2894            417978 ns/op
BenchmarkValidationHandler/psp:_100%_violations#02-8                2840            411070 ns/op
BenchmarkValidationHandler/psp:_100%_violations#03-8                2733            413003 ns/op
BenchmarkValidationHandler/psp:_100%_violations#04-8                2858            415405 ns/op
BenchmarkValidationHandler/psp:_100%_violations#05-8                2708            410037 ns/op
BenchmarkValidationHandler/psp:_100%_violations#06-8                2790            417943 ns/op
--- FAIL: BenchmarkValidationHandler
    policy_benchmark_test.go:300: test psp: 100% violations, failed to load templates into OPA: invalid ConstraintTemplate: spec.validation.openAPIV3Schema.properties[spec].properties[parameters].type: Required value: must not be empty for specified object fields
    policy_benchmark_test.go:305: test psp: 100% violations, failed to load constraints into OPA: missing ConstraintTemplate: Constraint kind "K8sPSPHostFilesystem" is not recognized, known kinds []
    policy_benchmark_test.go:300: test psp: 100% violations, failed to load templates into OPA: invalid ConstraintTemplate: spec.validation.openAPIV3Schema.properties[spec].properties[parameters].type: Required value: must not be empty for specified object fields
    policy_benchmark_test.go:305: test psp: 100% violations, failed to load constraints into OPA: missing ConstraintTemplate: Constraint kind "K8sPSPHostFilesystem" is not recognized, known kinds []
    policy_benchmark_test.go:300: test psp: 100% violations, failed to load templates into OPA: invalid ConstraintTemplate: spec.validation.openAPIV3Schema.properties[spec].properties[parameters].type: Required value: must not be empty for specified object fields
    policy_benchmark_test.go:305: test psp: 100% violations, failed to load constraints into OPA: missing ConstraintTemplate: Constraint kind "K8sPSPHostFilesystem" is not recognized, known kinds []
    policy_benchmark_test.go:300: test psp: 100% violations, failed to load templates into OPA: invalid ConstraintTemplate: spec.validation.openAPIV3Schema.properties[spec].properties[parameters].type: Required value: must not be empty for specified object fields
    policy_benchmark_test.go:305: test psp: 100% violations, failed to load constraints into OPA: missing ConstraintTemplate: Constraint kind "K8sPSPHostFilesystem" is not recognized, known kinds []
    policy_benchmark_test.go:300: test psp: 100% violations, failed to load templates into OPA: invalid ConstraintTemplate: spec.validation.openAPIV3Schema.properties[spec].properties[parameters].type: Required value: must not be empty for specified object fields
    policy_benchmark_test.go:305: test psp: 100% violations, failed to load constraints into OPA: missing ConstraintTemplate: Constraint kind "K8sPSPHostFilesystem" is not recognized, known kinds []
    policy_benchmark_test.go:300: test psp: 100% violations, failed to load templates into OPA: invalid ConstraintTemplate: spec.validation.openAPIV3Schema.properties[spec].properties[parameters].type: Required value: must not be empty for specified object fields
    policy_benchmark_test.go:305: test psp: 100% violations, failed to load constraints into OPA: missing ConstraintTemplate: Constraint kind "K8sPSPHostFilesystem" is not recognized, known kinds []
    policy_benchmark_test.go:300: test psp: 100% violations, failed to load templates into OPA: invalid ConstraintTemplate: spec.validation.openAPIV3Schema.properties[spec].properties[parameters].type: Required value: must not be empty for specified object fields
    policy_benchmark_test.go:305: test psp: 100% violations, failed to load constraints into OPA: missing ConstraintTemplate: Constraint kind "K8sPSPHostFilesystem" is not recognized, known kinds []
FAIL
exit status 1
FAIL    github.com/open-policy-agent/gatekeeper/pkg/webhook     10.912s
FAIL
```

After:

```
$ go test ./pkg/webhook/... -test.bench ^BenchmarkValidationHandler$
goos: darwin
goarch: amd64
pkg: github.com/open-policy-agent/gatekeeper/pkg/webhook
cpu: xxx
BenchmarkValidationHandler/psp:_100%_violations-8                    410           2907914 ns/op
BenchmarkValidationHandler/psp:_100%_violations#01-8                 282           4305184 ns/op
BenchmarkValidationHandler/psp:_100%_violations#02-8                  63          15874591 ns/op
BenchmarkValidationHandler/psp:_100%_violations#03-8                  33          32363133 ns/op
BenchmarkValidationHandler/psp:_100%_violations#04-8                  19          58677058 ns/op
BenchmarkValidationHandler/psp:_100%_violations#05-8                   4         284555432 ns/op
BenchmarkValidationHandler/psp:_100%_violations#06-8                   2         593391864 ns/op
PASS
ok      github.com/open-policy-agent/gatekeeper/pkg/webhook     15.577s

```


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
#1761

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
