### PR TITLE
docs: mention NET_BIND_SERVICE in cloud-specific

### DIFF
--- a/website/docs/cloud-specific.md
+++ b/website/docs/cloud-specific.md
@@ -11,9 +11,9 @@ Two ways of working around this:
 
 - create a new firewall rule from master to private nodes to open port `8443` (or any other custom port)
   - https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
-- make the pod to run on privileged port 443 (need to run pod as root)
+- make the pod to run on privileged port 443 (need to run pod as root, or have `NET_BIND_SERVICE` capability)
   - update Gatekeeper deployment manifest spec:
-    - remove `securityContext` settings that force the pods not to run as root
+    - add `NET_BIND_SERVICE` to `securityContext.capabilities.add` to allow binding on privileged ports as non-root
     - update port from `8443` to `443`
     ```yaml
     containers:
@@ -23,6 +23,10 @@ Two ways of working around this:
       - containerPort: 443
         name: webhook-server
         protocol: TCP
+      securityContext:
+        capabilities:
+          drop: ["all"]
+          add: ["NET_BIND_SERVICE"]
     ```
 
 ## Running on OpenShift 4.x

--- a/website/versioned_docs/version-v3.6.x/cloud-specific.md
+++ b/website/versioned_docs/version-v3.6.x/cloud-specific.md
@@ -11,9 +11,9 @@ Two ways of working around this:
 
 - create a new firewall rule from master to private nodes to open port `8443` (or any other custom port)
   - https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
-- make the pod to run on privileged port 443 (need to run pod as root)
+- make the pod to run on privileged port 443 (need to run pod as root, or have `NET_BIND_SERVICE` capability)
   - update Gatekeeper deployment manifest spec:
-    - remove `securityContext` settings that force the pods not to run as root
+    - add `NET_BIND_SERVICE` to `securityContext.capabilities.add` to allow binding on privileged ports as non-root
     - update port from `8443` to `443`
     ```yaml
     containers:
@@ -23,6 +23,10 @@ Two ways of working around this:
       - containerPort: 443
         name: webhook-server
         protocol: TCP
+      securityContext:
+        capabilities:
+          drop: ["all"]
+          add: ["NET_BIND_SERVICE"]
     ```
 
 ## Running on OpenShift 4.x

--- a/website/versioned_docs/version-v3.7.x/cloud-specific.md
+++ b/website/versioned_docs/version-v3.7.x/cloud-specific.md
@@ -11,9 +11,9 @@ Two ways of working around this:
 
 - create a new firewall rule from master to private nodes to open port `8443` (or any other custom port)
   - https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
-- make the pod to run on privileged port 443 (need to run pod as root)
+- make the pod to run on privileged port 443 (need to run pod as root, or have `NET_BIND_SERVICE` capability)
   - update Gatekeeper deployment manifest spec:
-    - remove `securityContext` settings that force the pods not to run as root
+    - add `NET_BIND_SERVICE` to `securityContext.capabilities.add` to allow binding on privileged ports as non-root
     - update port from `8443` to `443`
     ```yaml
     containers:
@@ -23,6 +23,10 @@ Two ways of working around this:
       - containerPort: 443
         name: webhook-server
         protocol: TCP
+      securityContext:
+        capabilities:
+          drop: ["all"]
+          add: ["NET_BIND_SERVICE"]
     ```
 
 ## Running on OpenShift 4.x

--- a/website/versioned_docs/version-v3.8.x/cloud-specific.md
+++ b/website/versioned_docs/version-v3.8.x/cloud-specific.md
@@ -11,9 +11,9 @@ Two ways of working around this:
 
 - create a new firewall rule from master to private nodes to open port `8443` (or any other custom port)
   - https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
-- make the pod to run on privileged port 443 (need to run pod as root)
+- make the pod to run on privileged port 443 (need to run pod as root, or have `NET_BIND_SERVICE` capability)
   - update Gatekeeper deployment manifest spec:
-    - remove `securityContext` settings that force the pods not to run as root
+    - add `NET_BIND_SERVICE` to `securityContext.capabilities.add` to allow binding on privileged ports as non-root
     - update port from `8443` to `443`
     ```yaml
     containers:
@@ -23,6 +23,10 @@ Two ways of working around this:
       - containerPort: 443
         name: webhook-server
         protocol: TCP
+      securityContext:
+        capabilities:
+          drop: ["all"]
+          add: ["NET_BIND_SERVICE"]
     ```
 
 ## Running on OpenShift 4.x


### PR DESCRIPTION
**What this PR does / why we need it**:
recommends using `NET_BIND_SERVICE` capability to bind to privileged ports instead of removing `securityContext` completely.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
None

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

