### PR TITLE
docs: Add a warning to name the Config conf

### DIFF
--- a/website/docs/exempt-namespaces.md
+++ b/website/docs/exempt-namespaces.md
@@ -5,6 +5,8 @@ title: Exempting Namespaces
 
 ## Exempting Namespaces from Gatekeeper using config resource
 
+> The "Config" resource must be named `config` for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it `config`.
+
 The config resource can be used as follows to exclude namespaces from certain processes for all constraints in the cluster. An asterisk can be used for wildcard matching (e.g. `kube-*`). To exclude namespaces at a constraint level, use `excludedNamespaces` in the [constraint](howto.md#constraints) instead.
 
 ```yaml

--- a/website/docs/sync.md
+++ b/website/docs/sync.md
@@ -3,7 +3,7 @@ id: sync
 title: Replicating Data
 ---
 
-> The "Config" resource has to be named "config" for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it "config".
+> The "Config" resource must be named `config` for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it `config`.
 
 Some constraints are impossible to write without access to more state than just the object under test. For example, it is impossible to know if an ingress's hostname is unique among all ingresses unless a rule has access to all other ingresses. To make such rules possible, we enable syncing of data into OPA.
 

--- a/website/versioned_docs/version-v3.6.x/exempt-namespaces.md
+++ b/website/versioned_docs/version-v3.6.x/exempt-namespaces.md
@@ -5,6 +5,8 @@ title: Exempting Namespaces
 
 ## Exempting Namespaces from Gatekeeper using config resource
 
+> The "Config" resource must be named `config` for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it `config`.
+
 The config resource can be used as follows to exclude namespaces from certain processes for all constraints in the cluster. An asterisk can be used for wildcard matching (e.g. `kube-*`). To exclude namespaces at a constraint level, use `excludedNamespaces` in the [constraint](howto.md#constraints) instead.
 
 ```yaml

--- a/website/versioned_docs/version-v3.6.x/sync.md
+++ b/website/versioned_docs/version-v3.6.x/sync.md
@@ -3,7 +3,7 @@ id: sync
 title: Replicating Data
 ---
 
-> The "Config" resource has to be named "config" for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it "config".
+> The "Config" resource must be named `config` for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it `config`.
 
 Some constraints are impossible to write without access to more state than just the object under test. For example, it is impossible to know if an ingress's hostname is unique among all ingresses unless a rule has access to all other ingresses. To make such rules possible, we enable syncing of data into OPA.
 

--- a/website/versioned_docs/version-v3.7.x/exempt-namespaces.md
+++ b/website/versioned_docs/version-v3.7.x/exempt-namespaces.md
@@ -5,6 +5,8 @@ title: Exempting Namespaces
 
 ## Exempting Namespaces from Gatekeeper using config resource
 
+> The "Config" resource must be named `config` for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it `config`.
+
 The config resource can be used as follows to exclude namespaces from certain processes for all constraints in the cluster. An asterisk can be used for wildcard matching (e.g. `kube-*`). To exclude namespaces at a constraint level, use `excludedNamespaces` in the [constraint](howto.md#constraints) instead.
 
 ```yaml

--- a/website/versioned_docs/version-v3.7.x/sync.md
+++ b/website/versioned_docs/version-v3.7.x/sync.md
@@ -3,7 +3,7 @@ id: sync
 title: Replicating Data
 ---
 
-> The "Config" resource has to be named "config" for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it "config".
+> The "Config" resource must be named `config` for it to be reconciled by Gatekeeper. Gatekeeper will ignore the resource if you do not name it `config`.
 
 Some constraints are impossible to write without access to more state than just the object under test. For example, it is impossible to know if an ingress's hostname is unique among all ingresses unless a rule has access to all other ingresses. To make such rules possible, we enable syncing of data into OPA.
 


### PR DESCRIPTION
While setting up Gatekeeper I had issue as I had renamed my `Config` to another name. After looking at the logs I saw that it ignored my name `exempted-mutation-ns`. When using `config` everything worked fine.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
