### PR TITLE
fix(helm): explicitly specify curl in probeWebhook

### DIFF
--- a/cmd/build/helmify/static/templates/_helpers.tpl
+++ b/cmd/build/helmify/static/templates/_helpers.tpl
@@ -48,6 +48,7 @@ Output post install webhook probe container entry
   image: "{{ .Values.postInstall.probeWebhook.image.repository }}:{{ .Values.postInstall.probeWebhook.image.tag }}"
   imagePullPolicy: {{ .Values.postInstall.probeWebhook.image.pullPolicy }}
   args:
+    - "curl"
     - "--retry"
     - "99999"
     - "--retry-max-time"

--- a/manifest_staging/charts/gatekeeper/templates/_helpers.tpl
+++ b/manifest_staging/charts/gatekeeper/templates/_helpers.tpl
@@ -48,6 +48,7 @@ Output post install webhook probe container entry
   image: "{{ .Values.postInstall.probeWebhook.image.repository }}:{{ .Values.postInstall.probeWebhook.image.tag }}"
   imagePullPolicy: {{ .Values.postInstall.probeWebhook.image.pullPolicy }}
   args:
+    - "curl"
     - "--retry"
     - "99999"
     - "--retry-max-time"


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `curl` as first argument of probeWebhook container, so it's possible to use different images which do have curl but don't have `curl` set as an entrypoint.

this is exactly what entrypoint of curlimages/curl does: it adds `curl` if first argument is not a valid command:
https://github.com/curl/curl-docker/blob/28034fa450ec24aa79cb17fe65b00eda85ae3e2c/alpine/latest/entrypoint.sh#L10-L12