### PR TITLE
fix: Update deployment to include mutation-status operation

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -128,6 +128,7 @@ spec:
         - args:
             - --operation=audit
             - --operation=status
+            - --operation=mutation-status
             - --logtostderr
             - --disable-opa-builtin={http.send}
           command:

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -2425,6 +2425,7 @@ spec:
       - args:
         - --operation=audit
         - --operation=status
+        - --operation=mutation-status
         - --logtostderr
         - --disable-opa-builtin={http.send}
         command:


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

**What this PR does / why we need it**:
Currently Gatekeeper deployment does not include the `mutation-status` operation by default. Note: helm chart includes it by default. https://github.com/open-policy-agent/gatekeeper/blob/8404d5ee309acdbcc6779337ddcee36a3aaddd88/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml#L53 This updates the deployment yaml to ensure it is included by default.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/open-policy-agent/gatekeeper/pull/1937/files#r838163357

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
