### PR TITLE
chore: Authenticating api server against webhook

### DIFF
--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -86,6 +86,7 @@ spec:
             - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation }}
             - --max-serving-threads={{ .Values.maxServingThreads }}
             - --tls-min-version={{ .Values.controllerManager.tlsMinVersion }}
+            - HELMBUST_ENABLE_TLS_APISERVER_AUTHENTICATION
             - HELMSUBST_METRICS_BACKEND_ARG
             - HELMSUBST_TLS_HEALTHCHECK_ENABLED_ARG
             - HELMSUBST_MUTATION_ENABLED_ARG

--- a/cmd/build/helmify/replacements.go
+++ b/cmd/build/helmify/replacements.go
@@ -79,6 +79,8 @@ var replacements = map[string]string{
 
 	"- HELMSUBST_TLS_HEALTHCHECK_ENABLED_ARG": `{{ if .Values.enableTLSHealthcheck}}- --enable-tls-healthcheck{{- end }}`,
 
+	"- HELMBUST_ENABLE_TLS_APISERVER_AUTHENTICATION": `{{ if ne .Values.controllerManager.clientCertName "" }}- --client-cert-name={{ .Values.controllerManager.clientCertName }}{{- end }}`,
+
 	"- HELMSUBST_MUTATION_ENABLED_ARG": `{{ if not .Values.disableMutation}}- --operation=mutation-webhook{{- end }}`,
 
 	"- HELMSUBST_MUTATION_STATUS_ENABLED_ARG": `{{ if not .Values.disableMutation}}- --operation=mutation-status{{- end }}`,

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -145,6 +145,7 @@ controllerManager:
   priorityClassName: system-cluster-critical
   disableCertRotation: false
   tlsMinVersion: 1.3
+  clientCertName: ""
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -64,6 +64,7 @@ spec:
         - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation }}
         - --max-serving-threads={{ .Values.maxServingThreads }}
         - --tls-min-version={{ .Values.controllerManager.tlsMinVersion }}
+        {{ if ne .Values.controllerManager.clientCertName "" }}- --client-cert-name={{ .Values.controllerManager.clientCertName }}{{- end }}
         
         {{- range .Values.metricsBackends}}
         - --metrics-backend={{ . }}

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -145,6 +145,7 @@ controllerManager:
   priorityClassName: system-cluster-critical
   disableCertRotation: false
   tlsMinVersion: 1.3
+  clientCertName: ""
   affinity:
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/webhook/mutation.go
+++ b/pkg/webhook/mutation.go
@@ -88,9 +88,7 @@ func AddMutatingWebhook(mgr manager.Manager, deps Dependencies) error {
 	if err := wh.InjectLogger(log); err != nil {
 		return err
 	}
-	server := mgr.GetWebhookServer()
-	server.TLSMinVersion = *tlsMinVersion
-	server.Register("/v1/mutate", wh)
+	getServerConfig(mgr).Register("/v1/mutate", wh)
 
 	return nil
 }

--- a/pkg/webhook/namespacelabel.go
+++ b/pkg/webhook/namespacelabel.go
@@ -39,9 +39,7 @@ func AddLabelWebhook(mgr manager.Manager, _ Dependencies) error {
 	if err := wh.InjectLogger(log); err != nil {
 		return err
 	}
-	server := mgr.GetWebhookServer()
-	server.TLSMinVersion = *tlsMinVersion
-	server.Register("/v1/admitlabel", wh)
+	getServerConfig(mgr).Register("/v1/admitlabel", wh)
 	return nil
 }
 

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -120,9 +120,7 @@ func AddPolicyWebhook(mgr manager.Manager, deps Dependencies) error {
 	if err := wh.InjectLogger(log); err != nil {
 		return err
 	}
-	server := mgr.GetWebhookServer()
-	server.TLSMinVersion = *tlsMinVersion
-	server.Register("/v1/admit", wh)
+	getServerConfig(mgr).Register("/v1/admit", wh)
 	return nil
 }
 

--- a/website/docs/externaldata.md
+++ b/website/docs/externaldata.md
@@ -450,11 +450,13 @@ server := &http.Server{
 
 2. If `cert-controller` is disabled via the `--disable-cert-rotation` flag, you can use a cluster-wide, well-known CA certificate for Gatekeeper so that your external data provider can trust it without being deployed to the `gatekeeper-system` namespace.
 
-### Authenticate API server against Webhook (Self managed kube cluster only)
+### Authenticate API server against Webhook (Self managed K8s cluster only)
 
-To have requests coming from apiserver authenticated by webhook, following configuration can be made:
+**Note:** To enable authenticate api server requires modifying cluster resources that may not be possible in managed K8s cluster
 
-1. Deploy gatekeeper a client CA name. Provide name of the client ca with the flag `--client-cert-name`. The same name will be used to read certificate from the webhook secret. The webhook will only authenticate apiserver requests if both client ca name is provided with flag.
+To ensure a request to the Gatekeeper webhook is coming from the api server, Gatekeeper needs to validate the client cert in the request. To enable authenticate api server, the following configuration can be made:
+
+1. Deploy gatekeeper with a client CA cert name. Provide name of the client CA with the flag `--client-cert-name`. The same name will be used to read certificate from the webhook secret. The webhook will only authenticate apiserver requests if client CA name is provided with flag.
 
 2. You will need to patch the webhook secret manually to attach client ca crt. Update secret `gatekeeper-webhook-server-cert` to include `clientca.crt`. Key name `clientca.crt` should match the name passed with `--client-cert-name` flag.
 
@@ -473,7 +475,7 @@ To have requests coming from apiserver authenticated by webhook, following confi
       namespace: <gatekeeper-namespace>
     type: Opaque
     ```
-3. You will need to make sure that apiserver includes appropriate certificate while sending requests to apiserver, otherwise webhook will not accept these requests and will log error of `tls client didn't provide a certificate`. To make sure apiserver attaches correct certificate to requests being sent to webhook, you must specify the location of the admission control configuration file via the `--admission-control-config-file` flag while starting apiserver. Here is an example admission control configuration file:
+3. You will need to make sure that apiserver includes appropriate certificate while sending requests to the webhook, otherwise webhook will not accept these requests and will log error of `tls client didn't provide a certificate`. To make sure apiserver attaches correct certificate to requests being sent to webhook, you must specify the location of the admission control configuration file via the `--admission-control-config-file` flag while starting apiserver. Here is an example admission control configuration file:
     ```
     apiVersion: apiserver.config.k8s.io/v1
     kind: AdmissionConfiguration

--- a/website/docs/externaldata.md
+++ b/website/docs/externaldata.md
@@ -449,3 +449,69 @@ server := &http.Server{
 ```
 
 2. If `cert-controller` is disabled via the `--disable-cert-rotation` flag, you can use a cluster-wide, well-known CA certificate for Gatekeeper so that your external data provider can trust it without being deployed to the `gatekeeper-system` namespace.
+
+### Authenticate API server against Webhook (Self managed kube cluster only)
+
+To have requests coming from apiserver authenticated by webhook, following configuration can be made:
+
+1. Deploy gatekeeper a client CA name. Provide name of the client ca with the flag `--client-cert-name`. The same name will be used to read certificate from the webhook secret. The webhook will only authenticate apiserver requests if both client ca name is provided with flag.
+
+2. You will need to patch the webhook secret manually to attach client ca crt. Update secret `gatekeeper-webhook-server-cert` to include `clientca.crt`. Key name `clientca.crt` should match the name passed with `--client-cert-name` flag.
+
+    ```
+    kind: Secret
+    apiVersion: v1
+    data:
+      ca.crt: <ca-crt>
+      ca.key: <ca-key>
+      tls.crt: <tls-crt>
+      tls.key: <tls-key>
+      clientca.crt: <apiserver's ca.crt>
+    metadata:
+      ...
+      name: <gatekeeper-webhook-service-name>
+      namespace: <gatekeeper-namespace>
+    type: Opaque
+    ```
+3. You will need to make sure that apiserver includes appropriate certificate while sending requests to apiserver, otherwise webhook will not accept these requests and will log error of `tls client didn't provide a certificate`. To make sure apiserver attaches correct certificate to requests being sent to webhook, you must specify the location of the admission control configuration file via the `--admission-control-config-file` flag while starting apiserver. Here is an example admission control configuration file:
+    ```
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: AdmissionConfiguration
+    plugins:
+    - name: ValidatingAdmissionWebhook
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: WebhookAdmissionConfiguration
+        kubeConfigFile: "<path-to-kubeconfig-file>"
+    - name: MutatingAdmissionWebhook
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1
+        kind: WebhookAdmissionConfiguration
+        kubeConfigFile: "<path-to-kubeconfig-file>"
+    ```
+  
+    KubeConfig file should look something like:
+
+    ```
+    apiVersion: v1
+    clusters:
+    - cluster:
+        certificate-authority-data: <clientca.crt> # same value as provided in gatekeeper webhook secret's clientca.crt 
+        server: https://<gatekeeper-webhook-service-name>.<gatekeeper-namespace>.svc:443
+      name: kind-kind
+    contexts:
+    - context:
+        cluster: kind-kind
+        user: api-server
+      name: kind-kind
+    current-context: kind-kind
+    kind: Config
+    users:
+    - name: api-server
+      user:
+        client-certificate-data: <kubernetes-admin-client-certificate-data>
+        client-key-data: <kubernetes-admin-client-key-data>
+    ```
+    **Note**: Default `gatekeeper-webhook-service-name` is `gatekeeper-webhook-service` and default `gatekeeper-namespace` is `gatekeeper-system`.
+
+    Visit [#authenticate-apiservers](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#authenticate-apiservers) for more details.


### PR DESCRIPTION
Signed-off-by: Jaydip Gabani <gabanijaydip@gmail.com>

**What this PR does / why we need it**:
To authenticate incoming requests from api-server to webhook

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Partially addresses #1294 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
