### PR TITLE
ValidatingWebhookConfiguration.webhooks[0].namespaceSelector.matchExpressions[1]) unknown field "value"

### DIFF
--- a/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -29,7 +29,7 @@ webhooks:
     {{- range $key, $value := .Values.mutatingWebhookExemptNamespacesLabels}}
     - key: {{ $key }}
       operator: NotIn
-      value: {{ $value }}
+      values: {{ $value }}
     {{- end }}
   objectSelector: {{ toYaml .Values.mutatingWebhookObjectSelector }}
   reinvocationPolicy: {{ .Values.mutatingWebhookReinvocationPolicy }}

--- a/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -29,7 +29,7 @@ webhooks:
     {{- range $key, $value := .Values.validatingWebhookExemptNamespacesLabels}}
     - key: {{ $key }}
       operator: NotIn
-      value: {{ $value }}
+      values: {{ $value }}
     {{- end }}
   objectSelector: {{ toYaml .Values.validatingWebhookObjectSelector }}
   rules:


### PR DESCRIPTION
**What this PR does / why we need it**:

- add ExemptNamespacesLabel : 
      -  validatingWebhookExemptNamespacesLabels
      - mutatingWebhookExemptNamespacesLabels
**Which issue(s) this PR fixes:

$ helm upgrade opa-gatekeeper ./gatekeeper --install --wait --namespace gatekeeper-system --values ./gatekeeper/values.yaml
_Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(ValidatingWebhookConfiguration.webhooks[0].namespaceSelector.matchExpressions[1]): **unknown field "value" in io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement_**

Fixes #
In the CRD (crds/modifyset-customresourcedefinition.yaml) an array of values (field values) has been declared for namespaceselector.matchExpressions (values with (s) )

```
                  namespaceSelector:
                    description: NamespaceSelector is a label selector against an object's containing namespace or the object itself, if the object is a namespace.
                    properties:
                      matchExpressions:
                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                        items:
                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                          properties:
                            key:
                              description: key is the label key that the selector applies to.
                              type: string
                            operator:
                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                              type: string
                            values:
                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                              items:
                                type: string
                              type: array
```
However, in the 2 templates  of your helm chart (gatekeeper-mutating-webhook-configuration -mutatingwebhookconfiguration.yaml and gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml) the value field in namespaceSelector.matchExpressions   without (s).

```
    {{- range $key, $value := .Values.mutatingWebhookExemptNamespacesLabels}}
    - key: {{ $key }}
      operator: NotIn
      value: {{ $value }}
    {{- end }}
```
<!--

