### PR TITLE
fix: fix race condition in mutator controller reconcile

### DIFF
--- a/pkg/mutation/schema/schema.go
+++ b/pkg/mutation/schema/schema.go
@@ -188,8 +188,8 @@ func (db *DB) HasConflicts(id types.ID) bool {
 
 func (db *DB) GetConflicts(id types.ID) IDSet {
 	db.mutex.RLock()
+	defer db.mutex.RUnlock()
 	mutator, ok := db.cachedMutators[id]
-	db.mutex.RUnlock()
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Before:

```
=== RUN   Test_Assign
    core.go: ...
==================
WARNING: DATA RACE
Write at 0x00c001438aa8 by goroutine 305:
  github.com/open-policy-agent/gatekeeper/pkg/mutation/schema.(*node).Add()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/schema/node.go:63 +0x6c9
  github.com/open-policy-agent/gatekeeper/pkg/mutation/schema.(*DB).upsert()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/schema/schema.go:108 +0x7d9
  github.com/open-policy-agent/gatekeeper/pkg/mutation/schema.(*DB).Upsert()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/schema/schema.go:78 +0xd6
  github.com/open-policy-agent/gatekeeper/pkg/mutation.(*System).Upsert()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/system.go:92 +0x405
  github.com/open-policy-agent/gatekeeper/pkg/controller/mutators/core.(*Reconciler).reconcileUpsert()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/controller/mutators/core/reconciler.go:170 +0x3c9
  github.com/open-policy-agent/gatekeeper/pkg/controller/mutators/core.(*Reconciler).Reconcile()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/controller/mutators/core/reconciler.go:131 +0x6cf
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114 +0x39b
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311 +0x43a
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266 +0x350
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227 +0xd7

Previous read at 0x00c001438aa8 by goroutine 129:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  github.com/open-policy-agent/gatekeeper/pkg/mutation/schema.(*DB).GetConflicts()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/schema/schema.go:199 +0x2e4
  github.com/open-policy-agent/gatekeeper/pkg/mutation.(*System).GetConflicts()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/mutation/system.go:129 +0x77b
  github.com/open-policy-agent/gatekeeper/pkg/controller/mutators/core.(*Reconciler).Reconcile()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/controller/mutators/core/reconciler.go:138 +0x6d9
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:114 +0x39b
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:311 +0x43a
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:266 +0x350
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:227 +0xd7

Goroutine 305 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:223 +0x4e4
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234 +0x2b5
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go:218 +0x1cb
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile·dwrap·12()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go:221 +0x47

Goroutine 129 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:223 +0x4e4
  sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:234 +0x2b5
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go:218 +0x1cb
  sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile·dwrap·12()
      /go/src/github.com/open-policy-agent/gatekeeper/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go:221 +0x47
==================
    core.go: ...
    testing.go:1152: race detected during execution of test
--- FAIL: Test_Assign (1.37s)
```

After:

```
--- PASS: Test_Assign (1.41s)
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

#1929

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
