### PR TITLE
style: add docs pointers from the demo folder

### DIFF
--- a/demo/agilebank/README.md
+++ b/demo/agilebank/README.md
@@ -1,3 +1,7 @@
+> NOTE: Be sure to look at the [prerequisite](https://open-policy-agent.github.io/gatekeeper/website/docs/install#prerequisites) and Gatekeeper [installation](https://open-policy-agent.github.io/gatekeeper/website/docs/install#installation) steps before attempting to run the script.
+
+> TIP: If you are new to k8s, you can stand up a simple cluster using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/): `kind create cluster`.
+
 This is a demo involving a fictitious bank named Agile Bank.
 
 To run, execute `demo.sh` and press enter.

--- a/demo/basic/README.md
+++ b/demo/basic/README.md
@@ -1,3 +1,7 @@
+> NOTE: Be sure to look at the [prerequisite](https://open-policy-agent.github.io/gatekeeper/website/docs/install#prerequisites) and Gatekeeper [installation](https://open-policy-agent.github.io/gatekeeper/website/docs/install#installation) steps before attempting to run the script.
+
+> TIP: If you are new to k8s, you can stand up a simple cluster using [kind](https://kind.sigs.k8s.io/docs/user/quick-start/): `kind create cluster`.
+
 Demo of basic Gatekeeper functionality.
 
 To run, execute `demo.sh` and press enter.


### PR DESCRIPTION
**What this PR does / why we need it**:

THIS IS A STRING CHANGE. But I think it's useful for folks like me that went straight into the `demo` folder without looking at / remembering to do the prerequisite and installation steps in the docs. I also want to help further lowering the barrier to entry here by being overly explicit about setting up a k8s cluster.

**Which issue(s) this PR fixes** 

Didn't see any issues referencing this.