### PR TITLE
chore: Adding version info for gk, opa, and frameworks in gator cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ BATS_TESTS_FILE ?= test/bats/test.bats
 HELM_VERSION ?= 3.7.2
 NODE_VERSION ?= 16-bullseye-slim
 YQ_VERSION ?= 4.2.0
+FRAMEWORKS_VERSION ?= $(shell go list -f '{{ .Version }}' -m github.com/open-policy-agent/frameworks/constraint)
+OPA_VERSION ?= $(shell go list -f '{{ .Version }}' -m github.com/open-policy-agent/opa)
 
 HELM_ARGS ?=
 GATEKEEPER_NAMESPACE ?= gatekeeper-system
@@ -43,8 +45,10 @@ BUILD_HOSTNAME := $(shell ./build/get-build-hostname.sh)
 LDFLAGS := "-X github.com/open-policy-agent/gatekeeper/pkg/version.Version=$(VERSION) \
 	-X github.com/open-policy-agent/gatekeeper/pkg/version.Vcs=$(BUILD_COMMIT) \
 	-X github.com/open-policy-agent/gatekeeper/pkg/version.Timestamp=$(BUILD_TIMESTAMP) \
-	-X github.com/open-policy-agent/gatekeeper/pkg/version.Hostname=$(BUILD_HOSTNAME)"
-
+	-X github.com/open-policy-agent/gatekeeper/pkg/version.Hostname=$(BUILD_HOSTNAME) \
+	-X main.frameworksVersion=$(FRAMEWORKS_VERSION) \
+	-X main.opaVersion=$(OPA_VERSION)"
+	
 MANAGER_IMAGE_PATCH := "apiVersion: apps/v1\
 \nkind: Deployment\
 \nmetadata:\

--- a/cmd/gator/gator.go
+++ b/cmd/gator/gator.go
@@ -1,15 +1,23 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/open-policy-agent/gatekeeper/cmd/gator/expand"
 	"github.com/open-policy-agent/gatekeeper/cmd/gator/test"
 	"github.com/open-policy-agent/gatekeeper/cmd/gator/verify"
+	"github.com/open-policy-agent/gatekeeper/pkg/version"
 	"github.com/spf13/cobra"
 )
 
-const version = "alpha"
+const state = "alpha"
+
+var (
+	frameworksVersion string
+
+	opaVersion string
+)
 
 var commands = []*cobra.Command{
 	verify.Cmd,
@@ -24,7 +32,7 @@ func init() {
 var rootCmd = &cobra.Command{
 	Use:     "gator subcommand",
 	Short:   "gator is a suite of authorship tools for Gatekeeper",
-	Version: version,
+	Version: fmt.Sprintf("\nGator version: %s  (Feature State: %s), OPA version: %s, Framework version: %s", version.Version, state, opaVersion, frameworksVersion),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return nil
 	},

--- a/gator.Dockerfile
+++ b/gator.Dockerfile
@@ -22,7 +22,7 @@ COPY . /tmp/gatekeeper
 
 WORKDIR /tmp/gatekeeper/cmd/gator
 
-RUN go build -mod vendor -a -ldflags "${LDFLAGS:--X github.com/open-policy-agent/gatekeeper/pkg/version.Version=latest}" -o /gator
+RUN go build -mod vendor -a -ldflags "${LDFLAGS:--X github.com/open-policy-agent/gatekeeper/pkg/version.Version=latest -X main.frameworksVersion=latest -X main.opaVersion=latest}" -o /gator
 
 FROM --platform=$BUILDPLATFORM $BASEIMAGE as build
 USER 65532:65532


### PR DESCRIPTION
Signed-off-by: Jaydip Gabani <gabanijaydip@gmail.com>

**What this PR does / why we need it**:
Adds more information in output of `gator --version`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #1643 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:

Result:
```
gator --version
gator version 
Gator & Gatekeeper version: v3.10.0-beta.2, OPA version: 0.44.0, Framework Version v0.0.0-20221006234738-a3d297b3152f
```
