### PR TITLE
feat: TLS support for External Data Providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -359,3 +359,6 @@ tilt-settings.json
 
 # cluster-test
 /cluster-test
+
+# dummy provider's certificate directory
+test/externaldata/dummy-provider/certs/

--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ e2e-build-load-image: docker-buildx
 	kind load docker-image --name kind ${IMG} ${CRD_IMG}
 
 e2e-build-load-externaldata-image: docker-buildx-builder
+	./test/externaldata/dummy-provider/scripts/generate-tls-certificate.sh
 	docker buildx build --platform="linux/amd64" -t dummy-provider:test --load -f test/externaldata/dummy-provider/Dockerfile test/externaldata/dummy-provider
 	kind load docker-image --name kind dummy-provider:test
 
@@ -446,8 +447,8 @@ tilt-prepare:
 	rm -rf .tiltbuild/charts/gatekeeper
 	cp -R manifest_staging/charts/gatekeeper .tiltbuild/charts
 	# disable some configs from the security context so we can perform live update
-	sed -i -e "/readOnlyRootFilesystem: true/d" .tiltbuild/charts/gatekeeper/templates/*.yaml
-	sed -i -e "/run.*: .*/d" .tiltbuild/charts/gatekeeper/templates/*.yaml
+	sed -i -e "/readOnlyRootFilesystem: true/d" .tiltbuild/charts/gatekeeper/values.yaml
+	sed -i -e "/run.*: .*/d" .tiltbuild/charts/gatekeeper/values.yaml
 
 tilt: generate manifests tilt-prepare
 	tilt up

--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -82,6 +82,7 @@ spec:
             - --enable-external-data={{ .Values.enableExternalData }}
             - --log-mutations={{ .Values.logMutations }}
             - --mutation-annotations={{ .Values.mutationAnnotations }}
+            - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation }}
             - HELMSUBST_METRICS_BACKEND_ARG
             - HELMSUBST_TLS_HEALTHCHECK_ENABLED_ARG
             - HELMSUBST_MUTATION_ENABLED_ARG
@@ -152,6 +153,7 @@ spec:
             - --prometheus-port=HELMSUBST_DEPLOYMENT_AUDIT_METRICS_PORT
             - --enable-external-data={{ .Values.enableExternalData }}
             - HELMSUBST_METRICS_BACKEND_ARG
+            - --disable-cert-rotation={{ .Values.audit.disableCertRotation }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           HELMSUBST_AUDIT_CONTROLLER_MANAGER_DEPLOYMENT_IMAGE_RELEASE: ""
           ports:

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -112,6 +112,7 @@ controllerManager:
   metricsPort: 8888
   healthPort: 9090
   priorityClassName: system-cluster-critical
+  disableCertRotation: false
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -149,6 +150,7 @@ audit:
   metricsPort: 8888
   healthPort: 9090
   priorityClassName: system-cluster-critical
+  disableCertRotation: true
   affinity: {}
   tolerations: []
   nodeSelector: {kubernetes.io/os: linux}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -35,6 +35,8 @@ patchesStrategicMerge:
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
 
+# [AUDIT] To enable audit, uncomment all the sections with [AUDIT] prefix including the one in crd/kustomization.yaml
+- manager_audit_patch.yaml
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 - manager_webhook_patch.yaml
 

--- a/config/default/manager_audit_patch.yaml
+++ b/config/default/manager_audit_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: audit
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -142,6 +142,7 @@ spec:
             - --operation=mutation-status
             - --logtostderr
             - --disable-opa-builtin={http.send}
+            - --disable-cert-rotation
           command:
             - /manager
           image: openpolicyagent/gatekeeper:v3.9.0-beta.2

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,7 +8,7 @@ Generally, design docs are on Google docs:
 
 ## Proposed
 * [Template e2e Testing Design](https://docs.google.com/document/d/15nWc9TH97LF9o58CTVxYxFM9tYk8-seB5erIa2gouPo/edit)
-* [ByPod Status Design](https://docs.google.com/document/d/13xmVQuE9Q8CFDpL9pzpoAyH1nIzHndP0OfccXVShiPo/edit?usp=sharing)
+* [ByPod Status Design](https://docs.google.com/document/d/13xmVQuE9Q8CFDpL9pzpoAyH1nIzHndP0OfccXVShiPo/edit)
 * [Namespace-Scoped Constraints](https://docs.google.com/document/d/1-pY7B5C6R0fjUbDu8izlcP7MSUDVDHv5XK16BFyTGRc/edit#heading=h.w8j68o8vjdts)
 * [Mutation Design - 4th Edition (current approach)](https://docs.google.com/document/d/1MdchNFz9guycX__QMGxpJviPaT_MZs8iXaAFqCvoXYQ/edit?ts=5f73fb77#
 )
@@ -17,7 +17,7 @@ Generally, design docs are on Google docs:
    * [Mutation Revised Design Doc (June 2019)](https://docs.google.com/document/d/1G7WgZKx1Y3VOTUjrqn7DjDaZgSKCIZowILm_I6psrw0/edit#heading=h.mtvdjag5uj9)
    * [Mutation Initial Design Doc (April 2019)](https://docs.google.com/document/d/1qTHwqoUX8AL2jodyWKB_2szrGDwhi14Ra_LlQ-ogtck/edit#heading=h.iu1ppjy7g7j)
 * [External Data](https://docs.google.com/document/d/1hPi86jdsCKg8puYT5_s_73mPGExUJeZfyKmvG-XWtPc/edit#)
-* [gator validate](https://docs.google.com/document/d/1B0hXDia8SExOkCVAEbPVHFJmnWeJgHziGvMxnzrENa0/edit?usp=sharing)
+* [gator validate](https://docs.google.com/document/d/1B0hXDia8SExOkCVAEbPVHFJmnWeJgHziGvMxnzrENa0/edit)
 
 ## Implemented
 * [V3 Accepted Design](https://docs.google.com/document/d/1yC4wgpVoJj6ngYnSTtO-HeaIBl05gla562sD7qKPy3M/edit#heading=h.z0bjqzl81dpe)
@@ -29,11 +29,11 @@ Generally, design docs are on Google docs:
 * [Dry-Run Design Doc](https://docs.google.com/document/d/17nJDJxjY_XHV8zrMNdOi2hFgfm6XKGJi0QyznsbhQ70/edit#heading=h.z0bjqzl81dpe)
 * [Constraint Framework Client Interface](https://docs.google.com/document/d/1NDOgu8F_yQqrxRRVTDiCXGXMsajA3Jtp-lwGrZsDFcI/edit#)
 * [Logging Design Doc](https://docs.google.com/document/d/1ap7AKOupNcR_42s8mkSh5FV9eteXTd4VCqelKst73VY/edit)
-* [Namespace Exclusion Design doc](https://docs.google.com/document/d/1yHuXFs_HQL5N9yT9QVi6AMyflWPtZS4Pg-uXczdqgZ8/edit?usp=sharing)
+* [Namespace Exclusion Design doc](https://docs.google.com/document/d/1yHuXFs_HQL5N9yT9QVi6AMyflWPtZS4Pg-uXczdqgZ8/edit)
 * [Metrics Design Issue](https://github.com/open-policy-agent/gatekeeper/issues/157#issuecomment-553015292)
 * [Gatekeeper v1beta1 CRD Deprecation](https://docs.google.com/document/d/12TD9vk79X3y0RgNxURamW4tQOyd6YjA6WrwDAqcplwg/edit#)
 * [Compiler Sharding Design](https://docs.google.com/document/d/1ibCxaI-7HyWyDjQNL4iDRMHnrauufIMJ1D6LwIKdlsI/edit)
-* [External Data TLS Support](https://docs.google.com/document/d/1GjV3WeC2bgQ3j37_mMpY9hr7YOAqzSJ6jDSu-DVrcmU/edit?usp=sharing)
+* [External Data TLS Support](https://docs.google.com/document/d/1GjV3WeC2bgQ3j37_mMpY9hr7YOAqzSJ6jDSu-DVrcmU/edit)
 
 ## Roadmap (in development)
 * See [milestones](https://github.com/open-policy-agent/gatekeeper/milestones?direction=asc&sort=due_date)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -33,6 +33,7 @@ Generally, design docs are on Google docs:
 * [Metrics Design Issue](https://github.com/open-policy-agent/gatekeeper/issues/157#issuecomment-553015292)
 * [Gatekeeper v1beta1 CRD Deprecation](https://docs.google.com/document/d/12TD9vk79X3y0RgNxURamW4tQOyd6YjA6WrwDAqcplwg/edit#)
 * [Compiler Sharding Design](https://docs.google.com/document/d/1ibCxaI-7HyWyDjQNL4iDRMHnrauufIMJ1D6LwIKdlsI/edit)
+* [External Data TLS Support](https://docs.google.com/document/d/1GjV3WeC2bgQ3j37_mMpY9hr7YOAqzSJ6jDSu-DVrcmU/edit?usp=sharing)
 
 ## Roadmap (in development)
 * See [milestones](https://github.com/open-policy-agent/gatekeeper/milestones?direction=asc&sort=due_date)

--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,8 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
-	github.com/open-policy-agent/cert-controller v0.3.0
-	github.com/open-policy-agent/frameworks/constraint v0.0.0-20220621170157-36b73e182701
+	github.com/open-policy-agent/cert-controller v0.4.0
+	github.com/open-policy-agent/frameworks/constraint v0.0.0-20220621232220-a0dd2a57505b
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.2
 	github.com/spf13/cobra v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -954,10 +954,10 @@ github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAl
 github.com/onsi/gomega v1.18.1/go.mod h1:0q+aL8jAiMXy9hbwj2mr5GziHiwhAIQpFmmtT5hitRs=
 github.com/onsi/gomega v1.19.0 h1:4ieX6qQjPP/BfC3mpsAtIGGlxTWPeA3Inl/7DtXw1tw=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/open-policy-agent/cert-controller v0.3.0 h1:9eUgN3yYMZsfyW7qdW8+CX9YZCUb5R5JfRTj0cqaSVg=
-github.com/open-policy-agent/cert-controller v0.3.0/go.mod h1:uOQW+2tMU51vSxy1Yt162oVUTMdqLuotC0aObQxrh6k=
-github.com/open-policy-agent/frameworks/constraint v0.0.0-20220621170157-36b73e182701 h1:WpDMWWpLte6RGs4UruGQ+/iuKD6WBSVCgvs4Sc/IKco=
-github.com/open-policy-agent/frameworks/constraint v0.0.0-20220621170157-36b73e182701/go.mod h1:2+TcEyrHgPQqnLpYiLMME0Zt/zW1pRe7EbD6YHeN/Js=
+github.com/open-policy-agent/cert-controller v0.4.0 h1:AQntgNq7fsoHgnoKrOk0lpRyab1na09vibeJCX4YBCs=
+github.com/open-policy-agent/cert-controller v0.4.0/go.mod h1:uOQW+2tMU51vSxy1Yt162oVUTMdqLuotC0aObQxrh6k=
+github.com/open-policy-agent/frameworks/constraint v0.0.0-20220621232220-a0dd2a57505b h1:GiWKMGVBxWi1LSRyPO3J/nt9H470XDkIb40FTYIflZw=
+github.com/open-policy-agent/frameworks/constraint v0.0.0-20220621232220-a0dd2a57505b/go.mod h1:20OhJ1ThhHMRfpeLXwaSjffYq1qtTHlWgtpY1gV8ekg=
 github.com/open-policy-agent/opa v0.41.0 h1:XDTkP8bcUVuY8WOVbRY4e/KZW31+f+/cxisPc0TPe5E=
 github.com/open-policy-agent/opa v0.41.0/go.mod h1:+kB8/8/4meTlq6ZmYRnvrL5nNrykd2eckDx4O6rk/dA=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func main() {
 
 	// Make sure certs are generated and valid if cert rotation is enabled.
 	setupFinished := make(chan struct{})
-	if !*disableCertRotation && (operations.IsAssigned(operations.Webhook) || operations.IsAssigned(operations.MutationWebhook)) {
+	if !*disableCertRotation {
 		setupLog.Info("setting up cert rotation")
 
 		keyUsages := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}

--- a/main.go
+++ b/main.go
@@ -16,12 +16,14 @@ limitations under the License.
 package main
 
 import (
+	"crypto/x509"
 	"errors"
 	"flag"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"path/filepath"
 	"time"
 
 	// set GOMAXPROCS to the number of container cores, if known.
@@ -62,6 +64,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	crzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -72,6 +75,8 @@ const (
 	secretName     = "gatekeeper-webhook-server-cert"
 	caName         = "gatekeeper-ca"
 	caOrganization = "gatekeeper"
+	certName       = "tls.crt"
+	keyName        = "tls.key"
 )
 
 var (
@@ -188,6 +193,12 @@ func main() {
 	setupFinished := make(chan struct{})
 	if !*disableCertRotation && (operations.IsAssigned(operations.Webhook) || operations.IsAssigned(operations.MutationWebhook)) {
 		setupLog.Info("setting up cert rotation")
+
+		keyUsages := []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		if *externaldata.ExternalDataEnabled {
+			keyUsages = append(keyUsages, x509.ExtKeyUsageClientAuth)
+		}
+
 		if err := rotator.AddRotator(mgr, &rotator.CertRotator{
 			SecretKey: types.NamespacedName{
 				Namespace: util.GetNamespace(),
@@ -199,6 +210,7 @@ func main() {
 			DNSName:        fmt.Sprintf("%s.%s.svc", *certServiceName, util.GetNamespace()),
 			IsReady:        setupFinished,
 			Webhooks:       webhooks,
+			ExtKeyUsages:   &keyUsages,
 		}); err != nil {
 			setupLog.Error(err, "unable to set up cert rotation")
 			os.Exit(1)
@@ -267,6 +279,28 @@ func setupControllers(mgr ctrl.Manager, sw *watch.ControllerSwitch, tracker *rea
 		providerCache = frameworksexternaldata.NewCache()
 		args = append(args, local.AddExternalDataProviderCache(providerCache))
 		mutationOpts.ProviderCache = providerCache
+
+		certFile := filepath.Join(*certDir, certName)
+		keyFile := filepath.Join(*certDir, keyName)
+
+		// certWatcher is used to watch for changes to Gatekeeper's certificate and key files.
+		certWatcher, err := certwatcher.New(certFile, keyFile)
+		if err != nil {
+			setupLog.Error(err, "unable to create client cert watcher")
+			os.Exit(1)
+		}
+
+		setupLog.Info("setting up client cert watcher")
+		if err := mgr.Add(certWatcher); err != nil {
+			setupLog.Error(err, "unable to register client cert watcher")
+			os.Exit(1)
+		}
+
+		// register the client cert watcher to the driver
+		args = append(args, local.EnableExternalDataClientAuth(), local.AddExternalDataClientCertWatcher(certWatcher))
+
+		// register the client cert watcher to the mutation system
+		mutationOpts.ClientCertWatcher = certWatcher
 	}
 	// initialize OPA
 	driver, err := local.New(args...)

--- a/manifest_staging/charts/gatekeeper/crds/provider-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/provider-customresourcedefinition.yaml
@@ -32,6 +32,12 @@ spec:
           spec:
             description: Spec defines the Provider specifications.
             properties:
+              caBundle:
+                description: CABundle is a base64-encoded string that contains the TLS CA bundle in PEM format. It is used to verify the signature of the provider's certificate.
+                type: string
+              insecureTLSSkipVerify:
+                description: InsecureTLSSkipVerify skips the verification of Provider's certificate if enabled.
+                type: boolean
               timeout:
                 description: Timeout is the timeout when querying the provider.
                 type: integer

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -66,6 +66,7 @@ spec:
         {{- range .Values.metricsBackends}}
         - --metrics-backend={{ . }}
         {{- end }}
+        - --disable-cert-rotation={{ .Values.audit.disableCertRotation }}
         command:
         - /manager
         env:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -111,6 +111,9 @@ spec:
           {{- end }}
           {{- toYaml .Values.audit.securityContext | nindent 10}}
         volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
         - mountPath: /tmp/audit
           name: tmp-volume
       dnsPolicy: {{ .Values.audit.dnsPolicy }}
@@ -127,6 +130,10 @@ spec:
       tolerations:
         {{- toYaml .Values.audit.tolerations | nindent 8 }}
       volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: gatekeeper-webhook-server-cert
       {{- if .Values.audit.writeToRAMDisk }}
       - emptyDir:
           medium: Memory

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -60,6 +60,7 @@ spec:
         - --enable-external-data={{ .Values.enableExternalData }}
         - --log-mutations={{ .Values.logMutations }}
         - --mutation-annotations={{ .Values.mutationAnnotations }}
+        - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation }}
         
         {{- range .Values.metricsBackends}}
         - --metrics-backend={{ . }}

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -112,6 +112,7 @@ controllerManager:
   metricsPort: 8888
   healthPort: 9090
   priorityClassName: system-cluster-critical
+  disableCertRotation: false
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:
@@ -149,6 +150,7 @@ audit:
   metricsPort: 8888
   healthPort: 9090
   priorityClassName: system-cluster-critical
+  disableCertRotation: true
   affinity: {}
   tolerations: []
   nodeSelector: {kubernetes.io/os: linux}

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -2434,6 +2434,7 @@ spec:
         - --operation=mutation-status
         - --logtostderr
         - --disable-opa-builtin={http.send}
+        - --disable-cert-rotation
         command:
         - /manager
         env:

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -2092,6 +2092,12 @@ spec:
           spec:
             description: Spec defines the Provider specifications.
             properties:
+              caBundle:
+                description: CABundle is a base64-encoded string that contains the TLS CA bundle in PEM format. It is used to verify the signature of the provider's certificate.
+                type: string
+              insecureTLSSkipVerify:
+                description: InsecureTLSSkipVerify skips the verification of Provider's certificate if enabled.
+                type: boolean
               timeout:
                 description: Timeout is the timeout when querying the provider.
                 type: integer
@@ -2482,6 +2488,9 @@ spec:
           runAsNonRoot: true
           runAsUser: 1000
         volumeMounts:
+        - mountPath: /certs
+          name: cert
+          readOnly: true
         - mountPath: /tmp/audit
           name: tmp-volume
       nodeSelector:
@@ -2490,6 +2499,10 @@ spec:
       serviceAccountName: gatekeeper-admin
       terminationGracePeriodSeconds: 60
       volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: gatekeeper-webhook-server-cert
       - emptyDir: {}
         name: tmp-volume
 ---

--- a/pkg/controller/externaldata/externaldata_controller_test.go
+++ b/pkg/controller/externaldata/externaldata_controller_test.go
@@ -66,8 +66,9 @@ func TestReconcile(t *testing.T) {
 			Name: "my-provider",
 		},
 		Spec: externaldatav1alpha1.ProviderSpec{
-			URL:     "http://my-provider:8080",
-			Timeout: 10,
+			URL:                   "http://my-provider:8080",
+			Timeout:               10,
+			InsecureTLSSkipVerify: true,
 		},
 	}
 
@@ -130,8 +131,9 @@ func TestReconcile(t *testing.T) {
 		}
 
 		want := externaldatav1alpha1.ProviderSpec{
-			URL:     "http://my-provider:8080",
-			Timeout: 10,
+			URL:                   "http://my-provider:8080",
+			Timeout:               10,
+			InsecureTLSSkipVerify: true,
 		}
 		if diff := cmp.Diff(want, entry.Spec); diff != "" {
 			t.Fatal(diff)
@@ -154,8 +156,9 @@ func TestReconcile(t *testing.T) {
 		}
 
 		wantSpec := externaldatav1alpha1.ProviderSpec{
-			URL:     "http://my-provider:8080",
-			Timeout: 20,
+			URL:                   "http://my-provider:8080",
+			Timeout:               20,
+			InsecureTLSSkipVerify: true,
 		}
 		if diff := cmp.Diff(wantSpec, entry.Spec); diff != "" {
 			t.Fatal(diff)

--- a/pkg/fakes/provider_cache.go
+++ b/pkg/fakes/provider_cache.go
@@ -20,8 +20,9 @@ func init() {
 			Name: ExternalDataProviderName,
 		},
 		Spec: v1alpha1.ProviderSpec{
-			URL:     "http://localhost:8080/validate",
-			Timeout: 1,
+			URL:                   "http://localhost:8080/validate",
+			Timeout:               1,
+			InsecureTLSSkipVerify: true,
 		},
 	})
 }

--- a/pkg/mutation/system.go
+++ b/pkg/mutation/system.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 )
 
 // ErrNotConverging reports that applying all Mutators isn't converging.
@@ -31,6 +32,7 @@ type System struct {
 	newUUID                           func() uuid.UUID
 	providerCache                     *externaldata.ProviderCache
 	sendRequestToExternalDataProvider externaldata.SendRequestToProvider
+	clientCertWatcher                 *certwatcher.CertWatcher
 }
 
 // SystemOpts allows for optional dependencies to be passed into the mutation System.
@@ -39,6 +41,7 @@ type SystemOpts struct {
 	NewUUID                           func() uuid.UUID
 	ProviderCache                     *externaldata.ProviderCache
 	SendRequestToExternalDataProvider externaldata.SendRequestToProvider
+	ClientCertWatcher                 *certwatcher.CertWatcher
 }
 
 // NewSystem initializes an empty mutation system.
@@ -55,6 +58,7 @@ func NewSystem(options SystemOpts) *System {
 		newUUID:                           options.NewUUID,
 		providerCache:                     options.ProviderCache,
 		sendRequestToExternalDataProvider: options.SendRequestToExternalDataProvider,
+		clientCertWatcher:                 options.ClientCertWatcher,
 	}
 }
 

--- a/pkg/mutation/system_external_data.go
+++ b/pkg/mutation/system_external_data.go
@@ -193,7 +193,7 @@ func (s *System) mutateWithExternalData(object *unstructured.Unstructured, exter
 // getTLSCertificate returns the gatekeeper's TLS certificate.
 func (s *System) getTLSCertificate() (*tls.Certificate, error) {
 	if s.clientCertWatcher == nil {
-		return nil, nil
+		return nil, fmt.Errorf("external data client certificate watcher is not initialized")
 	}
 
 	return s.clientCertWatcher.GetCertificate(nil)

--- a/pkg/mutation/system_external_data.go
+++ b/pkg/mutation/system_external_data.go
@@ -2,6 +2,7 @@ package mutation
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
 	"sync"
@@ -47,7 +48,12 @@ func (s *System) resolvePlaceholders(obj *unstructured.Unstructured) error {
 		return nil
 	}
 
-	externalData, errors := s.sendRequests(providerKeys)
+	clientCert, err := s.getTLSCertificate()
+	if err != nil {
+		return fmt.Errorf("failed to get client TLS certificate: %w", err)
+	}
+
+	externalData, errors := s.sendRequests(providerKeys, clientCert)
 	if err := s.mutateWithExternalData(obj, externalData, errors); err != nil {
 		return err
 	}
@@ -56,7 +62,7 @@ func (s *System) resolvePlaceholders(obj *unstructured.Unstructured) error {
 }
 
 // sendRequests sends requests to all providers in parallel.
-func (s *System) sendRequests(providerKeys map[string]sets.String) (map[string]map[string]*externaldata.Item, map[string]error) {
+func (s *System) sendRequests(providerKeys map[string]sets.String, clientCert *tls.Certificate) (map[string]map[string]*externaldata.Item, map[string]error) {
 	var (
 		wg    sync.WaitGroup
 		mutex sync.RWMutex
@@ -83,7 +89,7 @@ func (s *System) sendRequests(providerKeys map[string]sets.String) (map[string]m
 		go func(provider *v1alpha1.Provider, keys []string) {
 			defer wg.Done()
 
-			resp, _, err := fn(context.Background(), provider, keys)
+			resp, _, err := fn(context.Background(), provider, keys, clientCert)
 
 			mutex.Lock()
 			defer mutex.Unlock()
@@ -182,6 +188,15 @@ func (s *System) mutateWithExternalData(object *unstructured.Unstructured, exter
 	}
 
 	return errorsutil.NewAggregate(mutate(object.Object))
+}
+
+// getTLSCertificate returns the gatekeeper's TLS certificate.
+func (s *System) getTLSCertificate() (*tls.Certificate, error) {
+	if s.clientCertWatcher == nil {
+		return nil, nil
+	}
+
+	return s.clientCertWatcher.GetCertificate(nil)
 }
 
 // validateExternalDataResponse validates the given external data response.

--- a/pkg/mutation/system_external_data_test.go
+++ b/pkg/mutation/system_external_data_test.go
@@ -343,7 +343,10 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 	}
 	defer os.Remove(clientCertFile.Name())
 
-	_, _ = clientCertFile.WriteString(clientCert)
+	_, err = clientCertFile.WriteString(clientCert)
+	if err != nil {
+		t.Fatal(err)
+	}
 	clientCertFile.Close()
 
 	clientKeyFile, err := ioutil.TempFile("", "client-key")
@@ -352,7 +355,10 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 	}
 	defer os.Remove(clientKeyFile.Name())
 
-	_, _ = clientKeyFile.WriteString(clientKey)
+	_, err = clientKeyFile.WriteString(clientKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 	clientKeyFile.Close()
 
 	clientCertWatcher, err = certwatcher.New(clientCertFile.Name(), clientKeyFile.Name())

--- a/pkg/mutation/system_external_data_test.go
+++ b/pkg/mutation/system_external_data_test.go
@@ -2,8 +2,11 @@ package mutation
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"reflect"
 	"testing"
 
@@ -13,6 +16,65 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+)
+
+const (
+	clientCert = `
+-----BEGIN CERTIFICATE-----
+MIID0DCCArigAwIBAgIBATANBgkqhkiG9w0BAQUFADB/MQswCQYDVQQGEwJGUjET
+MBEGA1UECAwKU29tZS1TdGF0ZTEOMAwGA1UEBwwFUGFyaXMxDTALBgNVBAoMBERp
+bWkxDTALBgNVBAsMBE5TQlUxEDAOBgNVBAMMB0RpbWkgQ0ExGzAZBgkqhkiG9w0B
+CQEWDGRpbWlAZGltaS5mcjAeFw0xNDAxMjgyMDM2NTVaFw0yNDAxMjYyMDM2NTVa
+MFsxCzAJBgNVBAYTAkZSMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJ
+bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxFDASBgNVBAMMC3d3dy5kaW1pLmZyMIIB
+IjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvpnaPKLIKdvx98KW68lz8pGa
+RRcYersNGqPjpifMVjjE8LuCoXgPU0HePnNTUjpShBnynKCvrtWhN+haKbSp+QWX
+SxiTrW99HBfAl1MDQyWcukoEb9Cw6INctVUN4iRvkn9T8E6q174RbcnwA/7yTc7p
+1NCvw+6B/aAN9l1G2pQXgRdYC/+G6o1IZEHtWhqzE97nY5QKNuUVD0V09dc5CDYB
+aKjqetwwv6DFk/GRdOSEd/6bW+20z0qSHpa3YNW6qSp+x5pyYmDrzRIR03os6Dau
+ZkChSRyc/Whvurx6o85D6qpzywo8xwNaLZHxTQPgcIA5su9ZIytv9LH2E+lSwwID
+AQABo3sweTAJBgNVHRMEAjAAMCwGCWCGSAGG+EIBDQQfFh1PcGVuU1NMIEdlbmVy
+YXRlZCBDZXJ0aWZpY2F0ZTAdBgNVHQ4EFgQU+tugFtyN+cXe1wxUqeA7X+yS3bgw
+HwYDVR0jBBgwFoAUhMwqkbBrGp87HxfvwgPnlGgVR64wDQYJKoZIhvcNAQEFBQAD
+ggEBAIEEmqqhEzeXZ4CKhE5UM9vCKzkj5Iv9TFs/a9CcQuepzplt7YVmevBFNOc0
++1ZyR4tXgi4+5MHGzhYCIVvHo4hKqYm+J+o5mwQInf1qoAHuO7CLD3WNa1sKcVUV
+vepIxc/1aHZrG+dPeEHt0MdFfOw13YdUc2FH6AqEdcEL4aV5PXq2eYR8hR4zKbc1
+fBtuqUsvA8NWSIyzQ16fyGve+ANf6vXvUizyvwDrPRv/kfvLNa3ZPnLMMxU98Mvh
+PXy3PkB8++6U4Y3vdk2Ni2WYYlIls8yqbM4327IKmkDc2TimS8u60CT47mKU7aDY
+cbTV5RDkrlaYwm5yqlTIglvCv7o=
+-----END CERTIFICATE-----
+`
+
+	clientKey = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAvpnaPKLIKdvx98KW68lz8pGaRRcYersNGqPjpifMVjjE8LuC
+oXgPU0HePnNTUjpShBnynKCvrtWhN+haKbSp+QWXSxiTrW99HBfAl1MDQyWcukoE
+b9Cw6INctVUN4iRvkn9T8E6q174RbcnwA/7yTc7p1NCvw+6B/aAN9l1G2pQXgRdY
+C/+G6o1IZEHtWhqzE97nY5QKNuUVD0V09dc5CDYBaKjqetwwv6DFk/GRdOSEd/6b
+W+20z0qSHpa3YNW6qSp+x5pyYmDrzRIR03os6DauZkChSRyc/Whvurx6o85D6qpz
+ywo8xwNaLZHxTQPgcIA5su9ZIytv9LH2E+lSwwIDAQABAoIBAFml8cD9a5pMqlW3
+f9btTQz1sRL4Fvp7CmHSXhvjsjeHwhHckEe0ObkWTRsgkTsm1XLu5W8IITnhn0+1
+iNr+78eB+rRGngdAXh8diOdkEy+8/Cee8tFI3jyutKdRlxMbwiKsouVviumoq3fx
+OGQYwQ0Z2l/PvCwy/Y82ffq3ysC5gAJsbBYsCrg14bQo44ulrELe4SDWs5HCjKYb
+EI2b8cOMucqZSOtxg9niLN/je2bo/I2HGSawibgcOdBms8k6TvsSrZMr3kJ5O6J+
+77LGwKH37brVgbVYvbq6nWPL0xLG7dUv+7LWEo5qQaPy6aXb/zbckqLqu6/EjOVe
+ydG5JQECgYEA9kKfTZD/WEVAreA0dzfeJRu8vlnwoagL7cJaoDxqXos4mcr5mPDT
+kbWgFkLFFH/AyUnPBlK6BcJp1XK67B13ETUa3i9Q5t1WuZEobiKKBLFm9DDQJt43
+uKZWJxBKFGSvFrYPtGZst719mZVcPct2CzPjEgN3Hlpt6fyw3eOrnoECgYEAxiOu
+jwXCOmuGaB7+OW2tR0PGEzbvVlEGdkAJ6TC/HoKM1A8r2u4hLTEJJCrLLTfw++4I
+ddHE2dLeR4Q7O58SfLphwgPmLDezN7WRLGr7Vyfuv7VmaHjGuC3Gv9agnhWDlA2Q
+gBG9/R9oVfL0Dc7CgJgLeUtItCYC31bGT3yhV0MCgYEA4k3DG4L+RN4PXDpHvK9I
+pA1jXAJHEifeHnaW1d3vWkbSkvJmgVf+9U5VeV+OwRHN1qzPZV4suRI6M/8lK8rA
+Gr4UnM4aqK4K/qkY4G05LKrik9Ev2CgqSLQDRA7CJQ+Jn3Nb50qg6hFnFPafN+J7
+7juWln08wFYV4Atpdd+9XQECgYBxizkZFL+9IqkfOcONvWAzGo+Dq1N0L3J4iTIk
+w56CKWXyj88d4qB4eUU3yJ4uB4S9miaW/eLEwKZIbWpUPFAn0db7i6h3ZmP5ZL8Q
+qS3nQCb9DULmU2/tU641eRUKAmIoka1g9sndKAZuWo+o6fdkIb1RgObk9XNn8R4r
+psv+aQKBgB+CIcExR30vycv5bnZN9EFlIXNKaeMJUrYCXcRQNvrnUIUBvAO8+jAe
+CdLygS5RtgOLZib0IVErqWsP3EI1ACGuLts0vQ9GFLQGaN1SaMS40C9kvns1mlDu
+LhIhYpJ8UsCVt5snWo2N+M+6ANh5tpWdQnEK6zILh4tRbuzaiHgb
+-----END RSA PRIVATE KEY-----
+`
 )
 
 func TestSystem_resolvePlaceholders(t *testing.T) {
@@ -51,7 +113,7 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 			name: "when placeholder is part of a map[string]interface{}",
 			fields: fields{
 				providerCache: fakes.ExternalDataProviderCache,
-				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*externaldata.ProviderResponse, int, error) {
+				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*externaldata.ProviderResponse, int, error) {
 					return &externaldata.ProviderResponse{
 						Response: externaldata.Response{
 							Idempotent: true,
@@ -82,7 +144,7 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 			name: "when placeholder is part of a []interface{}",
 			fields: fields{
 				providerCache: fakes.ExternalDataProviderCache,
-				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*externaldata.ProviderResponse, int, error) {
+				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*externaldata.ProviderResponse, int, error) {
 					return &externaldata.ProviderResponse{
 						Response: externaldata.Response{
 							Idempotent: true,
@@ -121,7 +183,7 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 			name: "system error",
 			fields: fields{
 				providerCache: fakes.ExternalDataProviderCache,
-				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*externaldata.ProviderResponse, int, error) {
+				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*externaldata.ProviderResponse, int, error) {
 					return &externaldata.ProviderResponse{
 						Response: externaldata.Response{
 							Idempotent:  true,
@@ -147,7 +209,7 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 			name: "error when sending request",
 			fields: fields{
 				providerCache: fakes.ExternalDataProviderCache,
-				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*externaldata.ProviderResponse, int, error) {
+				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*externaldata.ProviderResponse, int, error) {
 					return nil, http.StatusInternalServerError, errors.New("error")
 				},
 			},
@@ -168,7 +230,7 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 			name: "failure policy fail",
 			fields: fields{
 				providerCache: fakes.ExternalDataProviderCache,
-				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*externaldata.ProviderResponse, int, error) {
+				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*externaldata.ProviderResponse, int, error) {
 					return &externaldata.ProviderResponse{
 						Response: externaldata.Response{
 							Idempotent: true,
@@ -199,7 +261,7 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 			name: "failure policy use default",
 			fields: fields{
 				providerCache: fakes.ExternalDataProviderCache,
-				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*externaldata.ProviderResponse, int, error) {
+				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*externaldata.ProviderResponse, int, error) {
 					return &externaldata.ProviderResponse{
 						Response: externaldata.Response{
 							Idempotent: true,
@@ -238,7 +300,7 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 			name: "failure policy ignore",
 			fields: fields{
 				providerCache: fakes.ExternalDataProviderCache,
-				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*externaldata.ProviderResponse, int, error) {
+				sendRequestToExternalDataProvider: func(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*externaldata.ProviderResponse, int, error) {
 					return &externaldata.ProviderResponse{
 						Response: externaldata.Response{
 							Idempotent: true,
@@ -274,12 +336,42 @@ func TestSystem_resolvePlaceholders(t *testing.T) {
 			},
 		},
 	}
+	var clientCertWatcher *certwatcher.CertWatcher
+	clientCertFile, err := ioutil.TempFile("", "client-cert")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(clientCertFile.Name())
+
+	_, _ = clientCertFile.WriteString(clientCert)
+	clientCertFile.Close()
+
+	clientKeyFile, err := ioutil.TempFile("", "client-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(clientKeyFile.Name())
+
+	_, _ = clientKeyFile.WriteString(clientKey)
+	clientKeyFile.Close()
+
+	clientCertWatcher, err = certwatcher.New(clientCertFile.Name(), clientKeyFile.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	go func() {
+		_ = clientCertWatcher.Start(context.Background())
+	}()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSystem(SystemOpts{
 				ProviderCache:                     tt.fields.providerCache,
 				SendRequestToExternalDataProvider: tt.fields.sendRequestToExternalDataProvider,
+				ClientCertWatcher:                 clientCertWatcher,
 			})
+
 			err := s.resolvePlaceholders(tt.args.obj)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("System.resolvePlaceholders() error = %v, wantErr %v", err, tt.wantErr)
@@ -343,6 +435,42 @@ func Test_validateExternalDataResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := validateExternalDataResponse(tt.args.r); (err != nil) != tt.wantErr {
 				t.Errorf("validateExternalDataResponse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSystem_getTLSCertificate(t *testing.T) {
+	type fields struct {
+		clientCertWatcher *certwatcher.CertWatcher
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    *tls.Certificate
+		wantErr bool
+	}{
+		{
+			name: "nil client cert watcher",
+			fields: fields{
+				clientCertWatcher: nil,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &System{
+				clientCertWatcher: tt.fields.clientCertWatcher,
+			}
+			got, err := s.getTLSCertificate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("System.getTLSCertificate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("System.getTLSCertificate() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/mutation/system_external_data_test.go
+++ b/pkg/mutation/system_external_data_test.go
@@ -462,7 +462,7 @@ func TestSystem_getTLSCertificate(t *testing.T) {
 				clientCertWatcher: nil,
 			},
 			want:    nil,
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -310,8 +310,9 @@ func Test_Provider(t *testing.T) {
 		}
 
 		want := externaldatav1alpha1.ProviderSpec{
-			URL:     "http://demo",
-			Timeout: 1,
+			URL:                   "http://demo",
+			Timeout:               1,
+			InsecureTLSSkipVerify: true,
 		}
 		if diff := cmp.Diff(want, instance.Spec); diff != "" {
 			t.Fatal(diff)

--- a/pkg/readiness/testdata/99-provider.yaml
+++ b/pkg/readiness/testdata/99-provider.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   url: http://demo
   timeout: 1
+  insecureTLSSkipVerify: true

--- a/pkg/readiness/testdata_test.go
+++ b/pkg/readiness/testdata_test.go
@@ -130,8 +130,9 @@ func makeProvider(name string) *externaldatav1alpha1.Provider {
 			Name: name,
 		},
 		Spec: externaldatav1alpha1.ProviderSpec{
-			URL:     "http://demo",
-			Timeout: 1,
+			URL:                   "http://demo",
+			Timeout:               1,
+			InsecureTLSSkipVerify: true,
 		},
 	}
 }

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -46,6 +46,7 @@ var (
 const (
 	serviceAccountName = "gatekeeper-admin"
 	mutationsGroup     = "mutations.gatekeeper.sh"
+	externalDataGroup  = "externaldata.gatekeeper.sh"
 	namespaceKind      = "Namespace"
 )
 

--- a/test/externaldata/dummy-provider/Dockerfile
+++ b/test/externaldata/dummy-provider/Dockerfile
@@ -28,7 +28,11 @@ FROM $BASEIMAGE
 
 WORKDIR /
 
-COPY --from=builder /go/src/github.com/open-policy-agent/gatekeeper/test/externaldata/dummy-provider .
+COPY --from=builder /go/src/github.com/open-policy-agent/gatekeeper/test/externaldata/dummy-provider/provider .
+
+COPY --from=builder --chown=65532:65532 /go/src/github.com/open-policy-agent/gatekeeper/test/externaldata/dummy-provider/certs/server.crt \
+    /go/src/github.com/open-policy-agent/gatekeeper/test/externaldata/dummy-provider/certs/server.key \
+    /etc/ssl/certs/
 
 USER 65532:65532
 

--- a/test/externaldata/dummy-provider/manifest/deployment.yaml
+++ b/test/externaldata/dummy-provider/manifest/deployment.yaml
@@ -1,13 +1,8 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: dummy-provider
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dummy-provider
-  namespace: dummy-provider
+  namespace: gatekeeper-system
 spec:
   replicas: 1
   selector:
@@ -25,6 +20,17 @@ spec:
         ports:
         - containerPort: 8090
           protocol: TCP
+        volumeMounts:
+        - name: gatekeeper-ca-cert
+          mountPath: /tmp/gatekeeper
+          readOnly: true
       restartPolicy: Always
       nodeSelector:
         kubernetes.io/os: linux
+      volumes:
+      - name: gatekeeper-ca-cert
+        secret:
+          secretName: gatekeeper-webhook-server-cert
+          items:
+          - key: ca.crt
+            path: ca.crt

--- a/test/externaldata/dummy-provider/manifest/provider.yaml
+++ b/test/externaldata/dummy-provider/manifest/provider.yaml
@@ -3,5 +3,5 @@ kind: Provider
 metadata:
   name: dummy-provider
 spec:
-  url: http://dummy-provider.dummy-provider:8090/validate
-  timeout: 2
+  url: https://dummy-provider.gatekeeper-system:8090/validate
+  timeout: 1

--- a/test/externaldata/dummy-provider/manifest/service.yaml
+++ b/test/externaldata/dummy-provider/manifest/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dummy-provider
-  namespace: dummy-provider
+  namespace: gatekeeper-system
 spec:
   ports:
   - port: 8090

--- a/test/externaldata/dummy-provider/scripts/generate-tls-certificate.sh
+++ b/test/externaldata/dummy-provider/scripts/generate-tls-certificate.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/../../../..
+cd "${REPO_ROOT}" || exit 1
+
+generate() {
+    # generate CA key and certificate
+    echo "Generating CA key and certificate for dummy provider..."
+    openssl genrsa -out ca.key 2048
+    openssl req -new -x509 -days 1 -key ca.key -subj "/O=Gatekeeper/CN=Gatekeeper Root CA" -out ca.crt
+
+    # generate server key and certificate
+    echo "Generating server key and certificate for dummy provider..."
+    openssl genrsa -out server.key 2048
+    openssl req -newkey rsa:2048 -nodes -keyout server.key -subj "/CN=dummy-provider.gatekeeper-system" -out server.csr
+    openssl x509 -req -extfile <(printf "subjectAltName=DNS:dummy-provider.gatekeeper-system") -days 1 -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt
+}
+
+mkdir -p "${REPO_ROOT}/test/externaldata/dummy-provider/certs"
+pushd "${REPO_ROOT}/test/externaldata/dummy-provider/certs"
+generate
+popd

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/deploy/crds.yaml
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/deploy/crds.yaml
@@ -366,6 +366,15 @@ spec:
           spec:
             description: Spec defines the Provider specifications.
             properties:
+              caBundle:
+                description: CABundle is a base64-encoded string that contains the
+                  TLS CA bundle in PEM format. It is used to verify the signature
+                  of the provider's certificate.
+                type: string
+              insecureTLSSkipVerify:
+                description: InsecureTLSSkipVerify skips the verification of Provider's
+                  certificate if enabled.
+                type: boolean
               timeout:
                 description: Timeout is the timeout when querying the provider.
                 type: integer

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/v1alpha1/provider_types.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/v1alpha1/provider_types.go
@@ -25,6 +25,11 @@ type ProviderSpec struct {
 	URL string `json:"url,omitempty"`
 	// Timeout is the timeout when querying the provider.
 	Timeout int `json:"timeout,omitempty"`
+	// CABundle is a base64-encoded string that contains the TLS CA bundle in PEM format.
+	// It is used to verify the signature of the provider's certificate.
+	CABundle string `json:"caBundle,omitempty"`
+	// InsecureTLSSkipVerify skips the verification of Provider's certificate if enabled.
+	InsecureTLSSkipVerify bool `json:"insecureTLSSkipVerify,omitempty"`
 }
 
 // +genclient

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local/args.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local/args.go
@@ -9,6 +9,7 @@ import (
 	"github.com/open-policy-agent/opa/storage"
 	"github.com/open-policy-agent/opa/topdown/print"
 	opatypes "github.com/open-policy-agent/opa/types"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 )
 
 type Arg func(*Driver) error
@@ -110,6 +111,22 @@ func DisableBuiltins(builtins ...string) Arg {
 		}
 
 		d.compilers.capabilities.Builtins = newBuiltins
+
+		return nil
+	}
+}
+
+func AddExternalDataClientCertWatcher(clientCertWatcher *certwatcher.CertWatcher) Arg {
+	return func(d *Driver) error {
+		d.clientCertWatcher = clientCertWatcher
+
+		return nil
+	}
+}
+
+func EnableExternalDataClientAuth() Arg {
+	return func(d *Driver) error {
+		d.enableExternalDataClientAuth = true
 
 		return nil
 	}

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local/builtin.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/local/builtin.go
@@ -20,7 +20,12 @@ func externalDataBuiltin(d *Driver) func(bctx rego.BuiltinContext, regorequest *
 			return externaldata.HandleError(http.StatusBadRequest, err)
 		}
 
-		externaldataResponse, statusCode, err := d.sendRequestToProvider(bctx.Context, &provider, regoReq.Keys)
+		clientCert, err := d.getTLSCertificate()
+		if err != nil {
+			return externaldata.HandleError(http.StatusBadRequest, err)
+		}
+
+		externaldataResponse, statusCode, err := d.sendRequestToProvider(bctx.Context, &provider, regoReq.Keys, clientCert)
 		if err != nil {
 			return externaldata.HandleError(statusCode, err)
 		}

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/externaldata/cache.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/externaldata/cache.go
@@ -1,8 +1,11 @@
 package externaldata
 
 import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"fmt"
-	"strings"
+	"net/url"
 	"sync"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/v1alpha1"
@@ -43,6 +46,9 @@ func (c *ProviderCache) Upsert(provider *v1alpha1.Provider) error {
 	if !isValidTimeout(provider.Spec.Timeout) {
 		return fmt.Errorf("provider timeout should be a positive integer. value: %d", provider.Spec.Timeout)
 	}
+	if err := isValidCABundle(provider); err != nil {
+		return err
+	}
 
 	c.cache[provider.GetName()] = *provider.DeepCopy()
 	return nil
@@ -60,15 +66,60 @@ func isValidName(name string) bool {
 }
 
 func isValidURL(url string) bool {
-	if len(url) == 0 {
-		return false
-	}
-	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
-		return false
-	}
-	return true
+	return len(url) != 0
 }
 
 func isValidTimeout(timeout int) bool {
 	return timeout >= 0
+}
+
+func isValidCABundle(provider *v1alpha1.Provider) error {
+	// verify attempts to parse the caBundle as a PEM encoded certificate
+	// to make sure it is valid before adding it to the cache
+	verify := func(caBundle string) error {
+		caPem, err := base64.StdEncoding.DecodeString(caBundle)
+		if err != nil {
+			return fmt.Errorf("failed to base64 decode caBundle: %w", err)
+		}
+
+		caDer, _ := pem.Decode(caPem)
+		if caDer == nil {
+			return fmt.Errorf("bad caBundle")
+		}
+
+		_, err = x509.ParseCertificate(caDer.Bytes)
+		if err != nil {
+			return fmt.Errorf("failed to parse caBundle: %w", err)
+		}
+
+		return nil
+	}
+
+	u, err := url.Parse(provider.Spec.URL)
+	if err != nil {
+		return err
+	}
+
+	switch u.Scheme {
+	case HTTPScheme:
+		if !provider.Spec.InsecureTLSSkipVerify {
+			return fmt.Errorf("only HTTPS scheme is supported for this Provider. To enable HTTP scheme, set insecureTLSSkipVerify to true")
+		}
+		if provider.Spec.CABundle != "" {
+			if err := verify(provider.Spec.CABundle); err != nil {
+				return err
+			}
+		}
+	case HTTPSScheme:
+		if provider.Spec.CABundle == "" {
+			return fmt.Errorf("caBundle should be set for HTTPS scheme")
+		}
+		if err := verify(provider.Spec.CABundle); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("only HTTPS and HTTP schemes are supported for Providers")
+	}
+
+	return nil
 }

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/externaldata/request.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/externaldata/request.go
@@ -3,13 +3,22 @@ package externaldata
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/v1alpha1"
+)
+
+const (
+	HTTPScheme  = "http"
+	HTTPSScheme = "https"
 )
 
 // RegoRequest is the request for external_data rego function.
@@ -48,14 +57,19 @@ func NewProviderRequest(keys []string) *ProviderRequest {
 }
 
 // SendRequestToProvider is a function that sends a request to the external data provider.
-type SendRequestToProvider func(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*ProviderResponse, int, error)
+type SendRequestToProvider func(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*ProviderResponse, int, error)
 
 // DefaultSendRequestToProvider is the default function to send the request to the external data provider.
-func DefaultSendRequestToProvider(ctx context.Context, provider *v1alpha1.Provider, keys []string) (*ProviderResponse, int, error) {
+func DefaultSendRequestToProvider(ctx context.Context, provider *v1alpha1.Provider, keys []string, clientCert *tls.Certificate) (*ProviderResponse, int, error) {
 	externaldataRequest := NewProviderRequest(keys)
 	body, err := json.Marshal(externaldataRequest)
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to marshal external data request: %w", err)
+	}
+
+	client, err := getClient(provider, clientCert)
+	if err != nil {
+		return nil, http.StatusInternalServerError, fmt.Errorf("failed to get HTTP client: %w", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, provider.Spec.URL, bytes.NewBuffer(body))
@@ -67,7 +81,7 @@ func DefaultSendRequestToProvider(ctx context.Context, provider *v1alpha1.Provid
 	ctxWithDeadline, cancel := context.WithDeadline(ctx, time.Now().Add(time.Duration(provider.Spec.Timeout)*time.Second))
 	defer cancel()
 
-	resp, err := http.DefaultClient.Do(req.WithContext(ctxWithDeadline))
+	resp, err := client.Do(req.WithContext(ctxWithDeadline))
 	if err != nil {
 		return nil, http.StatusInternalServerError, fmt.Errorf("failed to send external data request: %w", err)
 	}
@@ -84,6 +98,51 @@ func DefaultSendRequestToProvider(ctx context.Context, provider *v1alpha1.Provid
 	}
 
 	return &externaldataResponse, resp.StatusCode, nil
+}
+
+// getClient returns a new HTTP client, and set up its TLS configuration if necessary.
+func getClient(provider *v1alpha1.Provider, clientCert *tls.Certificate) (*http.Client, error) {
+	u, err := url.Parse(provider.Spec.URL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse provider URL %s: %w", provider.Spec.URL, err)
+	}
+
+	client := &http.Client{
+		Timeout: time.Duration(provider.Spec.Timeout) * time.Second,
+	}
+
+	tlsConfig := &tls.Config{
+		//nolint:gosec
+		InsecureSkipVerify: provider.Spec.InsecureTLSSkipVerify,
+	}
+
+	// present our client cert to the server
+	// in case provider wants to verify it
+	if clientCert != nil {
+		tlsConfig.Certificates = []tls.Certificate{*clientCert}
+	}
+
+	if u.Scheme == HTTPSScheme && !provider.Spec.InsecureTLSSkipVerify {
+		// if the provider presents its own CA bundle,
+		// we will use it to verify the server's certificate
+		caBundleData, err := base64.StdEncoding.DecodeString(provider.Spec.CABundle)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode CA bundle: %w", err)
+		}
+
+		providerCertPool := x509.NewCertPool()
+		if ok := providerCertPool.AppendCertsFromPEM(caBundleData); !ok {
+			return nil, fmt.Errorf("failed to append provider's CA bundle to certificate pool")
+		}
+
+		tlsConfig.RootCAs = providerCertPool
+	}
+
+	client.Transport = &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+
+	return client, nil
 }
 
 // ProviderKind strings are special string constants for Providers.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -295,10 +295,10 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/open-policy-agent/cert-controller v0.3.0
+# github.com/open-policy-agent/cert-controller v0.4.0
 ## explicit; go 1.17
 github.com/open-policy-agent/cert-controller/pkg/rotator
-# github.com/open-policy-agent/frameworks/constraint v0.0.0-20220621170157-36b73e182701
+# github.com/open-policy-agent/frameworks/constraint v0.0.0-20220621232220-a0dd2a57505b
 ## explicit; go 1.17
 github.com/open-policy-agent/frameworks/constraint/deploy
 github.com/open-policy-agent/frameworks/constraint/pkg/apis


### PR DESCRIPTION
**What this PR does / why we need it**:

Design doc: [docs.google.com/document/d/1GjV3WeC2bgQ3j37_mMpY9hr7YOAqzSJ6jDSu-DVrcmU/edit#](https://docs.google.com/document/d/1GjV3WeC2bgQ3j37_mMpY9hr7YOAqzSJ6jDSu-DVrcmU/edit#)

This PR integrates changes in https://github.com/open-policy-agent/frameworks/pull/226 and https://github.com/open-policy-agent/cert-controller/pull/43 to enable the end-to-end experience of TLS support for external data providers.

ref: #1576

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
