### PR TITLE
feat: Allow disabling of referential data in gatortest.Test()

### DIFF
--- a/pkg/gator/test/types.go
+++ b/pkg/gator/test/types.go
@@ -64,3 +64,25 @@ func (r *GatorResponses) Results() []*GatorResult {
 
 	return res
 }
+
+type testOptions struct {
+	referentialData bool
+}
+
+func defaultTestOptions() *testOptions {
+	return &testOptions{
+		referentialData: true,
+	}
+}
+
+func mutateTestOptions(ops *testOptions, mutators ...TestOptionMutator) {
+	for _, m := range mutators {
+		m(ops)
+	}
+}
+
+type TestOptionMutator func(*testOptions)
+
+var DisableReferentialData TestOptionMutator = func(ops *testOptions) {
+	ops.referentialData = false
+}


### PR DESCRIPTION
In manual benchmarks of the gator test CLI, I found that calls to Test() that included adding all the objects under evaluation to OPA via the AddData() call were exponentially slower.

These calls to AddData() are to support referential templates.

This PR adds a variadic argument to Test() that allows one to disable referential data support in Test(), yielding a significant speed improvement for users who do not require the feature.

Next steps:

1) Add a flag to `gator test` like --referential-data, that defaults to
   true

Signed-off-by: juliankatz <juliankatz@google.com>
