### PR TITLE
fix: exclude gs namespace in matchExpressions

### DIFF
--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -231,6 +231,7 @@ webhooks:
     matchExpressions:
     - key: admission.gatekeeper.sh/ignore
       operator: DoesNotExist
+    - HELMSUBST_MUTATING_WEBHOOK_MATCHEXPRESSION_METADATANAME
     - HELMSUBST_MUTATING_WEBHOOK_EXEMPT_NAMESPACE_LABELS
   objectSelector: HELMSUBST_MUTATING_WEBHOOK_OBJECT_SELECTOR
   sideEffects: None
@@ -254,6 +255,7 @@ webhooks:
     matchExpressions:
     - key: admission.gatekeeper.sh/ignore
       operator: DoesNotExist
+    - HELMSUBST_VALIDATING_WEBHOOK_MATCHEXPRESSION_METADATANAME
     - HELMSUBST_VALIDATING_WEBHOOK_EXEMPT_NAMESPACE_LABELS
   objectSelector: HELMSUBST_VALIDATING_WEBHOOK_OBJECT_SELECTOR
   timeoutSeconds: HELMSUBST_VALIDATING_WEBHOOK_TIMEOUT
@@ -266,6 +268,9 @@ webhooks:
       namespace: gatekeeper-system
       path: /v1/admitlabel
   name: check-ignore-label.gatekeeper.sh
+  namespaceSelector:
+    matchExpressions:
+    - HELMSUBST_VALIDATING_WEBHOOK_MATCHEXPRESSION_METADATANAME
   timeoutSeconds: HELMSUBST_VALIDATING_WEBHOOK_TIMEOUT
   failurePolicy: HELMSUBST_VALIDATING_WEBHOOK_CHECK_IGNORE_FAILURE_POLICY
 ---

--- a/cmd/build/helmify/replacements.go
+++ b/cmd/build/helmify/replacements.go
@@ -91,6 +91,11 @@ var replacements = map[string]string{
 
 	"HELMSUBST_MUTATING_WEBHOOK_ANNOTATIONS": `{{- toYaml .Values.mutatingWebhookAnnotations | trim | nindent 4 }}`,
 
+	"HELMSUBST_MUTATING_WEBHOOK_MATCHEXPRESSION_METADATANAME": `key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}`,
+
 	"- HELMSUBST_MUTATING_WEBHOOK_EXEMPT_NAMESPACE_LABELS": `
     {{- range $key, $value := .Values.mutatingWebhookExemptNamespacesLabels}}
     - key: {{ $key }}
@@ -123,6 +128,11 @@ var replacements = map[string]string{
 	"HELMSUBST_VALIDATING_WEBHOOK_FAILURE_POLICY": `{{ .Values.validatingWebhookFailurePolicy }}`,
 
 	"HELMSUBST_VALIDATING_WEBHOOK_ANNOTATIONS": `{{- toYaml .Values.validatingWebhookAnnotations | trim | nindent 4 }}`,
+
+	"HELMSUBST_VALIDATING_WEBHOOK_MATCHEXPRESSION_METADATANAME": `key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}`,
 
 	"- HELMSUBST_VALIDATING_WEBHOOK_EXEMPT_NAMESPACE_LABELS": `
     {{- range $key, $value := .Values.validatingWebhookExemptNamespacesLabels}}

--- a/config/webhook/webhook_patch.yaml
+++ b/config/webhook/webhook_patch.yaml
@@ -10,6 +10,10 @@ webhooks:
       matchExpressions:
         - key: admission.gatekeeper.sh/ignore
           operator: DoesNotExist
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - gatekeeper-system
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -23,6 +27,16 @@ webhooks:
       matchExpressions:
         - key: admission.gatekeeper.sh/ignore
           operator: DoesNotExist
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - gatekeeper-system
   - name: check-ignore-label.gatekeeper.sh
     sideEffects: None
     timeoutSeconds: 3
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+          - gatekeeper-system

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -26,6 +26,10 @@ webhooks:
     matchExpressions:
     - key: admission.gatekeeper.sh/ignore
       operator: DoesNotExist
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
     
     {{- range $key, $value := .Values.mutatingWebhookExemptNamespacesLabels}}
     - key: {{ $key }}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -26,6 +26,10 @@ webhooks:
     matchExpressions:
     - key: admission.gatekeeper.sh/ignore
       operator: DoesNotExist
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
     
     {{- range $key, $value := .Values.validatingWebhookExemptNamespacesLabels}}
     - key: {{ $key }}
@@ -84,6 +88,12 @@ webhooks:
   failurePolicy: {{ .Values.validatingWebhookCheckIgnoreFailurePolicy }}
   matchPolicy: Exact
   name: check-ignore-label.gatekeeper.sh
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - {{ .Release.Namespace }}
   rules:
   - apiGroups:
     - ""

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -3428,6 +3428,10 @@ webhooks:
     matchExpressions:
     - key: admission.gatekeeper.sh/ignore
       operator: DoesNotExist
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - gatekeeper-system
   rules:
   - apiGroups:
     - '*'
@@ -3463,6 +3467,10 @@ webhooks:
     matchExpressions:
     - key: admission.gatekeeper.sh/ignore
       operator: DoesNotExist
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - gatekeeper-system
   rules:
   - apiGroups:
     - '*'
@@ -3501,6 +3509,12 @@ webhooks:
   failurePolicy: Fail
   matchPolicy: Exact
   name: check-ignore-label.gatekeeper.sh
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - gatekeeper-system
   rules:
   - apiGroups:
     - ""


### PR DESCRIPTION
Signed-off-by: Rita Zhang <rita.z.zhang@gmail.com>

**What this PR does / why we need it**:
Exclude gatekeeper-system namespace as part of matchExpressions in the webhook configs

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
