### PR TITLE
fix: Validation error in all_ns_must_have_gatekeeper constraint

### DIFF
--- a/demo/basic/constraints/all_ns_must_have_gatekeeper.yaml
+++ b/demo/basic/constraints/all_ns_must_have_gatekeeper.yaml
@@ -8,5 +8,4 @@ spec:
       - apiGroups: [""]
         kinds: ["Namespace"]
   parameters:
-    labels:
-      - key : "gatekeeper"
+    labels: ["gatekeeper"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to fix - validation error when we apply all_ns_must_have_gatekeeper constraint

**Which issue(s) this PR fixes** **:
Fixes # fix - error validating data: ValidationError(K8sRequiredLabels.spec.parameters.labels[0]): invalid type for sh.gatekeeper.constraints.v1beta1.K8sRequiredLabels.spec.parameters.labels: got "map", expected "string"


<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
example run of constraint-
```
$ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/demo/basic/constraints/all_ns_must_have_gatekeeper.yaml  

agent/gatekeeper/master/demo/basic/constraints/all_ns_must_have_gatekeeper.yaml
error: error validating "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/demo/basic/constraints/all_ns_must_have_gatekeeper.yaml": error validating data: ValidationError(K8sRequiredLabels.spec.parameters.labels[0]): invalid type for sh.gatekeeper.constraints.v1beta1.K8sRequiredLabels.spec.parameters.labels: got "map", expected "string"; if you choose to ignore these errors, turn validation off with --validate=false
```
