### PR TITLE
chore: use errors.Is to check for a specific error

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -619,7 +619,7 @@ func (am *Manager) getFilesFromDir(directory string, batchSize int) (files []str
 	defer dir.Close()
 	for {
 		names, err := dir.Readdirnames(batchSize)
-		if err == io.EOF || len(names) == 0 {
+		if errors.Is(err, io.EOF) || len(names) == 0 {
 			break
 		}
 		if err != nil {
@@ -638,7 +638,7 @@ func (am *Manager) removeAllFromDir(directory string, batchSize int) error {
 	defer dir.Close()
 	for {
 		names, err := dir.Readdirnames(batchSize)
-		if err == io.EOF || len(names) == 0 {
+		if errors.Is(err, io.EOF) || len(names) == 0 {
 			break
 		}
 		for _, n := range names {

--- a/pkg/gator/reader/read_constraints.go
+++ b/pkg/gator/reader/read_constraints.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -188,7 +189,7 @@ func ReadK8sResources(r io.Reader) ([]*unstructured.Unstructured, error) {
 			Object: make(map[string]interface{}),
 		}
 		err := decoder.Decode(&u.Object)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What this PR does / why we need it**:

Comparing with `==` will fail on wrapped errors. Use errors.Is to check for a specific error

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
