### PR TITLE
fix: fix race condition in TestPrometheusExporter

### DIFF
--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -76,8 +76,9 @@ func (r *runner) shutdownMetricsExporter(ctx context.Context) error {
 	switch mb {
 	case prometheusExporter:
 		log.Info("shutting down prometheus server")
-		if curPromSrv != nil {
-			if err := curPromSrv.Shutdown(ctx); err != nil {
+		srv := curPromSrv.Srv()
+		if srv != nil {
+			if err := srv.Shutdown(ctx); err != nil {
 				return err
 			}
 		}

--- a/pkg/metrics/prometheus_exporter_test.go
+++ b/pkg/metrics/prometheus_exporter_test.go
@@ -26,7 +26,8 @@ func TestPrometheusExporter(t *testing.T) {
 	}()
 
 	time.Sleep(100 * time.Millisecond)
-	if curPromSrv.Addr != expectedAddr {
-		t.Errorf("Expected address %v but got %v", expectedAddr, curPromSrv.Addr)
+	srv := curPromSrv.Srv()
+	if srv.Addr != expectedAddr {
+		t.Errorf("Expected address %v but got %v", expectedAddr, srv.Addr)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Before:

```
=== RUN   TestPrometheusExporter
==================
WARNING: DATA RACE
Read at 0x00000353cec0 by goroutine 42:
  github.com/open-policy-agent/gatekeeper/pkg/metrics.TestPrometheusExporter()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/metrics/prometheus_exporter_test.go:29 +0xba
  testing.tRunner()
      /go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /go/src/testing/testing.go:1306 +0x47

Previous write at 0x00000353cec0 by goroutine 43:
  github.com/open-policy-agent/gatekeeper/pkg/metrics.startNewPromSrv()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/metrics/prometheus_exporter.go:44 +0x184
  github.com/open-policy-agent/gatekeeper/pkg/metrics.newPrometheusExporter()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/metrics/prometheus_exporter.go:32 +0x24f
  github.com/open-policy-agent/gatekeeper/pkg/metrics.TestPrometheusExporter.func1()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/metrics/prometheus_exporter_test.go:12 +0x2f

Goroutine 42 (running) created at:
  testing.(*T).Run()
      /go/src/testing/testing.go:1306 +0x726
  testing.runTests.func1()
      /go/src/testing/testing.go:1598 +0x99
  testing.tRunner()
      /go/src/testing/testing.go:1259 +0x22f
  testing.runTests()
      /go/src/testing/testing.go:1596 +0x7ca
  testing.(*M).Run()
      /go/src/testing/testing.go:1504 +0x9d1
  main.main()
      _testmain.go:45 +0x22b

Goroutine 43 (running) created at:
  github.com/open-policy-agent/gatekeeper/pkg/metrics.TestPrometheusExporter()
      /go/src/github.com/open-policy-agent/gatekeeper/pkg/metrics/prometheus_exporter_test.go:11 +0xa4
  testing.tRunner()
      /go/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /go/src/testing/testing.go:1306 +0x47
==================
...
    testing.go:1152: race detected during execution of test
--- FAIL: TestPrometheusExporter (0.10s)
```

After:

```
=== RUN   TestPrometheusExporter
--- PASS: TestPrometheusExporter (0.10s)
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

#1929

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
