### PR TITLE
fix(helm): Use .chart template for Chart label

### DIFF
--- a/cmd/build/helmify/kustomization.yaml
+++ b/cmd/build/helmify/kustomization.yaml
@@ -1,7 +1,7 @@
 namespace: "{{ .Release.Namespace }}"
 commonLabels:
   app: '{{ template "gatekeeper.name" . }}'
-  chart: '{{ template "gatekeeper.name" . }}'
+  chart: '{{ template "gatekeeper.chart" . }}'
   release: "{{ .Release.Name }}"
   heritage: "{{ .Release.Service }}"
 bases:

--- a/cmd/build/helmify/static/templates/namespace-post-install.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-install.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gatekeeper-update-namespace-label
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/cmd/build/helmify/static/templates/namespace-post-upgrade.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-upgrade.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gatekeeper-update-namespace-label-post-upgrade
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/cmd/build/helmify/static/templates/probe-webhook-post-install.yaml
+++ b/cmd/build/helmify/static/templates/probe-webhook-post-install.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gatekeeper-probe-webhook-post-install
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
+++ b/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
@@ -61,11 +61,11 @@ metadata:
   name: gatekeeper-update-crds-hook
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "gatekeeper.name" . }}
-    chart: {{ template "gatekeeper.name" . }}
+    app: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "1"

--- a/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
+++ b/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gatekeeper-delete-webhook-configs
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-admin-podsecuritypolicy.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-admin-podsecuritypolicy.yaml
@@ -6,7 +6,7 @@ metadata:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-admin-serviceaccount.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-admin-serviceaccount.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     control-plane: audit-controller
     gatekeeper.sh/operation: audit
     gatekeeper.sh/system: "yes"
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app: '{{ template "gatekeeper.name" . }}'
-      chart: '{{ template "gatekeeper.name" . }}'
+      chart: '{{ template "gatekeeper.chart" . }}'
       control-plane: audit-controller
       gatekeeper.sh/operation: audit
       gatekeeper.sh/system: "yes"
@@ -31,7 +31,7 @@ spec:
       labels:
 {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
-        chart: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.chart" . }}'
         control-plane: audit-controller
         gatekeeper.sh/operation: audit
         gatekeeper.sh/system: "yes"

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     control-plane: controller-manager
     gatekeeper.sh/operation: webhook
     gatekeeper.sh/system: "yes"
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app: '{{ template "gatekeeper.name" . }}'
-      chart: '{{ template "gatekeeper.name" . }}'
+      chart: '{{ template "gatekeeper.chart" . }}'
       control-plane: controller-manager
       gatekeeper.sh/operation: webhook
       gatekeeper.sh/system: "yes"
@@ -31,7 +31,7 @@ spec:
       labels:
 {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
-        chart: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.chart" . }}'
         control-plane: controller-manager
         gatekeeper.sh/operation: webhook
         gatekeeper.sh/system: "yes"

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
@@ -7,7 +7,7 @@ kind: PodDisruptionBudget
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'
@@ -18,7 +18,7 @@ spec:
   selector:
     matchLabels:
       app: '{{ template "gatekeeper.name" . }}'
-      chart: '{{ template "gatekeeper.name" . }}'
+      chart: '{{ template "gatekeeper.chart" . }}'
       control-plane: controller-manager
       gatekeeper.sh/operation: webhook
       gatekeeper.sh/system: "yes"

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-critical-pods-resourcequota.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-critical-pods-resourcequota.yaml
@@ -4,7 +4,7 @@ kind: ResourceQuota
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
@@ -5,7 +5,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-role.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-role.yaml
@@ -5,7 +5,7 @@ metadata:
   creationTimestamp: null
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-rolebinding-clusterrolebinding.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-rolebinding-clusterrolebinding.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-rolebinding-rolebinding.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-rolebinding-rolebinding.yaml
@@ -4,7 +4,7 @@ kind: RoleBinding
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -4,7 +4,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -4,7 +4,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations: {{- toYaml .Values.secretAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-service-service.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-service-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'
@@ -30,7 +30,7 @@ spec:
   {{- end }}
   selector:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     control-plane: controller-manager
     gatekeeper.sh/operation: webhook
     gatekeeper.sh/system: "yes"

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gatekeeper-update-namespace-label
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-upgrade.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-upgrade.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gatekeeper-update-namespace-label-post-upgrade
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/probe-webhook-post-install.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/probe-webhook-post-install.yaml
@@ -6,7 +6,7 @@ metadata:
   name: gatekeeper-probe-webhook-post-install
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'

--- a/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
@@ -61,11 +61,11 @@ metadata:
   name: gatekeeper-update-crds-hook
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "gatekeeper.name" . }}
-    chart: {{ template "gatekeeper.name" . }}
+    app: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
+    heritage: '{{ .Release.Service }}'
+    release: '{{ .Release.Name }}'
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "1"

--- a/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
@@ -5,7 +5,7 @@ metadata:
   name: gatekeeper-delete-webhook-configs
   labels:
     app: '{{ template "gatekeeper.name" . }}'
-    chart: '{{ template "gatekeeper.name" . }}'
+    chart: '{{ template "gatekeeper.chart" . }}'
     gatekeeper.sh/system: "yes"
     heritage: '{{ .Release.Service }}'
     release: '{{ .Release.Name }}'


### PR DESCRIPTION
**What this PR does / why we need it**:
It changes `chart:` label to use template `.chart` instead of `.name`