### PR TITLE
test: Fix `BenchmarkModifySetMutator_Mutate` was broken

### DIFF
--- a/pkg/mutation/mutators/modifyset/modify_set_mutator_benchmark_test.go
+++ b/pkg/mutation/mutators/modifyset/modify_set_mutator_benchmark_test.go
@@ -1,7 +1,6 @@
 package modifyset
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -10,19 +9,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/match"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/tester"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 )
-
-func makeValue(v interface{}) runtime.RawExtension {
-	v2 := map[string]interface{}{
-		"value": v,
-	}
-	j, err := json.Marshal(v2)
-	if err != nil {
-		panic(err)
-	}
-	return runtime.RawExtension{Raw: j}
-}
 
 func modifyset(value interface{}, location string) *unversioned.ModifySet {
 	result := &unversioned.ModifySet{
@@ -34,8 +21,9 @@ func modifyset(value interface{}, location string) *unversioned.ModifySet {
 			}},
 			Location: location,
 			Parameters: unversioned.ModifySetParameters{
+				Operation: unversioned.MergeOp,
 				Values: unversioned.Values{
-					FromList: []interface{}{makeValue(value)},
+					FromList: []interface{}{value},
 				},
 			},
 		},


### PR DESCRIPTION


**What this PR does / why we need it**:

The benchmark test `BenchmarkModifySetMutator_Mutate` was broken:

Before:

```
$ go test ./pkg/mutation/mutators/modifyset/... -bench ^BenchmarkModifySetMutator_Mutate$
panic: cannot deep copy runtime.RawExtension

goroutine 98 [running]:
k8s.io/apimachinery/pkg/runtime.DeepCopyJSONValue({0x1ee51a0, 0xc0004e4150})
        /xxx/src/github.com/open-policy-agent/gatekeeper/vendor/k8s.io/apimachinery/pkg/runtime/converter.go:639 +0x273
github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned.(*Values).DeepCopyInto(0xc000337860, 0xc000337ce0)
        /xxx/src/github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned/modifyset_types.go:107 +0xd0
github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned.(*ModifySetParameters).DeepCopyInto(0xc000337838, 0xc000337cb8)
        /xxx/src/github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned/zz_generated.deepcopy.go:354 +0xe5
github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned.(*ModifySetSpec).DeepCopyInto(0xc000337798, 0xc000337c18)
        /xxx/src/github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned/zz_generated.deepcopy.go:378 +0xf4
github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned.(*ModifySet).DeepCopyInto(0xc000337680, 0xc000337b00)
        /xxx/src/github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned/zz_generated.deepcopy.go:292 +0xe5
github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned.(*ModifySet).DeepCopy(...)
        /xxx/src/github.com/open-policy-agent/gatekeeper/apis/mutations/unversioned/zz_generated.deepcopy.go:302
github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset.MutatorForModifySet(0xc000337680)
        /xxx/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset/modify_set_mutator.go:171 +0x565
github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset.benchmarkModifySetMutator(0xc0003366c0, 0x1)
        /xxx/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset/modify_set_mutator_benchmark_test.go:48 +0x6e
github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset.BenchmarkModifySetMutator_Mutate.func1(0xc0003366c0)
        /xxx/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset/modify_set_mutator_benchmark_test.go:106 +0x25
testing.(*B).runN(0xc0003366c0, 0x1)
        /xxx/src/testing/benchmark.go:192 +0x126
testing.(*B).run1.func1()
        /xxx/src/testing/benchmark.go:232 +0x59
created by testing.(*B).run1
        /xxx/src/testing/benchmark.go:225 +0xa5
exit status 2
FAIL    github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset 0.042s
FAIL

```

After:


```
$ go test ./pkg/mutation/mutators/modifyset/... -bench ^BenchmarkModifySetMutator_Mutate$
goos: darwin
goarch: amd64
pkg: github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset
cpu: xxx
BenchmarkModifySetMutator_Mutate/always_mutate_1-depth-8                 1176950              1066 ns/op
BenchmarkModifySetMutator_Mutate/always_mutate_2-depth-8                 1000000              1072 ns/op
BenchmarkModifySetMutator_Mutate/always_mutate_5-depth-8                 1000000              1375 ns/op
BenchmarkModifySetMutator_Mutate/always_mutate_10-depth-8                 814732              1353 ns/op
BenchmarkModifySetMutator_Mutate/always_mutate_20-depth-8                 712807              1697 ns/op
BenchmarkModifySetMutator_Mutate/never_mutate_1-depth-8                  3822511               315.9 ns/op
BenchmarkModifySetMutator_Mutate/never_mutate_2-depth-8                  3447248               345.6 ns/op
BenchmarkModifySetMutator_Mutate/never_mutate_5-depth-8                  2873970               414.7 ns/op
BenchmarkModifySetMutator_Mutate/never_mutate_10-depth-8                 2293888               544.3 ns/op
BenchmarkModifySetMutator_Mutate/never_mutate_20-depth-8                 1532072               749.6 ns/op
PASS
ok      github.com/open-policy-agent/gatekeeper/pkg/mutation/mutators/modifyset 16.459s

```


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

#1761

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
