### PR TITLE
feat: add the errorlint check for golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,6 +27,7 @@ linters:
   enable:
     - deadcode
     - errcheck
+    - errorlint
     - exportloopref
     - forcetypeassert
     - gocritic

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -384,7 +384,7 @@ func setupController(mgr manager.Manager, wm *watch.Manager, tracker *readiness.
 	// initialize OPA
 	driver, err := local.New(local.Tracing(true))
 	if err != nil {
-		return fmt.Errorf("unable to set up Driver: %v", err)
+		return fmt.Errorf("unable to set up Driver: %w", err)
 	}
 
 	opaClient, err := constraintclient.NewClient(constraintclient.Targets(&target.K8sValidationTarget{}), constraintclient.Driver(driver))
@@ -802,7 +802,7 @@ func ensureCreated(ctx context.Context, c client.Client, toCreate client.Object)
 			return fmt.Errorf("a copy of %v %v already exists - run ensureDeleted to ensure a fresh copy exists for testing",
 				gvk, key)
 		} else if err != nil {
-			return fmt.Errorf("creating %v %v: %v", gvk, key, err)
+			return fmt.Errorf("creating %v %v: %w", gvk, key, err)
 		}
 
 		return nil

--- a/pkg/controller/mutators/core/reconciler_test.go
+++ b/pkg/controller/mutators/core/reconciler_test.go
@@ -263,7 +263,8 @@ type errSome struct{ id int }
 func newErrSome(id int) error { return &errSome{id: id} }
 
 func (e *errSome) Is(target error) bool {
-	if t, ok := target.(*errSome); ok {
+	var t *errSome
+	if errors.As(target, &t) {
 		return t.id == e.id
 	}
 

--- a/pkg/controller/mutators/stats_reporter_test.go
+++ b/pkg/controller/mutators/stats_reporter_test.go
@@ -181,7 +181,7 @@ func getRow(rows []*view.Row, tagValue string) (*view.Row, error) {
 func checkData(name string, rowLength int) ([]*view.Row, error) {
 	rows, err := view.RetrieveData(name)
 	if err != nil {
-		return nil, fmt.Errorf("got RetrieveData error %v from %v, want nil", err, name)
+		return nil, fmt.Errorf("got RetrieveData error %w from %v, want nil", err, name)
 	}
 	if len(rows) != rowLength {
 		return nil, fmt.Errorf("got %q row length %v, want %v", name, len(rows), rowLength)

--- a/pkg/expansion/system.go
+++ b/pkg/expansion/system.go
@@ -143,7 +143,7 @@ func (s *System) Expand(base *mutationtypes.Mutable) ([]*Resultant, error) {
 		}
 		_, err := s.mutationSystem.Mutate(mutable)
 		if err != nil {
-			return nil, fmt.Errorf("failed to mutate resultant resource %s: %s", res.Obj.GetName(), err)
+			return nil, fmt.Errorf("failed to mutate resultant resource %s: %w", res.Obj.GetName(), err)
 		}
 	}
 
@@ -166,7 +166,7 @@ func expandResource(obj *unstructured.Unstructured, ns *corev1.Namespace, templa
 
 	src, ok, err := unstructured.NestedMap(obj.Object, sourcePath(srcPath)...)
 	if err != nil {
-		return nil, fmt.Errorf("could not extract source field from unstructured: %s", err)
+		return nil, fmt.Errorf("could not extract source field from unstructured: %w", err)
 	}
 	if !ok {
 		return nil, fmt.Errorf("could not find source field %q in Obj", srcPath)

--- a/pkg/gator/expand/expand.go
+++ b/pkg/gator/expand/expand.go
@@ -63,18 +63,18 @@ func NewExpander(resources []*unstructured.Unstructured) (*Expander, error) {
 	}
 
 	if err := er.addResources(resources); err != nil {
-		return nil, fmt.Errorf("error parsing resources: %s", err)
+		return nil, fmt.Errorf("error parsing resources: %w", err)
 	}
 
 	for _, te := range er.templateExpansions {
 		if err := er.expSystem.UpsertTemplate(te); err != nil {
-			return nil, fmt.Errorf("error upserting template %s: %s", te.Name, err)
+			return nil, fmt.Errorf("error upserting template %s: %w", te.Name, err)
 		}
 	}
 
 	for _, m := range er.mutators {
 		if err := er.mutSystem.Upsert(m); err != nil {
-			return nil, fmt.Errorf("error upserting mutator: %s", err)
+			return nil, fmt.Errorf("error upserting mutator: %w", err)
 		}
 	}
 
@@ -92,12 +92,12 @@ func (er *Expander) Expand(resource *unstructured.Unstructured) ([]*expansion.Re
 		Source:    types.SourceTypeOriginal,
 	}
 	if _, err := er.mutSystem.Mutate(base); err != nil {
-		return nil, fmt.Errorf("error mutating base resource %s: %s", resource.GetName(), err)
+		return nil, fmt.Errorf("error mutating base resource %s: %w", resource.GetName(), err)
 	}
 
 	resultants, err := er.expSystem.Expand(base)
 	if err != nil {
-		return nil, fmt.Errorf("error expanding resource %s: %s", resource.GetName(), err)
+		return nil, fmt.Errorf("error expanding resource %s: %w", resource.GetName(), err)
 	}
 
 	return resultants, nil

--- a/pkg/gator/test/test.go
+++ b/pkg/gator/test/test.go
@@ -82,7 +82,7 @@ func Test(objs []*unstructured.Unstructured, includeTrace bool) (*GatorResponses
 	// create the expander
 	er, err := expand.NewExpander(objs)
 	if err != nil {
-		return nil, fmt.Errorf("error creating expander: %s", err)
+		return nil, fmt.Errorf("error creating expander: %w", err)
 	}
 
 	// now audit all objects
@@ -100,14 +100,14 @@ func Test(objs []*unstructured.Unstructured, includeTrace bool) (*GatorResponses
 
 		review, err := client.Review(ctx, au)
 		if err != nil {
-			return nil, fmt.Errorf("reviewing %v %s/%s: %v",
+			return nil, fmt.Errorf("reviewing %v %s/%s: %w",
 				obj.GroupVersionKind(), obj.GetNamespace(), obj.GetName(), err)
 		}
 
 		// Attempt to expand the obj and review resultant resources (if any)
 		resultants, err := er.Expand(obj)
 		if err != nil {
-			return nil, fmt.Errorf("expanding resource %s: %s", obj.GetName(), err)
+			return nil, fmt.Errorf("expanding resource %s: %w", obj.GetName(), err)
 		}
 		for _, resultant := range resultants {
 			au := target.AugmentedUnstructured{
@@ -117,7 +117,7 @@ func Test(objs []*unstructured.Unstructured, includeTrace bool) (*GatorResponses
 			}
 			resultantReview, err := client.Review(ctx, au)
 			if err != nil {
-				return nil, fmt.Errorf("reviewing expanded resource %v %s/%s: %v",
+				return nil, fmt.Errorf("reviewing expanded resource %v %s/%s: %w",
 					resultant.Obj.GroupVersionKind(), resultant.Obj.GetNamespace(), resultant.Obj.GetName(), err)
 			}
 			expansion.OverrideEnforcementAction(resultant.EnforcementAction, resultantReview)

--- a/pkg/mutation/mutators/assign/assign_mutator_test.go
+++ b/pkg/mutation/mutators/assign/assign_mutator_test.go
@@ -91,7 +91,7 @@ func newPod(pod *corev1.Pod) *unstructured.Unstructured {
 func ensureObj(u *unstructured.Unstructured, expected interface{}, path ...string) error {
 	v, exists, err := unstructured.NestedFieldNoCopy(u.Object, path...)
 	if err != nil {
-		return fmt.Errorf("could not retrieve value: %v", err)
+		return fmt.Errorf("could not retrieve value: %w", err)
 	}
 	if !exists {
 		return fmt.Errorf("value does not exist at %+v: %s", path, spew.Sdump(u.Object))
@@ -105,7 +105,7 @@ func ensureObj(u *unstructured.Unstructured, expected interface{}, path ...strin
 func ensureMissing(u *unstructured.Unstructured, path ...string) error {
 	v, exists, err := unstructured.NestedFieldNoCopy(u.Object, path...)
 	if err != nil {
-		return fmt.Errorf("could not retrieve value: %v", err)
+		return fmt.Errorf("could not retrieve value: %w", err)
 	}
 	if exists {
 		return fmt.Errorf("value exists at %+v as %v, expected missing: %s", path, v, spew.Sdump(u.Object))

--- a/pkg/mutation/mutators/core/mutation_function_setter_test.go
+++ b/pkg/mutation/mutators/core/mutation_function_setter_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation/path/parser"
@@ -27,7 +28,7 @@ func TestKeyedListIncompatible(t *testing.T) {
 	}
 	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
 	m, err := Mutate(path, &tester.Tester{}, &notKeyedSetter{}, obj)
-	if err != ErrNonKeyedSetter {
+	if !errors.Is(err, ErrNonKeyedSetter) {
 		t.Errorf("wanted err = %+v, got %+v", ErrNonKeyedSetter, err)
 	}
 	if m != false {

--- a/pkg/mutation/path/parser/errors.go
+++ b/pkg/mutation/path/parser/errors.go
@@ -38,6 +38,5 @@ func (e invalidIntegerError) Error() string {
 }
 
 func (e invalidIntegerError) Is(target error) bool {
-	_, ok := target.(invalidIntegerError)
-	return ok
+	return errors.As(target, &invalidIntegerError{})
 }

--- a/pkg/mutation/schema/errors.go
+++ b/pkg/mutation/schema/errors.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/open-policy-agent/gatekeeper/pkg/util"
@@ -28,8 +29,8 @@ func (e ErrConflictingSchema) Error() string {
 }
 
 func (e ErrConflictingSchema) Is(other error) bool {
-	o, ok := other.(ErrConflictingSchema)
-	if !ok {
+	var o ErrConflictingSchema
+	if !errors.As(other, &o) {
 		return false
 	}
 

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -373,7 +373,7 @@ func (h *validationHandler) validateTemplate(ctx context.Context, req *admission
 	// ensures the Rego code both parses and compiles.
 	d, err := local.New()
 	if err != nil {
-		return false, fmt.Errorf("unable to create Driver: %v", err)
+		return false, fmt.Errorf("unable to create Driver: %w", err)
 	}
 
 	err = d.AddTemplate(ctx, unversioned)
@@ -504,13 +504,13 @@ func (h *validationHandler) reviewRequest(ctx context.Context, req *admission.Re
 
 	review, err := h.createReviewForRequest(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create augmentedReview: %s", err)
+		return nil, fmt.Errorf("failed to create augmentedReview: %w", err)
 	}
 
 	// Convert the request's generator resource to unstructured for expansion
 	obj := &unstructured.Unstructured{}
 	if _, _, err := deserializer.Decode(req.Object.Raw, nil, obj); err != nil {
-		return nil, fmt.Errorf("error decoding generator resource %s: %v", req.Name, err)
+		return nil, fmt.Errorf("error decoding generator resource %s: %w", req.Name, err)
 	}
 	obj.SetNamespace(req.Namespace)
 	obj.SetGroupVersionKind(
@@ -529,19 +529,19 @@ func (h *validationHandler) reviewRequest(ctx context.Context, req *admission.Re
 	}
 	resultants, err := h.expansionSystem.Expand(base)
 	if err != nil {
-		return nil, fmt.Errorf("unable to expand object: %s", err)
+		return nil, fmt.Errorf("unable to expand object: %w", err)
 	}
 
 	trace, dump := h.tracingLevel(ctx, req)
 	resp, err := h.review(ctx, review, trace, dump)
 	if err != nil {
-		return nil, fmt.Errorf("error reviewing resource %s: %s", req.Name, err)
+		return nil, fmt.Errorf("error reviewing resource %s: %w", req.Name, err)
 	}
 
 	for _, res := range resultants {
 		resultantResp, err := h.review(ctx, createReviewForResultant(res.Obj, review.Namespace), trace, dump)
 		if err != nil {
-			return nil, fmt.Errorf("error reviewing resultant resource: %s", err)
+			return nil, fmt.Errorf("error reviewing resultant resource: %w", err)
 		}
 		expansion.OverrideEnforcementAction(res.EnforcementAction, resultantResp)
 		expansion.AggregateResponses(res.TemplateName, resp, resultantResp)


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What this PR does / why we need it**:

Adds errorlint checks to `golangci-lint`, standardizing the error format and error judgments

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
