### PR TITLE
feat: Return violating resource in pkg/gator/test.Test

### DIFF
--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -116,7 +116,7 @@ func run(cmd *cobra.Command, args []string) {
 	os.Exit(exitCode)
 }
 
-func enforceableFailure(results []*types.Result) bool {
+func enforceableFailure(results []*test.GatorResult) bool {
 	for _, result := range results {
 		if result.EnforcementAction == string(util.Deny) {
 			return true

--- a/pkg/gator/test/test_test.go
+++ b/pkg/gator/test/test_test.go
@@ -60,7 +60,7 @@ func TestTest(t *testing.T) {
 	tcs := []struct {
 		name   string
 		inputs []string
-		want   []*types.Result
+		want   []*GatorResult
 		err    error
 	}{
 		{
@@ -78,21 +78,27 @@ func TestTest(t *testing.T) {
 				fixtures.ConstraintNeverValidate,
 				fixtures.Object,
 			},
-			want: []*types.Result{
+			want: []*GatorResult{
 				{
-					Target:     target.Name,
-					Msg:        "never validate",
-					Constraint: constraintNeverValidate,
+					Result: types.Result{
+						Target:     target.Name,
+						Msg:        "never validate",
+						Constraint: constraintNeverValidate,
+					},
 				},
 				{
-					Target:     target.Name,
-					Msg:        "never validate",
-					Constraint: constraintNeverValidate,
+					Result: types.Result{
+						Target:     target.Name,
+						Msg:        "never validate",
+						Constraint: constraintNeverValidate,
+					},
 				},
 				{
-					Target:     target.Name,
-					Msg:        "never validate",
-					Constraint: constraintNeverValidate,
+					Result: types.Result{
+						Target:     target.Name,
+						Msg:        "never validate",
+						Constraint: constraintNeverValidate,
+					},
 				},
 			},
 		},
@@ -104,16 +110,20 @@ func TestTest(t *testing.T) {
 				fixtures.ObjectReferentialInventory,
 				fixtures.ObjectReferentialDeny,
 			},
-			want: []*types.Result{
+			want: []*GatorResult{
 				{
-					Target:     target.Name,
-					Msg:        "same selector as service <gatekeeper-test-service-disallowed> in namespace <default>",
-					Constraint: constraintReferential,
+					Result: types.Result{
+						Target:     target.Name,
+						Msg:        "same selector as service <gatekeeper-test-service-disallowed> in namespace <default>",
+						Constraint: constraintReferential,
+					},
 				},
 				{
-					Target:     target.Name,
-					Msg:        "same selector as service <gatekeeper-test-service-example> in namespace <default>",
-					Constraint: constraintReferential,
+					Result: types.Result{
+						Target:     target.Name,
+						Msg:        "same selector as service <gatekeeper-test-service-example> in namespace <default>",
+						Constraint: constraintReferential,
+					},
 				},
 			},
 		},
@@ -166,7 +176,6 @@ func TestTest(t *testing.T) {
 
 			resps, err := Test(objs)
 			if tc.err != nil {
-				// If we're checking for specific errors, use errors.Is() to verify
 				if err == nil {
 					t.Errorf("got nil err, want %v", tc.err)
 				}
@@ -179,9 +188,9 @@ func TestTest(t *testing.T) {
 
 			got := resps.Results()
 
-			diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(types.Result{}, "Metadata", "EnforcementAction"))
+			diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(GatorResult{}, "Metadata", "EnforcementAction", "ViolatingObject"))
 			if diff != "" {
-				t.Errorf("diff in Result objects (-want +got):\n%s", diff)
+				t.Errorf("diff in GatorResult objects (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/gator/test/types.go
+++ b/pkg/gator/test/types.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"sort"
+
+	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type GatorResult struct {
+	types.Result
+
+	ViolatingObject *unstructured.Unstructured
+}
+
+func fromFrameworkResult(frameResult *types.Result, violatingObject *unstructured.Unstructured) *GatorResult {
+	gResult := &GatorResult{Result: *frameResult}
+
+	// do a deep copy to detach us from the Constraint Framework's references
+	gResult.Constraint = frameResult.Constraint.DeepCopy()
+
+	// set the violating object, which is no longer part of framework results
+	gResult.ViolatingObject = violatingObject
+
+	return gResult
+}
+
+// Response is a collection of Constraint violations for a particular Target.
+// Each Result is for a distinct Constraint.
+type GatorResponse struct {
+	Trace   *string
+	Target  string
+	Results []*GatorResult
+}
+
+type GatorResponses struct {
+	ByTarget map[string]*GatorResponse
+	Handled  map[string]bool
+}
+
+func (r *GatorResponses) Results() []*GatorResult {
+	if r == nil {
+		return nil
+	}
+
+	var res []*GatorResult
+	for target, resp := range r.ByTarget {
+		for _, rr := range resp.Results {
+			rr.Target = target
+			res = append(res, rr)
+		}
+	}
+
+	// Make results more (but not completely) deterministic.
+	// After we shard Rego compilation environments, we will be able to tie
+	// responses to individual constraints. This is a stopgap to make tests easier
+	// to write until then.
+	sort.Slice(res, func(i, j int) bool {
+		if res[i].EnforcementAction != res[j].EnforcementAction {
+			return res[i].EnforcementAction < res[j].EnforcementAction
+		}
+		return res[i].Msg < res[j].Msg
+	})
+
+	return res
+}


### PR DESCRIPTION
During the refactoring of the Constraint Framework, the violating
resource was removed from the pkg/types.Result struct.

As this struct was returned in the public interface of Gatekeeper's
pkg/gator/test.Test() function, consumers of that test package were
deprived of their ability to discern which resource was causing the
violation returned to them.

This PR declares a new set of types in the `test` package that are meant
to mirror those of CF's `types` package, but that include a reference to
the violating object.

This PR also updates the gator test CLI command to use this new
interface.

Signed-off-by: juliankatz <juliankatz@google.com>
