### PR TITLE
chore: adding a tag to indicate dry run requests in valication request count metric

### DIFF
--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -164,7 +164,13 @@ func (h *validationHandler) Handle(ctx context.Context, req admission.Request) a
 	requestResponse := unknownResponse
 	defer func() {
 		if h.reporter != nil {
-			if err := h.reporter.ReportValidationRequest(ctx, requestResponse, time.Since(timeStart)); err != nil {
+			var isDryRun string
+			if req.DryRun != nil && *req.DryRun {
+				isDryRun = "true"
+			} else {
+				isDryRun = "false"
+			}
+			if err := h.reporter.ReportValidationRequest(ctx, requestResponse, isDryRun, time.Since(timeStart)); err != nil {
 				log.Error(err, "failed to report request")
 			}
 		}

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -164,11 +164,9 @@ func (h *validationHandler) Handle(ctx context.Context, req admission.Request) a
 	requestResponse := unknownResponse
 	defer func() {
 		if h.reporter != nil {
-			var isDryRun string
+			isDryRun := "false"
 			if req.DryRun != nil && *req.DryRun {
 				isDryRun = "true"
-			} else {
-				isDryRun = "false"
 			}
 			if err := h.reporter.ReportValidationRequest(ctx, requestResponse, isDryRun, time.Since(timeStart)); err != nil {
 				log.Error(err, "failed to report request")

--- a/pkg/webhook/stats_reporter_test.go
+++ b/pkg/webhook/stats_reporter_test.go
@@ -17,6 +17,8 @@ const (
 
 	wantCount     int64 = 2
 	wantRowLength int   = 1
+
+	dryRun string = "false"
 )
 
 func TestValidationReportRequest(t *testing.T) {
@@ -31,12 +33,12 @@ func TestValidationReportRequest(t *testing.T) {
 		t.Fatalf("got newStatsReporter() error %v, want nil", err)
 	}
 
-	err = r.ReportValidationRequest(ctx, allowResponse, "false", minValidationDuration)
+	err = r.ReportValidationRequest(ctx, allowResponse, dryRun, minValidationDuration)
 	if err != nil {
 		t.Fatalf("got ReportValidationRequest() error = %v, want nil", err)
 	}
 
-	err = r.ReportValidationRequest(ctx, allowResponse, "false", maxValidationDuration)
+	err = r.ReportValidationRequest(ctx, allowResponse, dryRun, maxValidationDuration)
 	if err != nil {
 		t.Fatalf("got ReportValidationRequest() error = %v, want nil", err)
 	}

--- a/pkg/webhook/stats_reporter_test.go
+++ b/pkg/webhook/stats_reporter_test.go
@@ -22,6 +22,7 @@ const (
 func TestValidationReportRequest(t *testing.T) {
 	wantTags := map[string]string{
 		"admission_status": "allow",
+		"admission_dryrun": "false",
 	}
 
 	ctx := context.Background()
@@ -30,12 +31,12 @@ func TestValidationReportRequest(t *testing.T) {
 		t.Fatalf("got newStatsReporter() error %v, want nil", err)
 	}
 
-	err = r.ReportValidationRequest(ctx, allowResponse, minValidationDuration)
+	err = r.ReportValidationRequest(ctx, allowResponse, "false", minValidationDuration)
 	if err != nil {
 		t.Fatalf("got ReportValidationRequest() error = %v, want nil", err)
 	}
 
-	err = r.ReportValidationRequest(ctx, allowResponse, maxValidationDuration)
+	err = r.ReportValidationRequest(ctx, allowResponse, "false", maxValidationDuration)
 	if err != nil {
 		t.Fatalf("got ReportValidationRequest() error = %v, want nil", err)
 	}

--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -69,6 +69,8 @@ Below are the list of metrics provided by Gatekeeper:
 
     - `admission_status`: [`allow`, `deny`]
 
+    - `admission_dryrun`: [`true`, `false`]
+
     Aggregation: `Count`
 
 - Name: `gatekeeper_validation_request_duration_seconds`


### PR DESCRIPTION
Signed-off-by: Jaydip Gabani <gabanijaydip@gmail.com>

**What this PR does / why we need it**:

Adds additional tag under `gatekeeper_validation_request_count` to indicate if the request is dryrun

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #2345 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:

Output after the changes for `gatekeeper_validation_request_count`:
```
gatekeeper_validation_request_count{admission_dryrun="false",admission_status="allow"} 246
gatekeeper_validation_request_count{admission_dryrun="false",admission_status="deny"} 1
gatekeeper_validation_request_count{admission_dryrun="true",admission_status="allow"} 1
gatekeeper_validation_request_count{admission_dryrun="true",admission_status="deny"} 1
```
