### PR TITLE
fix: Change 'securityContext/capabilities/drop' from 'all' to 'ALL'.

### DIFF
--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -56,7 +56,7 @@ postUpgrade:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -94,7 +94,7 @@ postInstall:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -116,7 +116,7 @@ preUninstall:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -170,7 +170,7 @@ controllerManager:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -203,7 +203,7 @@ audit:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -223,7 +223,7 @@ crds:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 65532
     runAsNonRoot: true

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -56,7 +56,7 @@ postUpgrade:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -94,7 +94,7 @@ postInstall:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -116,7 +116,7 @@ preUninstall:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -170,7 +170,7 @@ controllerManager:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -203,7 +203,7 @@ audit:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -223,7 +223,7 @@ crds:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - all
+      - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 65532
     runAsNonRoot: true


### PR DESCRIPTION
Signed-off-by: Chris Burke <christopher.burke@airnz.co.nz>

**What this PR does / why we need it**:
The helm chart default values used the incorrect case for `securityContext.capabilities.drop`.
Was:
```yaml
  securityContext:
    capabilities:
      drop:
        - all
```
Now:
```yaml
  securityContext:
    capabilities:
      drop:
        - ALL
```
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #2271

**Special notes for your reviewer**:
