### PR TITLE
feat: add audit_last_run_end_time metric

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -161,9 +161,13 @@ func (am *Manager) audit(ctx context.Context) error {
 	// record audit latency
 	defer func() {
 		logFinish(am.log)
-		latency := time.Since(startTime)
+		endTime := time.Now()
+		latency := endTime.Sub(startTime)
 		if err := am.reporter.reportLatency(latency); err != nil {
 			am.log.Error(err, "failed to report latency")
+		}
+		if err := am.reporter.reportRunEnd(endTime); err != nil {
+			am.log.Error(err, "failed to report run end time")
 		}
 	}()
 

--- a/website/docs/audit.md
+++ b/website/docs/audit.md
@@ -13,7 +13,8 @@ There are three ways to gather audit results, depending on the level of detail n
 
 Prometheus metrics provide an aggregated look at the number of audit violations:
 
-* `gatekeeper_audit_last_run_time` provides the timestamp of the most recently completed audit run
+* `gatekeeper_audit_last_run_time` provides the start time timestamp of the most recent audit run
+* `gatekeeper_audit_last_run_end_time` provides the end time timestamp of the last completed audit run
 * `gatekeeper_violations` provides the total number of audited violations for the last audit run, broken down by violation severity
 
 ### Constraint Status

--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -113,7 +113,13 @@ Below are the list of metrics provided by Gatekeeper:
 
 - Name: `gatekeeper_audit_last_run_time`
 
-    Description: `Timestamp of last audit run time`
+    Description: `Timestamp of last audit run starting time`
+
+    Aggregation: `LastValue`
+
+- Name: `gatekeeper_audit_last_run_end_time`
+
+    Description: `Timestamp of last audit run ending time`
 
     Aggregation: `LastValue`
 

--- a/website/versioned_docs/version-v3.6.x/audit.md
+++ b/website/versioned_docs/version-v3.6.x/audit.md
@@ -13,7 +13,7 @@ There are three ways to gather audit results, depending on the level of detail n
 
 Prometheus metrics provide an aggregated look at the number of audit violations:
 
-* `gatekeeper_audit_last_run_time` provides the timestamp of the most recently completed audit run
+* `gatekeeper_audit_last_run_time` provides the start time timestamp of the most recent audit run
 * `gatekeeper_violations` provides the total number of audited violations for the last audit run, broken down by violation severity
 
 ### Constraint Status

--- a/website/versioned_docs/version-v3.7.x/audit.md
+++ b/website/versioned_docs/version-v3.7.x/audit.md
@@ -13,7 +13,7 @@ There are three ways to gather audit results, depending on the level of detail n
 
 Prometheus metrics provide an aggregated look at the number of audit violations:
 
-* `gatekeeper_audit_last_run_time` provides the timestamp of the most recently completed audit run
+* `gatekeeper_audit_last_run_time` provides the start time timestamp of the most recent audit run
 * `gatekeeper_violations` provides the total number of audited violations for the last audit run, broken down by violation severity
 
 ### Constraint Status

--- a/website/versioned_docs/version-v3.8.x/audit.md
+++ b/website/versioned_docs/version-v3.8.x/audit.md
@@ -13,7 +13,7 @@ There are three ways to gather audit results, depending on the level of detail n
 
 Prometheus metrics provide an aggregated look at the number of audit violations:
 
-* `gatekeeper_audit_last_run_time` provides the timestamp of the most recently completed audit run
+* `gatekeeper_audit_last_run_time` provides the start time timestamp of the most recent audit run
 * `gatekeeper_violations` provides the total number of audited violations for the last audit run, broken down by violation severity
 
 ### Constraint Status

--- a/website/versioned_docs/version-v3.9.x/audit.md
+++ b/website/versioned_docs/version-v3.9.x/audit.md
@@ -13,7 +13,7 @@ There are three ways to gather audit results, depending on the level of detail n
 
 Prometheus metrics provide an aggregated look at the number of audit violations:
 
-* `gatekeeper_audit_last_run_time` provides the timestamp of the most recently completed audit run
+* `gatekeeper_audit_last_run_time` provides the start time timestamp of the most recent audit run
 * `gatekeeper_violations` provides the total number of audited violations for the last audit run, broken down by violation severity
 
 ### Constraint Status


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds a new metric to track last finishing time for audit runs, to ensure that audit runs do actually finish.
It also updates description of existing metric to note that it only shows time when audit has started, and not when audit has finished.

See #2197 for more info.
