### PR TITLE
perf: set mem request and limit to the same value

### DIFF
--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -166,7 +166,7 @@ controllerManager:
       memory: 512Mi
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -199,7 +199,7 @@ audit:
       memory: 512Mi
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -93,7 +93,7 @@ spec:
               memory: 512Mi
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
           livenessProbe:
             httpGet:
               path: /healthz
@@ -197,7 +197,7 @@ spec:
               memory: 512Mi
             requests:
               cpu: 100m
-              memory: 256Mi
+              memory: 512Mi
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -166,7 +166,7 @@ controllerManager:
       memory: 512Mi
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
@@ -199,7 +199,7 @@ audit:
       memory: 512Mi
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -3245,7 +3245,7 @@ spec:
             memory: 512Mi
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -3366,7 +3366,7 @@ spec:
             memory: 512Mi
           requests:
             cpu: 100m
-            memory: 256Mi
+            memory: 512Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
Signed-off-by: Alex Pana <8968914+acpana@users.noreply.github.com>

**What this PR does / why we need it**:

AFAIU, there may be cases in which a container starts at the requested `memory`  but can't reach its limit. This potentially results in the workload being rescheduled. We can avoid that by setting the limit and request to the same value right out the gate.