### PR TITLE
fix: skip empty k8s resources

### DIFF
--- a/pkg/gator/read_constraints.go
+++ b/pkg/gator/read_constraints.go
@@ -193,8 +193,10 @@ func ReadK8sResources(r io.Reader) ([]*unstructured.Unstructured, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading yaml source: %w", err)
 		}
-
-		objs = append(objs, u)
+		// skip empty resources
+		if len(u.Object) > 0 {
+			objs = append(objs, u)
+		}
 	}
 
 	return objs, nil

--- a/pkg/gator/read_constraints_test.go
+++ b/pkg/gator/read_constraints_test.go
@@ -1,0 +1,77 @@
+package gator
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestReadK8sResources(t *testing.T) {
+	type args struct {
+		r io.Reader
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []*unstructured.Unstructured
+		wantErr bool
+	}{
+		{
+			name: "test with valid input objects",
+			args: args{r: strings.NewReader("---\n# Source: some/templates/file.yaml\nname: object1\nattrs:\n  - attr1\n  - attr2\n---\n# Source: some/templates/file.yaml\nname: object2\nlabels:\n  - label1\n  - label2\n")},
+			want: []*unstructured.Unstructured{
+				{Object: map[string]interface{}{
+					"name": "object1",
+					"attrs": []interface{}{
+						"attr1",
+						"attr2",
+					},
+				}},
+				{Object: map[string]interface{}{
+					"name": "object2",
+					"labels": []interface{}{
+						"label1",
+						"label2",
+					},
+				}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "test with valid and also empty input objects",
+			args: args{r: strings.NewReader("---\n# Source: some/templates/file.yaml\nname: object1\nattrs:\n  - attr1\n  - attr2\n---\n# Source: some/templates/file.yaml\n# only containing some comment\n---\n# Source: some/templates/file.yaml\nname: object2\nlabels:\n  - label1\n  - label2\n")},
+			want: []*unstructured.Unstructured{
+				{Object: map[string]interface{}{
+					"name": "object1",
+					"attrs": []interface{}{
+						"attr1",
+						"attr2",
+					},
+				}},
+				{Object: map[string]interface{}{
+					"name": "object2",
+					"labels": []interface{}{
+						"label1",
+						"label2",
+					},
+				}},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReadK8sResources(tt.args.r)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadK8sResources() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ReadK8sResources() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

While using the Gator CLI (v3.9.0) to test helm rendered k8s resources against our Gatekeeper constraints we ran into the following error: `auditing objects: adding data of GVK "/, Kind=": admission.k8s.gatekeeper.sh: invalid request object: resource  has no version`
After investigation we found out that the error was due to a input file like the following one:
```yaml
---
# Source: some/templates/file.yaml
name: object1
attrs:
  - attr1
  - attr2
---
# Source: some/templates/file.yaml
# only containing some comment
---
# Source: some/templates/file.yaml
name: object2
labels:
  - label1
  - label2
```
Apparently Gator CLI attempts to parse above snippet as 3 seperate YAML documents, looking for k8s resources inside them, which won't work as the second one containing only the comment cannot be parsed into a valid k8s resource at all.
This PR suggests skipping empty k8s resources.