### PR TITLE
fix: include cmd/gator in native-test and fix gatortest_test.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ all: lint test manager
 
 # Run tests
 native-test:
-	GO111MODULE=on go test -mod vendor ./pkg/... ./apis/... -race -bench . -coverprofile cover.out
+	GO111MODULE=on go test -mod vendor ./pkg/... ./apis/... ./cmd/gator/... -race -bench . -coverprofile cover.out
 
 # Hook to run docker tests
 .PHONY: test

--- a/cmd/gator/test/gatortest_test.go
+++ b/cmd/gator/test/gatortest_test.go
@@ -60,6 +60,7 @@ func Test_formatOutput(t *testing.T) {
         object:
             kind: kind
     enforcementaction: ""
+    evaluationmeta: null
   violatingObject:
     bar: xyz
   trace: xyz


### PR DESCRIPTION
Signed-off-by: davis-haba <davishaba@google.com>

**What this PR does / why we need it**:

The `cmd/gator` directory was not included in our test pipeline. Currently, the only test this directory has is `cmd/gator/test/gatortest_test.go`. 

This PR adds the `cmd/gator` directory to `make native-test`. It also includes a small fix to add `evaluationmeta` to a unit test for `gator test`. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #2482 
