### PR TITLE
chore: use volume mounts for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,13 +100,9 @@ native-test:
 
 # Hook to run docker tests
 .PHONY: test
-test:
-	rm -rf .staging/test
-	mkdir -p .staging/test
-	cp -r * .staging/test
-	-rm .staging/test/Dockerfile
-	cp test/Dockerfile .staging/test/Dockerfile
-	docker build --pull .staging/test -t gatekeeper-test && docker run -t gatekeeper-test
+test: __test-image
+	docker run --rm -t -v $(shell pwd):/app \
+		gatekeeper-test make native-test
 
 .PHONY: test-e2e
 test-e2e:
@@ -428,6 +424,10 @@ CONVERSION_GEN=docker run --rm -v $(shell pwd):/gatekeeper gatekeeper-tooling co
 __tooling-image:
 	docker build build/tooling \
 		-t gatekeeper-tooling
+
+__test-image:
+	docker build test/image \
+		-t gatekeeper-test
 
 .PHONY: vendor
 vendor:

--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -22,8 +22,4 @@ RUN curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/k
     chmod +x kustomize &&\
     mv kustomize /usr/local/bin
 
-# Copy in the go src
-WORKDIR /go/src/github.com/open-policy-agent/gatekeeper
-COPY .    .
-
-ENTRYPOINT ["make", "native-test"]
+WORKDIR /app


### PR DESCRIPTION
**What this PR does / why we need it**:
Build a testing image and run tests with a volume mount, instead of
copying sources into a test image.

Tests work as lint and gen jobs now, which simplifes and speeds up test
development.

**Which issue(s) this PR fixes**
None I'm aware of
