### PR TITLE
perf: unset CPU limit

### DIFF
--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -162,7 +162,6 @@ controllerManager:
   nodeSelector: {kubernetes.io/os: linux}
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m
@@ -195,7 +194,6 @@ audit:
   nodeSelector: {kubernetes.io/os: linux}
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -162,6 +162,7 @@ controllerManager:
   nodeSelector: {kubernetes.io/os: linux}
   resources:
     limits:
+      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m
@@ -194,6 +195,7 @@ audit:
   nodeSelector: {kubernetes.io/os: linux}
   resources:
     limits:
+      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -162,7 +162,6 @@ controllerManager:
   nodeSelector: {kubernetes.io/os: linux}
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m
@@ -195,7 +194,6 @@ audit:
   nodeSelector: {kubernetes.io/os: linux}
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -89,7 +89,6 @@ spec:
               value: "manager"
           resources:
             limits:
-              cpu: 1000m
               memory: 512Mi
             requests:
               cpu: 100m
@@ -193,7 +192,6 @@ spec:
               port: 9090
           resources:
             limits:
-              cpu: 1000m
               memory: 512Mi
             requests:
               cpu: 100m

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -162,7 +162,6 @@ controllerManager:
   nodeSelector: {kubernetes.io/os: linux}
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m
@@ -195,7 +194,6 @@ audit:
   nodeSelector: {kubernetes.io/os: linux}
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       cpu: 100m

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -3241,7 +3241,6 @@ spec:
             port: 9090
         resources:
           limits:
-            cpu: 1000m
             memory: 512Mi
           requests:
             cpu: 100m
@@ -3362,7 +3361,6 @@ spec:
             port: 9090
         resources:
           limits:
-            cpu: 1000m
             memory: 512Mi
           requests:
             cpu: 100m


### PR DESCRIPTION
Signed-off-by: Alex Pana <8968914+acpana@users.noreply.github.com>

**What this PR does / why we need it**: 

This diff removes `cpu` limits on g8r resources. Unsetting the `cpu` limit is desirable. This is because a predefined limit for a cgroup impacts the parent cgroup too. In turn, having a set cpu limit can result in weird quota exhaustions, without actually exhaustive the cpu resource. 

---

Refs: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-pods-with-resource-limits-are-run 