### PR TITLE
fix: document mutations name matcher

### DIFF
--- a/website/docs/mutation.md
+++ b/website/docs/mutation.md
@@ -25,6 +25,7 @@ metadata:
 spec:
   match:
     scope: Namespaced
+    name: nginx-*
     kinds:
     - apiGroups: ["*"]
       kinds: ["Pod"]
@@ -73,6 +74,7 @@ The `match` section is common to all mutators. It supports the following match c
 - namespaces - list of allowed namespaces, only resources in listed namespaces will be mutated
 - namespaceSelector - filters resources by namespace selector
 - excludedNamespaces - list of excluded namespaces, resources in listed namespaces will not be mutated
+- name - the name of an object.  If defined, it matches against objects with the specified name.  Name also supports a prefix-based glob.  For example, `name: pod-*` matches both `pod-a` and `pod-b`.
 
 Note that any empty/undefined match criteria are inclusive: they match any object.
 

--- a/website/versioned_docs/version-v3.7.x/mutation.md
+++ b/website/versioned_docs/version-v3.7.x/mutation.md
@@ -25,6 +25,7 @@ metadata:
 spec:
   match:
     scope: Namespaced
+    name: nginx-*
     kinds:
     - apiGroups: ["*"]
       kinds: ["Pod"]
@@ -73,6 +74,7 @@ The `match` section is common to all mutators. It supports the following match c
 - namespaces - list of allowed namespaces, only resources in listed namespaces will be mutated
 - namespaceSelector - filters resources by namespace selector
 - excludedNamespaces - list of excluded namespaces, resources in listed namespaces will not be mutated
+- name - the name of an object.  If defined, it matches against objects with the specified name.  Name also supports a prefix-based glob.  For example, `name: pod-*` matches both `pod-a` and `pod-b`.
 
 Note that any empty/undefined match criteria are inclusive: they match any object.
 

--- a/website/versioned_docs/version-v3.8.x/mutation.md
+++ b/website/versioned_docs/version-v3.8.x/mutation.md
@@ -25,6 +25,7 @@ metadata:
 spec:
   match:
     scope: Namespaced
+    name: nginx-*
     kinds:
     - apiGroups: ["*"]
       kinds: ["Pod"]
@@ -73,6 +74,7 @@ The `match` section is common to all mutators. It supports the following match c
 - namespaces - list of allowed namespaces, only resources in listed namespaces will be mutated
 - namespaceSelector - filters resources by namespace selector
 - excludedNamespaces - list of excluded namespaces, resources in listed namespaces will not be mutated
+- name - the name of an object.  If defined, it matches against objects with the specified name.  Name also supports a prefix-based glob.  For example, `name: pod-*` matches both `pod-a` and `pod-b`.
 
 Note that any empty/undefined match criteria are inclusive: they match any object.
 

--- a/website/versioned_docs/version-v3.9.x/mutation.md
+++ b/website/versioned_docs/version-v3.9.x/mutation.md
@@ -25,6 +25,7 @@ metadata:
 spec:
   match:
     scope: Namespaced
+    name: nginx-*
     kinds:
     - apiGroups: ["*"]
       kinds: ["Pod"]
@@ -73,6 +74,7 @@ The `match` section is common to all mutators. It supports the following match c
 - namespaces - list of allowed namespaces, only resources in listed namespaces will be mutated
 - namespaceSelector - filters resources by namespace selector
 - excludedNamespaces - list of excluded namespaces, resources in listed namespaces will not be mutated
+- name - the name of an object.  If defined, it matches against objects with the specified name.  Name also supports a prefix-based glob.  For example, `name: pod-*` matches both `pod-a` and `pod-b`.
 
 Note that any empty/undefined match criteria are inclusive: they match any object.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Documents the name matcher which exists and functions but is unmentioned in the mutations documents.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
N/A

Uncertain if I should also go and add this to the versioned docs. Would that be the right thing to do here?

