### PR TITLE
fix: #2095 GV in constraint StatusViolation

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -80,6 +80,8 @@ type Manager struct {
 
 // StatusViolation represents each violation under status.
 type StatusViolation struct {
+	Group             string `json:"group"`
+	Version           string `json:"version"`
 	Kind              string `json:"kind"`
 	Name              string `json:"name"`
 	Namespace         string `json:"namespace,omitempty"`
@@ -736,6 +738,8 @@ func (ucloop *updateConstraintLoop) updateConstraintStatus(ctx context.Context, 
 		// append statusViolations for this constraint until constraintViolationsLimit has reached
 		if uint(len(statusViolations)) < *constraintViolationsLimit {
 			statusViolations = append(statusViolations, StatusViolation{
+				Group:             ar.group,
+				Version:           ar.version,
 				Kind:              ar.kind,
 				Name:              ar.name,
 				Namespace:         ar.namespace,


### PR DESCRIPTION
For https://github.com/open-policy-agent/gatekeeper/issues/2095

**What this PR does / why we need it**: Provides group and version of violating resources inside StatusViolation by copying over the group and version fields from updateListEntry.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #2095

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

**Special notes for your reviewer**:
