### PR TITLE
fix: do a audit run when we deploy

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -549,6 +549,10 @@ func (am *Manager) readUnstructured(jsonBytes []byte) (*unstructured.Unstructure
 }
 
 func (am *Manager) auditManagerLoop(ctx context.Context) {
+	// do an initial run so we get fast feedback on fresh deploys
+	am.auditAndLog(ctx)
+
+	// start a ticker to do a run every auditInterval
 	ticker := time.NewTicker(time.Duration(*auditInterval) * time.Second)
 	defer ticker.Stop()
 	for {
@@ -558,10 +562,14 @@ func (am *Manager) auditManagerLoop(ctx context.Context) {
 			close(am.stopper)
 			return
 		case <-ticker.C:
-			if err := am.audit(ctx); err != nil {
-				log.Error(err, "audit manager audit() failed")
-			}
+			am.auditAndLog(ctx)
 		}
+	}
+}
+
+func (am *Manager) auditAndLog(ctx context.Context) {
+	if err := am.audit(ctx); err != nil {
+		log.Error(err, "audit manager audit() failed")
 	}
 }
 


### PR DESCRIPTION
when we deploy we have to wait 15 min to get a new audit, that is a long time to wait and means that our feedback loop for "you deployed something bad" does not kick in fast enough and causes 15min of pain to our end-users if a new constraint was bad (we deploy web+audit together)

so fix this by running the audit once on start

ticker does not have an option to do an initial runs as per  https://github.com/golang/go/issues/17601

/cc @ritazh @sozercan @ctab 