### PR TITLE
feat: evaluation_metrics

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -25,4 +25,6 @@ const (
 	MutationApplied      = "mutation_applied"
 	Mutator              = "mutator"
 	DebugLevel           = 2 // r.log.Debug(foo) == r.log.V(logging.DebugLevel).Info(foo)
+
+	EvaluationMetrics = "evaluation_metrics"
 )

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -58,6 +58,7 @@ var (
 	deserializer                       = codecs.UniversalDeserializer()
 	disableEnforcementActionValidation = flag.Bool("disable-enforcementaction-validation", false, "disable validation of the enforcementAction field of a constraint")
 	logDenies                          = flag.Bool("log-denies", false, "log detailed info on each deny")
+	logEvalMetrics                     = flag.Bool("log-eval-metrics", false, "(alpha) log evaluation metrics info on each deny")
 	emitAdmissionEvents                = flag.Bool("emit-admission-events", false, "(alpha) emit Kubernetes events in gatekeeper namespace for each admission violation")
 	tlsMinVersion                      = flag.String("tls-min-version", "1.3", "minimum version of TLS supported")
 	serviceaccount                     = fmt.Sprintf("system:serviceaccount:%s:%s", util.GetNamespace(), serviceAccountName)


### PR DESCRIPTION
#### overview

This patch adds config flags for webhook & audit to log the evaluation metrics introduced in https://github.com/open-policy-agent/frameworks/pull/263 .

#### reviewer notes
*  i figured there's value in letting folks turn these on as needed per process since log volume can be a concern


#### example logs

audit evaluation metrics
```
{
  "level": "info",
  "ts": 1671224079.425537,
  "logger": "controller",
  "msg": "logging evaluation metrics",
  "process": "audit",
  "audit_id": "2022-12-16T20:54:38Z",
  "event_type": "violation",
  "constraint_name": "psp-privileged-container",
  "constraint_group": "constraints.gatekeeper.sh",
  "constraint_api_version": "v1beta1",
  "constraint_kind": "K8sPSPPrivilegedContainer",
  "constraint_action": "deny",
  "evaluation_metrics": {
    "templateRunTime": 0.340511,
    "constraintCount": 1
  }
}
```

audit from cache
```
{
  "level": "info",
  "ts": 1671226336.3312683,
  "logger": "controller",
  "msg": "logging evaluation metrics",
  "process": "audit",
  "audit_id": "2022-12-16T21:32:15Z",
  "event_type": "violation",
  "constraint_name": "psp-privileged-container",
  "constraint_group": "constraints.gatekeeper.sh",
  "constraint_api_version": "v1beta1",
  "constraint_kind": "K8sPSPPrivilegedContainer",
  "constraint_action": "deny",
  "evaluation_metrics": {
    "templateRunTime": 0.3231,
    "constraintCount": 1
  }
}
```

admission metrics
```
{
  "level": "info",
  "ts": 1671224298.7102497,
  "logger": "webhook",
  "msg": "logging evaluation metrics for target: admission.k8s.gatekeeper.sh",
  "process": "admission",
  "event_type": "violation",
  "constraint_name": "psp-privileged-container",
  "constraint_group": "constraints.gatekeeper.sh",
  "constraint_api_version": "v1beta1",
  "constraint_kind": "K8sPSPPrivilegedContainer",
  "constraint_action": "deny",
  "resource_group": "",
  "resource_api_version": "v1",
  "resource_kind": "Pod",
  "resource_namespace": "default",
  "resource_name": "",
  "request_username": "kubernetes-admin",
  "evaluation_metrics": {
    "templateRunTime": 0.76555,
    "constraintCount": 1
  }
}
```

TODO:
* [ ] docs (will come as a separate PR most likely)