### PR TITLE
fix: Docker related Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,9 +426,8 @@ __conversion-gen: __tooling-image
 CONVERSION_GEN=docker run --rm -v $(shell pwd):/gatekeeper gatekeeper-tooling conversion-gen
 
 __tooling-image:
-	docker build . \
-		-t gatekeeper-tooling \
-		-f build/tooling/Dockerfile
+	docker build build/tooling \
+		-t gatekeeper-tooling
 
 .PHONY: vendor
 vendor:

--- a/Makefile
+++ b/Makefile
@@ -420,10 +420,10 @@ uninstall:
 		/config/overlays/dev | kubectl delete -f -
 
 __controller-gen: __tooling-image
-CONTROLLER_GEN=docker run -v $(shell pwd):/gatekeeper gatekeeper-tooling controller-gen
+CONTROLLER_GEN=docker run --rm -v $(shell pwd):/gatekeeper gatekeeper-tooling controller-gen
 
 __conversion-gen: __tooling-image
-CONVERSION_GEN=docker run -v $(shell pwd):/gatekeeper gatekeeper-tooling conversion-gen
+CONVERSION_GEN=docker run --rm -v $(shell pwd):/gatekeeper gatekeeper-tooling conversion-gen
 
 __tooling-image:
 	docker build . \


### PR DESCRIPTION
**What this PR does / why we need it**:
1) It adds `--rm` flag to _GEN docker commands, so they don't leave unnecessary completed containers (this is already done for lint, and probably can be done for tests – but those are a different story)

2) it changes context directory passed to `docker build` for __tooling-image from `.` to `build/tooling`: tooling image doesn't need that context at all, but `docker build` doesn't know that in advance so it still has to pass all the context to the daemon, which can takes time and is completely unnecessary. now it only passes context of a directory only containing the dockerfile itself, so it's not such an issue anymore.

these are just simple quality of development improvements to speed up tooling in docker related processes and to stop gatekeeper development workflow from leaving garbage containers in docker.