### PR TITLE
helm: Label exempted namespaces

### DIFF
--- a/cmd/build/helmify/static/templates/namespace-post-install.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-install.yaml
@@ -36,6 +36,9 @@ spec:
             - label
             - ns
             - {{ .Release.Namespace }}
+            {{- range .Values.postInstall.labelNamespace.extraNamespaces }}
+            - {{ . }}
+            {{- end }}
             - admission.gatekeeper.sh/ignore=no-self-managing
             - --overwrite
           securityContext:
@@ -76,6 +79,9 @@ rules:
       - patch
     resourceNames:
       - {{ .Release.Namespace }}
+      {{- range .Values.postInstall.labelNamespace.extraNamespaces }}
+      - {{ . }}
+      {{- end }}
 {{- end }}
 ---
 {{- if .Values.rbac.create }}

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -34,6 +34,7 @@ postInstall:
       tag: v3.9.0-beta.0
       pullPolicy: IfNotPresent
       pullSecrets: []
+    extraNamespaces: []
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
@@ -36,6 +36,9 @@ spec:
             - label
             - ns
             - {{ .Release.Namespace }}
+            {{- range .Values.postInstall.labelNamespace.extraNamespaces }}
+            - {{ . }}
+            {{- end }}
             - admission.gatekeeper.sh/ignore=no-self-managing
             - --overwrite
           securityContext:
@@ -76,6 +79,9 @@ rules:
       - patch
     resourceNames:
       - {{ .Release.Namespace }}
+      {{- range .Values.postInstall.labelNamespace.extraNamespaces }}
+      - {{ . }}
+      {{- end }}
 {{- end }}
 ---
 {{- if .Values.rbac.create }}

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -34,6 +34,7 @@ postInstall:
       tag: v3.9.0-beta.0
       pullPolicy: IfNotPresent
       pullSecrets: []
+    extraNamespaces: []
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:


### PR DESCRIPTION
Allows to label extra namespace for exemption, defaulting to kube-system

Fixes #1952
