### PR TITLE
fix: Only set ConstraintTemplate's status.created on success

### DIFF
--- a/pkg/controller/constrainttemplate/constants.go
+++ b/pkg/controller/constrainttemplate/constants.go
@@ -1,7 +1,12 @@
 package constrainttemplate
 
-// ErrCreateCode indicates a problem creating a ConstraintTemplate.
-const ErrCreateCode = "create_error"
-
-// ErrIngestCode indicates a problem creating a ConstraintTemplate.
-const ErrIngestCode = "ingest_error"
+const (
+	// ErrCreateCode indicates a problem creating a ConstraintTemplate CRD.
+	ErrCreateCode = "create_error"
+	// ErrUpdateCode indicates a problem updating a ConstraintTemplate CRD.
+	ErrUpdateCode = "update_error"
+	// ErrConversionCode indicates a problem converting a ConstraintTemplate CRD.
+	ErrConversionCode = "conversion_error"
+	// ErrIngestCode indicates a problem ingesting a ConstraintTemplate Rego code.
+	ErrIngestCode = "ingest_error"
+)

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -356,7 +356,7 @@ func (r *ReconcileConstraintTemplate) Reconcile(ctx context.Context, request rec
 		r.tracker.TryCancelTemplate(unversionedCT) // Don't track templates that failed compilation
 		r.metrics.registry.add(request.NamespacedName, metrics.ErrorStatus)
 		logError(request.NamespacedName.Name)
-		err := r.reportErrorOnCTStatus(ctx, "conversion_error", "Could not convert from unversioned resource", status, err)
+		err := r.reportErrorOnCTStatus(ctx, ErrConversionCode, "Could not convert from unversioned resource", status, err)
 		return reconcile.Result{}, err
 	}
 
@@ -426,7 +426,7 @@ func (r *ReconcileConstraintTemplate) handleUpdate(
 		if err := r.metrics.reportIngestDuration(ctx, metrics.ErrorStatus, time.Since(beginCompile)); err != nil {
 			logger.Error(err, "failed to report constraint template ingestion duration")
 		}
-		err := r.reportErrorOnCTStatus(ctx, "ingest_error", "Could not ingest Rego", status, err)
+		err := r.reportErrorOnCTStatus(ctx, ErrIngestCode, "Could not ingest Rego", status, err)
 		r.tracker.TryCancelTemplate(unversionedCT) // Don't track templates that failed compilation
 		return reconcile.Result{}, err
 	}
@@ -461,7 +461,7 @@ func (r *ReconcileConstraintTemplate) handleUpdate(
 	} else if !reflect.DeepEqual(newCRD, currentCRD) {
 		logger.Info("updating crd")
 		if err := r.Update(ctx, newCRD); err != nil {
-			err := r.reportErrorOnCTStatus(ctx, "update_error", "Could not update CRD", status, err)
+			err := r.reportErrorOnCTStatus(ctx, ErrUpdateCode, "Could not update CRD", status, err)
 			return reconcile.Result{}, err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently ConstraintTemplate's `.status.created` field is set to true if there's at least one ConstraintTemplatePodStatus for it.
However, it doesn't check if ConstraintTemplatePodStatus has actually succeeded (has no errors). This PR fixes that – `.status.created` is only set to `true` if there's at least one `ConstraintTemplatePodStatus` for this template with no errors.

I've also noticed that `Err..Code` constants are used inconsistently in the constrainttemplate controller, so I've fixed that too. Please tell me if it has to be separated into a different PR.

**Which issue(s) this PR fixes**:
Fixes #2053