### PR TITLE
Helm: Allow setting of tolerations on multiple jobs

### DIFF
--- a/cmd/build/helmify/static/templates/namespace-post-install.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-install.yaml
@@ -40,6 +40,8 @@ spec:
             - --overwrite
           securityContext:
             {{- toYaml .Values.postInstall.securityContext | nindent 12 }}
+      tolerations:
+        {{- toYaml .Values.postInstall.labelNamespace.tolerations | nindent 8 }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
+++ b/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
@@ -42,6 +42,9 @@ spec:
             {{- end }}
           securityContext:
             {{- toYaml .Values.preUninstall.securityContext | nindent 10 }}
+    tolerations:
+      {{- toYaml .Values.preUninstall.deleteWebhookConfigurations.tolerations | nindent 8 }}
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -34,6 +34,7 @@ postInstall:
       tag: v3.9.0-beta.0
       pullPolicy: IfNotPresent
       pullSecrets: []
+    tolerations: []
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -51,6 +52,7 @@ preUninstall:
       tag: v3.9.0-beta.0
       pullPolicy: IfNotPresent
       pullSecrets: []
+    tolerations: []
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
@@ -40,6 +40,8 @@ spec:
             - --overwrite
           securityContext:
             {{- toYaml .Values.postInstall.securityContext | nindent 12 }}
+      tolerations:
+        {{- toYaml .Values.postInstall.labelNamespace.tolerations | nindent 8 }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
@@ -42,6 +42,9 @@ spec:
             {{- end }}
           securityContext:
             {{- toYaml .Values.preUninstall.securityContext | nindent 10 }}
+    tolerations:
+      {{- toYaml .Values.preUninstall.deleteWebhookConfigurations.tolerations | nindent 8 }}
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -34,6 +34,7 @@ postInstall:
       tag: v3.9.0-beta.0
       pullPolicy: IfNotPresent
       pullSecrets: []
+    tolerations: []
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -51,6 +52,7 @@ preUninstall:
       tag: v3.9.0-beta.0
       pullPolicy: IfNotPresent
       pullSecrets: []
+    tolerations: []
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:


### PR DESCRIPTION
Signed-off-by: Bryan Pearson <bpearson@morningconsult.com>

Setting tolerations on multiple jobs, so they can run in environments which require tolerations to be set.