### PR TITLE
revert: "do a audit run when we deploy (#1901)"

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -549,10 +549,6 @@ func (am *Manager) readUnstructured(jsonBytes []byte) (*unstructured.Unstructure
 }
 
 func (am *Manager) auditManagerLoop(ctx context.Context) {
-	// do an initial run so we get fast feedback on fresh deploys
-	am.auditAndLog(ctx)
-
-	// start a ticker to do a run every auditInterval
 	ticker := time.NewTicker(time.Duration(*auditInterval) * time.Second)
 	defer ticker.Stop()
 	for {
@@ -562,14 +558,10 @@ func (am *Manager) auditManagerLoop(ctx context.Context) {
 			close(am.stopper)
 			return
 		case <-ticker.C:
-			am.auditAndLog(ctx)
+			if err := am.audit(ctx); err != nil {
+				log.Error(err, "audit manager audit() failed")
+			}
 		}
-	}
-}
-
-func (am *Manager) auditAndLog(ctx context.Context) {
-	if err := am.audit(ctx); err != nil {
-		log.Error(err, "audit manager audit() failed")
 	}
 }
 


### PR DESCRIPTION
Reverting due to #1927

This reverts commit a3d8a0dd9b2d94f3d4a28fc11c7f5e43e1d15e64.

Signed-off-by: Max Smythe <smythe@google.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
