### PR TITLE
fix: increase mutating webhook timeout to 3s

### DIFF
--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -19,7 +19,7 @@ mutatingWebhookFailurePolicy: Ignore
 mutatingWebhookReinvocationPolicy: Never
 mutatingWebhookExemptNamespacesLabels: {}
 mutatingWebhookObjectSelector: {}
-mutatingWebhookTimeoutSeconds: 1
+mutatingWebhookTimeoutSeconds: 3
 mutatingWebhookCustomRules: {}
 mutationAnnotations: false
 auditChunkSize: 500

--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -5,7 +5,7 @@ metadata:
 webhooks:
   - name: mutation.gatekeeper.sh
     sideEffects: None
-    timeoutSeconds: 1
+    timeoutSeconds: 3
     namespaceSelector:
       matchExpressions:
         - key: admission.gatekeeper.sh/ignore

--- a/deploy/gatekeeper.yaml
+++ b/deploy/gatekeeper.yaml
@@ -2658,7 +2658,7 @@ webhooks:
     resources:
     - '*'
   sideEffects: None
-  timeoutSeconds: 1
+  timeoutSeconds: 3
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -19,7 +19,7 @@ mutatingWebhookFailurePolicy: Ignore
 mutatingWebhookReinvocationPolicy: Never
 mutatingWebhookExemptNamespacesLabels: {}
 mutatingWebhookObjectSelector: {}
-mutatingWebhookTimeoutSeconds: 1
+mutatingWebhookTimeoutSeconds: 3
 mutatingWebhookCustomRules: {}
 mutationAnnotations: false
 auditChunkSize: 500

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -2658,7 +2658,7 @@ webhooks:
     resources:
     - '*'
   sideEffects: None
-  timeoutSeconds: 1
+  timeoutSeconds: 3
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
**What this PR does / why we need it**:

1s is a bit low on slow clusters.

(Same as the validating webhook, and the (previously incorect) chart doc)