### PR TITLE
fix(helm): helm chart updates for disabling psp and default api for poddisruptionbudget

### DIFF
--- a/cmd/build/helmify/main.go
+++ b/cmd/build/helmify/main.go
@@ -142,11 +142,15 @@ func (ks *kindSet) Write() error {
 			}
 
 			if name == "gatekeeper-controller-manager" && kind == "PodDisruptionBudget" {
-				obj = strings.Replace(obj, "apiVersion: policy/v1beta1", "{{- if .Capabilities.APIVersions.Has \"policy/v1\" }}\napiVersion: policy/v1\n{{ else }}\napiVersion: policy/v1beta1\n{{ end -}}", 1)
+				obj = strings.Replace(obj, "apiVersion: policy/v1beta1", "{{- $v1 := .Capabilities.APIVersions.Has \"policy/v1/PodDisruptionBudget\" -}}\n{{- $v1beta1 := .Capabilities.APIVersions.Has \"policy/v1beta1/PodDisruptionBudget\" -}}\napiVersion: policy/v1{{- if and (not $v1) $v1beta1 -}}beta1{{- end }}", 1)
 			}
 
 			if name == "gatekeeper-admin" && kind == "PodSecurityPolicy" {
 				obj = "{{- if .Values.psp.enabled }}\n" + obj + "{{- end }}\n"
+			}
+
+			if name == "gatekeeper-manager-role" && kind == "ClusterRole" {
+				obj = strings.Replace(obj, "- apiGroups:\n  - policy\n  resourceNames:\n  - gatekeeper-admin\n  resources:\n  - podsecuritypolicies\n  verbs:\n  - use\n", "{{- if .Values.psp.enabled }}\n- apiGroups:\n  - policy\n  resourceNames:\n  - gatekeeper-admin\n  resources:\n  - podsecuritypolicies\n  verbs:\n  - use\n{{- end }}\n", 1)
 			}
 
 			if err := os.WriteFile(destFile, []byte(obj), 0o600); err != nil {

--- a/cmd/build/helmify/main.go
+++ b/cmd/build/helmify/main.go
@@ -146,11 +146,11 @@ func (ks *kindSet) Write() error {
 			}
 
 			if name == "gatekeeper-admin" && kind == "PodSecurityPolicy" {
-				obj = "{{- if .Values.psp.enabled }}\n" + obj + "{{- end }}\n"
+				obj = "{{- if and .Values.psp.enabled (.Capabilities.APIVersions.Has \"policy/v1beta1/PodSecurityPolicy\") }}\n" + obj + "{{- end }}\n"
 			}
 
 			if name == "gatekeeper-manager-role" && kind == "ClusterRole" {
-				obj = strings.Replace(obj, "- apiGroups:\n  - policy\n  resourceNames:\n  - gatekeeper-admin\n  resources:\n  - podsecuritypolicies\n  verbs:\n  - use\n", "{{- if .Values.psp.enabled }}\n- apiGroups:\n  - policy\n  resourceNames:\n  - gatekeeper-admin\n  resources:\n  - podsecuritypolicies\n  verbs:\n  - use\n{{- end }}\n", 1)
+				obj = strings.Replace(obj, "- apiGroups:\n  - policy\n  resourceNames:\n  - gatekeeper-admin\n  resources:\n  - podsecuritypolicies\n  verbs:\n  - use\n", "{{- if and .Values.psp.enabled (.Capabilities.APIVersions.Has \"policy/v1beta1/PodSecurityPolicy\") }}\n- apiGroups:\n  - policy\n  resourceNames:\n  - gatekeeper-admin\n  resources:\n  - podsecuritypolicies\n  verbs:\n  - use\n{{- end }}\n", 1)
 			}
 
 			if err := os.WriteFile(destFile, []byte(obj), 0o600); err != nil {

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-admin-podsecuritypolicy.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-admin-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.psp.enabled }}
+{{- if and .Values.psp.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
@@ -1,8 +1,6 @@
-{{- if .Capabilities.APIVersions.Has "policy/v1" }}
-apiVersion: policy/v1
-{{ else }}
-apiVersion: policy/v1beta1
-{{ end -}}
+{{- $v1 := .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+{{- $v1beta1 := .Capabilities.APIVersions.Has "policy/v1beta1/PodDisruptionBudget" -}}
+apiVersion: policy/v1{{- if and (not $v1) $v1beta1 -}}beta1{{- end }}
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
@@ -99,7 +99,7 @@ rules:
   - patch
   - update
   - watch
-{{- if .Values.psp.enabled }}
+{{- if and .Values.psp.enabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
 - apiGroups:
   - policy
   resourceNames:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
@@ -99,6 +99,7 @@ rules:
   - patch
   - update
   - watch
+{{- if .Values.psp.enabled }}
 - apiGroups:
   - policy
   resourceNames:
@@ -107,6 +108,7 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+{{- end }}
 - apiGroups:
   - status.gatekeeper.sh
   resources:


### PR DESCRIPTION

Signed-off-by: Michael McLeroy <michaelmcleroy@cloudfitsoftware.com>

**What this PR does / why we need it**:

- Removes remnant in `ClusterRole` of PodSecurityPolicy when `psp.enabled: false` is set.  Previously, only the `PodSecurityPolicy` itself was removed.
- Adds logic to default to `policy/v1` for `PodDisruptionBudget` when neither `v1` or `v1beta1` are found in the cluster (e.g. we are running `helm template`).  This will allow static analysis (e.g. linting) tools to not flag this as deprecated.

**Which issue(s) this PR fixes** 
fixes #2185, fixes #2186 

**Special notes for your reviewer**:
