### PR TITLE
fix: update gatekeeper_mutators metrics when a mutator is deleted

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -83,17 +83,34 @@ def build_crds():
 # deploy_gatekeeper defines the deploy process for the gatekeeper chart from manifest_staging/charts/gatekeeper.
 def deploy_gatekeeper():
     local("kubectl create namespace gatekeeper-system || true")
+
+    helm_values = settings.get("helm_values", {})
     k8s_yaml(helm(
         ".tiltbuild/charts/gatekeeper",
         name="gatekeeper",
         namespace="gatekeeper-system",
         values=[".tiltbuild/charts/gatekeeper/values.yaml"],
-        set=["{}={}".format(k, str(v).lower()) for k, v in settings.get("helm_values", []).items()],
+        set=["{}={}".format(k, str(v).lower()) for k, v in helm_values.items()],
     ))
 
     # add label to resources
     for resource in ["gatekeeper-audit", "gatekeeper-controller-manager", "gatekeeper-update-namespace-label", "gatekeeper-update-crds-hook"]:
         k8s_resource(resource, labels=["controllers"])
+
+    # port-foward the metrics server
+    if "audit.metricsPort" in helm_values:
+        port = int(helm_values["audit.metricsPort"])
+        k8s_resource(
+            workload="gatekeeper-audit",
+            port_forwards=[port_forward(port, name="View metrics", link_path="/metrics")],
+        )
+
+    if "controllerManager.metricsPort" in helm_values:
+        port = int(helm_values["controllerManager.metricsPort"])
+        k8s_resource(
+            workload="gatekeeper-controller-manager",
+            port_forwards=[port_forward(port, name="View metrics", link_path="/metrics")],
+        )
 
 build_manager()
 

--- a/pkg/controller/mutators/cache.go
+++ b/pkg/controller/mutators/cache.go
@@ -46,7 +46,10 @@ func (c *Cache) TallyStatus() map[MutatorIngestionStatus]int {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
 
-	statusTally := make(map[MutatorIngestionStatus]int)
+	statusTally := map[MutatorIngestionStatus]int{
+		MutatorStatusActive: 0,
+		MutatorStatusError:  0,
+	}
 	for _, status := range c.cache {
 		statusTally[status.ingestion]++
 	}

--- a/pkg/controller/mutators/cache_test.go
+++ b/pkg/controller/mutators/cache_test.go
@@ -1,0 +1,76 @@
+package mutators
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
+)
+
+func TestCache_TallyStatus(t *testing.T) {
+	type fields struct {
+		cache map[types.ID]mutatorStatus
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   map[MutatorIngestionStatus]int
+	}{
+		{
+			name: "empty cache",
+			fields: fields{
+				cache: make(map[types.ID]mutatorStatus),
+			},
+			want: map[MutatorIngestionStatus]int{
+				MutatorStatusActive: 0,
+				MutatorStatusError:  0,
+			},
+		},
+		{
+			name: "one active mutator",
+			fields: fields{
+				cache: map[types.ID]mutatorStatus{
+					{Name: "foo"}: {
+						ingestion: MutatorStatusActive,
+					},
+				},
+			},
+			want: map[MutatorIngestionStatus]int{
+				MutatorStatusActive: 1,
+				MutatorStatusError:  0,
+			},
+		},
+		{
+			name: "two active mutators and one erroneous mutator",
+			fields: fields{
+				cache: map[types.ID]mutatorStatus{
+					{Name: "foo"}: {
+						ingestion: MutatorStatusActive,
+					},
+					{Name: "bar"}: {
+						ingestion: MutatorStatusActive,
+					},
+					{Name: "baz"}: {
+						ingestion: MutatorStatusError,
+					},
+				},
+			},
+			want: map[MutatorIngestionStatus]int{
+				MutatorStatusActive: 2,
+				MutatorStatusError:  1,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Cache{
+				cache: tt.fields.cache,
+				mux:   sync.RWMutex{},
+			}
+			if got := c.TallyStatus(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Cache.TallyStatus() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -117,6 +117,48 @@ Below are the list of metrics provided by Gatekeeper:
 
     Aggregation: `LastValue`
 
+## Mutation
+
+- Name: `gatekeeper_mutator_ingestion_count`
+
+    Description: `Total number of Mutator ingestion actions`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Count`
+
+- Name: `gatekeeper_mutator_ingestion_duration_seconds`
+
+    Description: `The distribution of Mutator ingestion durations`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Distribution`
+
+- Name: `gatekeeper_mutators`
+
+    Description: `The current number of Mutator objects`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Count`
+
+- Name: `gatekeeper_mutator_conflicting_count`
+
+    Description: `The current number of conflicting Mutator objects`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Count`
+
 ## Sync
 
 - Name: `gatekeeper_sync`

--- a/website/versioned_docs/version-v3.6.x/metrics.md
+++ b/website/versioned_docs/version-v3.6.x/metrics.md
@@ -117,6 +117,38 @@ Below are the list of metrics provided by Gatekeeper:
 
     Aggregation: `LastValue`
 
+## Mutation
+
+- Name: `gatekeeper_mutator_ingestion_count`
+
+    Description: `Total number of Mutator ingestion actions`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Count`
+
+- Name: `gatekeeper_mutator_ingestion_duration_seconds`
+
+    Description: `The distribution of Mutator ingestion durations`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Distribution`
+
+- Name: `gatekeeper_mutators`
+
+    Description: `The current number of Mutator objects`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Count`
+
 ## Sync
 
 - Name: `gatekeeper_sync`

--- a/website/versioned_docs/version-v3.7.x/metrics.md
+++ b/website/versioned_docs/version-v3.7.x/metrics.md
@@ -117,6 +117,38 @@ Below are the list of metrics provided by Gatekeeper:
 
     Aggregation: `LastValue`
 
+## Mutation
+
+- Name: `gatekeeper_mutator_ingestion_count`
+
+    Description: `Total number of Mutator ingestion actions`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Count`
+
+- Name: `gatekeeper_mutator_ingestion_duration_seconds`
+
+    Description: `The distribution of Mutator ingestion durations`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Distribution`
+
+- Name: `gatekeeper_mutators`
+
+    Description: `The current number of Mutator objects`
+
+    Tags:
+
+    - `status`: [`active`, `error`]
+
+    Aggregation: `Count`
+
 ## Sync
 
 - Name: `gatekeeper_sync`


### PR DESCRIPTION
**What this PR does / why we need it**:

We incorrectly upserted mutator ingestion status when the user deleted a mutator, causing the metrics to report an incorrect number of mutators. This PR:

- moves `r.cache.Upsert` from `reportMutator` to `Reconcile`
- initializes all keys in `statusTally` map to 0 in `TallyStatus()` instead of creating an empty map so we can correctly reset the metrics if we remove all mutators
- updates metrics documentation
- performs metrics port-forwarding in Tiltfile if metrics port(s) is defined in `tilt-settings.json`


Example:

```
$ kubectl apply -f test.yaml 
assignmetadata.mutations.gatekeeper.sh/demo-annotation-owner created
```

Metrics:

```
gatekeeper_mutators{status="active"} 1
gatekeeper_mutators{status="error"} 0
```

```
$ kubectl delete -f test.yaml 
assignmetadata.mutations.gatekeeper.sh "demo-annotation-owner" deleted
```

Metrics:

```
gatekeeper_mutators{status="active"} 0
gatekeeper_mutators{status="error"} 0
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1925

<!--
**Are you making changes to Gatekeeper Helm chart?**
Helm chart is auto-generated in Gatekeeper. If you have any changes in `charts` directory, they will get clobbered when we do a new release. Please see [contributing changes doc](charts/../../charts/gatekeeper/README.md#contributing-changes) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Gatekeeper auto-generates versioned docs. If you have any doc changes for a particular version, please update in `website/docs` as well as in `website/versioned_docs/version-[Gatekeeper version]` directory. If the change is for next release, please update in `website/docs`, then the change will be part of next versioned doc when we do a new release.
-->

**Special notes for your reviewer**:
