### PR TITLE
chore: bump golangci/golangci-lint-action from 2 to 3

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -36,13 +36,20 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v3
+      - name: Set up Go 1.17
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
       # source: https://github.com/golangci/golangci-lint-action
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-        # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-        version: v1.45.2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.45.2
 
   test:
     name: "Unit test"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -37,7 +37,7 @@ jobs:
       contents: read
     steps:
       - name: Set up Go 1.17
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.17
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

`golangci/golangci-lint-action@v2` installs the latest stable Go version on behalf of the user. That Go version might not always align with Gatekeeper's go version. `golangci/golangci-lint-action@v3` removes that step and relies on manual installation through `actions/setup-go@v2`.

Fixes linting errors in #1981

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
