### PR TITLE
fix: match helm mwh timeout default value

### DIFF
--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -16,7 +16,7 @@ enableTLSHealthcheck: false
 mutatingWebhookFailurePolicy: Ignore
 mutatingWebhookReinvocationPolicy: Never
 mutatingWebhookExemptNamespacesLabels: {}
-mutatingWebhookTimeoutSeconds: 3
+mutatingWebhookTimeoutSeconds: 1
 mutatingWebhookCustomRules: {}
 mutationAnnotations: false
 auditChunkSize: 500

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -16,7 +16,7 @@ enableTLSHealthcheck: false
 mutatingWebhookFailurePolicy: Ignore
 mutatingWebhookReinvocationPolicy: Never
 mutatingWebhookExemptNamespacesLabels: {}
-mutatingWebhookTimeoutSeconds: 3
+mutatingWebhookTimeoutSeconds: 1
 mutatingWebhookCustomRules: {}
 mutationAnnotations: false
 auditChunkSize: 500


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
Match Helm's mwh timeout with yaml (https://github.com/open-policy-agent/gatekeeper/blob/master/deploy/gatekeeper.yaml#L2531)

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
