### PR TITLE
ci: bump release timeout to 45m (release-3.11)

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -327,7 +327,7 @@ jobs:
       contents: write
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-policy-agent/gatekeeper'
     needs: [lint, test, build_test, helm_build_test, scan_vulnerabilities]
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b


### PR DESCRIPTION
Co-authored-by: sozercan <sozercan@users.noreply.github.com>

**What this PR does / why we need it**:
With the newly added external data tests, we are getting close to 30m for release tests


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
