### PR TITLE
feat: Allow config resource to be specified by name

### DIFF
--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -82,6 +82,7 @@ spec:
             - --enable-external-data={{ .Values.enableExternalData }}
             - --log-mutations={{ .Values.logMutations }}
             - --mutation-annotations={{ .Values.mutationAnnotations }}
+            - --config-name={{ .Values.controllerManager.configName }}
             - HELMSUBST_TLS_HEALTHCHECK_ENABLED_ARG
             - HELMSUBST_MUTATION_ENABLED_ARG
             - HELMSUBST_DEPLOYMENT_CONTROLLER_MANAGER_DISABLED_BUILTIN
@@ -150,6 +151,7 @@ spec:
             - --health-addr=:HELMSUBST_DEPLOYMENT_AUDIT_HEALTH_PORT
             - --prometheus-port=HELMSUBST_DEPLOYMENT_AUDIT_METRICS_PORT
             - --enable-external-data={{ .Values.enableExternalData }}
+            - --config-name={{ .Values.audit.configName }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           HELMSUBST_AUDIT_CONTROLLER_MANAGER_DEPLOYMENT_IMAGE_RELEASE: ""
           ports:

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -72,6 +72,7 @@ podLabels: {}
 podCountLimit: 100
 secretAnnotations: {}
 controllerManager:
+  configName: config
   exemptNamespaces: []
   exemptNamespacePrefixes: []
   hostNetwork: false
@@ -111,6 +112,7 @@ controllerManager:
     runAsNonRoot: true
     runAsUser: 1000
 audit:
+  configName: config
   hostNetwork: false
   dnsPolicy: ClusterFirst
   metricsPort: 8888

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -60,6 +60,7 @@ spec:
         - --health-addr=:{{ .Values.audit.healthPort }}
         - --prometheus-port={{ .Values.audit.metricsPort }}
         - --enable-external-data={{ .Values.enableExternalData }}
+        - --config-name={{ .Values.audit.configName }}
         command:
         - /manager
         env:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -58,6 +58,7 @@ spec:
         - --enable-external-data={{ .Values.enableExternalData }}
         - --log-mutations={{ .Values.logMutations }}
         - --mutation-annotations={{ .Values.mutationAnnotations }}
+        - --config-name={{ .Values.controllerManager.configName }}
         {{ if .Values.enableTLSHealthcheck}}- --enable-tls-healthcheck{{- end }}
         {{ if not .Values.disableMutation}}- --operation=mutation-webhook{{- end }}
         

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -72,6 +72,7 @@ podLabels: {}
 podCountLimit: 100
 secretAnnotations: {}
 controllerManager:
+  configName: config
   exemptNamespaces: []
   exemptNamespacePrefixes: []
   hostNetwork: false
@@ -111,6 +112,7 @@ controllerManager:
     runAsNonRoot: true
     runAsUser: 1000
 audit:
+  configName: config
   hostNetwork: false
   dnsPolicy: ClusterFirst
   metricsPort: 8888

--- a/pkg/controller/config/config_controller_suite_test.go
+++ b/pkg/controller/config/config_controller_suite_test.go
@@ -37,6 +37,9 @@ import (
 var cfg *rest.Config
 
 func TestMain(m *testing.M) {
+	// set --config-name flag to test-config for test purposes
+	*configResourceName = "test-config"
+
 	t := &envtest.Environment{
 		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -57,7 +57,7 @@ import (
 )
 
 var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{
-	Name:      "config",
+	Name:      "test-config",
 	Namespace: "gatekeeper-system",
 }}
 
@@ -98,7 +98,7 @@ func TestReconcile(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	instance := &configv1alpha1.Config{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config",
+			Name:      "test-config",
 			Namespace: "gatekeeper-system",
 		},
 		Spec: configv1alpha1.ConfigSpec{
@@ -716,7 +716,7 @@ func configFor(kinds []schema.GroupVersionKind) *configv1alpha1.Config {
 			Kind:       "Config",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "config",
+			Name:      "test-config",
 			Namespace: "gatekeeper-system",
 		},
 		Spec: configv1alpha1.ConfigSpec{


### PR DESCRIPTION
**What this PR does / why we need it**: This PR allows users to specify a `Config` resource by name, rather than hardcoding the name as `config`. This enables users to configure the Gatekeeper audit & controller-manager differently - for example caching different resources.