### PR TITLE
Fix go get

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/open-policy-agent/gatekeeper
+module github.com/open-policy-agent/gatekeeper/v3
 
 go 1.17
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Without this change go get shows the following error:

```ShellSession
$ go get github.com/open-policy-agent/gatekeeper@v3.8.1+incompatible
go get: github.com/open-policy-agent/gatekeeper@v3.8.1+incompatible: invalid version: module contains a go.mod file, so module path must match major version ("github.com/open-policy-agent/gatekeeper/v3")
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:


I tested this in https://github.com/SuperSandro2000/gatekeeper/commit/5cd973ad1be073cd4846cc5cd34a6fb6d9348f34 which fixes ``go get github.com/SuperSandro2000/gatekeeper/v3@v3.9.9``