### PR TITLE
docs: Updating slack community ref in footer

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -54,8 +54,8 @@ module.exports = {
               href: 'https://github.com/open-policy-agent/gatekeeper',
             },
             {
-              label: 'Slack',
-              href: 'https://openpolicyagent.slack.com/messages/CDTN970AX',
+              label: 'Slack (#opa-gatekeeper)',
+              href: 'https://slack.openpolicyagent.org/',
             },
             {
               label: 'Meetings',


### PR DESCRIPTION
Signed-off-by: Jaydip Gabani <gabanijaydip@gmail.com>

**What this PR does / why we need it**:
Updates footer slack community link of the website to easily navigate to workspace invite/sign-in page

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #2334 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
