### PR TITLE
feat(helm): unify and extend hook job pod labels

### DIFF
--- a/cmd/build/helmify/static/templates/namespace-post-install.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-install.yaml
@@ -19,7 +19,11 @@ spec:
       annotations:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
+        {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
       restartPolicy: OnFailure

--- a/cmd/build/helmify/static/templates/namespace-post-upgrade.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-upgrade.yaml
@@ -17,7 +17,11 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
       restartPolicy: OnFailure

--- a/cmd/build/helmify/static/templates/probe-webhook-post-install.yaml
+++ b/cmd/build/helmify/static/templates/probe-webhook-post-install.yaml
@@ -20,7 +20,11 @@ spec:
       annotations:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
+        {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
       restartPolicy: Never

--- a/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
+++ b/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
@@ -77,6 +77,13 @@ spec:
       name: gatekeeper-update-crds-hook
       annotations:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
+      labels:
+        {{- include "gatekeeper.podLabels" . }}
+        app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
+        release: '{{ .Release.Name }}'
     spec:
       serviceAccountName: gatekeeper-admin-upgrade-crds
       restartPolicy: Never

--- a/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
+++ b/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
@@ -19,7 +19,11 @@ spec:
       annotations:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
+        {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
       restartPolicy: OnFailure

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
@@ -19,7 +19,11 @@ spec:
       annotations:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
+        {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
       restartPolicy: OnFailure

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-upgrade.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-upgrade.yaml
@@ -17,7 +17,11 @@ spec:
   template:
     metadata:
       labels:
+        {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
       restartPolicy: OnFailure

--- a/manifest_staging/charts/gatekeeper/templates/probe-webhook-post-install.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/probe-webhook-post-install.yaml
@@ -20,7 +20,11 @@ spec:
       annotations:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
+        {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
       restartPolicy: Never

--- a/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
@@ -77,6 +77,13 @@ spec:
       name: gatekeeper-update-crds-hook
       annotations:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
+      labels:
+        {{- include "gatekeeper.podLabels" . }}
+        app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
+        release: '{{ .Release.Name }}'
     spec:
       serviceAccountName: gatekeeper-admin-upgrade-crds
       restartPolicy: Never

--- a/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
@@ -19,7 +19,11 @@ spec:
       annotations:
         {{- toYaml .Values.podAnnotations | trim | nindent 8 }}
       labels:
+        {{- include "gatekeeper.podLabels" . }}
         app: '{{ template "gatekeeper.name" . }}'
+        chart: '{{ template "gatekeeper.name" . }}'
+        gatekeeper.sh/system: "yes"
+        heritage: '{{ .Release.Service }}'
         release: '{{ .Release.Name }}'
     spec:
       restartPolicy: OnFailure


### PR DESCRIPTION
**What this PR does / why we need it**:
It unifies all of the hook jobs to have same labels, and to have them both on Job and Pod being created by it.

**Which issue(s) this PR fixes**:
Fixes #2204
