### PR TITLE
test: use custom filter to make tests less brittle

### DIFF
--- a/cmd/gator/test/gatortest_test.go
+++ b/cmd/gator/test/gatortest_test.go
@@ -1,21 +1,16 @@
 package test
 
 import (
-	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/types"
 	"github.com/open-policy-agent/gatekeeper/pkg/gator/test"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Test_formatOutput makes sure that the formatted output of `gator test`
-// is consitent as we iterate over the tool. The test IS NOT
+// is consitent as we iterate over the tool. The purpose of this test IS NOT
 // testing the `gator test` results themselves.
 func Test_formatOutput(t *testing.T) {
 	constraintObj := &unstructured.Unstructured{}
@@ -27,8 +22,7 @@ func Test_formatOutput(t *testing.T) {
 	}
 	barObject := &unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"bar":  "xyz",
-			"kind": "kind",
+			"bar": "xyz",
 		},
 	}
 	xyzTrace := "xyz"
@@ -41,7 +35,7 @@ func Test_formatOutput(t *testing.T) {
 	}{
 		{
 			name: "default output",
-			// inputFormat: "default", // note that the inputFormat defaults to "default"/ human friendly
+			// inputFormat: "default", // note that the inputFormat defaults to "default"
 			input: []*test.GatorResult{{
 				Result:          fooRes,
 				ViolatingObject: barObject,
@@ -66,6 +60,7 @@ func Test_formatOutput(t *testing.T) {
         object:
             kind: kind
     enforcementaction: ""
+    evaluationmeta: null
   violatingObject:
     bar: xyz
   trace: xyz
@@ -86,8 +81,7 @@ func Test_formatOutput(t *testing.T) {
             "kind": "kind"
         },
         "violatingObject": {
-            "bar": "xyz",
-            "kind": "kind"
+            "bar": "xyz"
         },
         "trace": "xyz"
     }
@@ -96,27 +90,9 @@ func Test_formatOutput(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.NotEmpty(t, formatOutput(tc.inputFormat, tc.input))
-
-			switch strings.ToLower(tc.inputFormat) {
-			case stringJSON:
-				var gatorResult []*test.GatorResult
-				require.NoError(t, json.Unmarshal([]byte(tc.expectedOutput), &gatorResult))
-
-				if diff := cmp.Diff(tc.input, gatorResult, cmpopts.IgnoreFields(test.GatorResult{}, "Metadata")); diff != "" {
-					t.Fatal(diff)
-				}
-			case stringYAML:
-				var gatorResult []*test.GatorResult
-				require.NoError(t, yaml.Unmarshal([]byte(tc.expectedOutput), &gatorResult))
-
-				if diff := cmp.Diff(tc.input, gatorResult, cmpopts.IgnoreFields(test.GatorResult{}, "Metadata", "ViolatingObject")); diff != "" {
-					t.Fatal(diff)
-				}
-
-			case stringHumanFriendly:
-			default:
-				require.Equal(t, tc.expectedOutput, formatOutput(tc.inputFormat, tc.input))
+			output := formatOutput(tc.inputFormat, tc.input)
+			if diff := cmp.Diff(tc.expectedOutput, output); diff != "" {
+				t.Fatal(diff)
 			}
 		})
 	}

--- a/pkg/gator/test/test_test.go
+++ b/pkg/gator/test/test_test.go
@@ -251,12 +251,8 @@ func Test_Test_withTrace(t *testing.T) {
 		},
 	}
 
-	diff := cmp.Diff(want, got, cmpopts.IgnoreFields(
+	diff := cmp.Diff(want, got, ignoreGatorResultFields(), cmpopts.IgnoreFields(
 		GatorResult{},
-		"Metadata",
-		"EvaluationMeta",
-		"EnforcementAction",
-		"ViolatingObject",
 		"Trace", // ignore Trace for now, we will assert non nil further down
 	))
 	if diff != "" {

--- a/pkg/gator/test/test_test.go
+++ b/pkg/gator/test/test_test.go
@@ -72,10 +72,11 @@ func ignoreGatorResultFields() cmp.Option {
 
 func TestTest(t *testing.T) {
 	tcs := []struct {
-		name   string
-		inputs []string
-		want   []*GatorResult
-		err    error
+		name      string
+		inputs    []string
+		want      []*GatorResult
+		cmpOption cmp.Option
+		err       error
 	}{
 		{
 			name: "basic no violation",
@@ -84,6 +85,7 @@ func TestTest(t *testing.T) {
 				fixtures.ConstraintAlwaysValidate,
 				fixtures.Object,
 			},
+			cmpOption: ignoreGatorResultFields(),
 		},
 		{
 			name: "basic violation",
@@ -115,6 +117,7 @@ func TestTest(t *testing.T) {
 					},
 				},
 			},
+			cmpOption: ignoreGatorResultFields(),
 		},
 		{
 			name: "referential constraint with violation",
@@ -140,6 +143,7 @@ func TestTest(t *testing.T) {
 					},
 				},
 			},
+			cmpOption: ignoreGatorResultFields(),
 		},
 		{
 			name: "referential constraint without violation",
@@ -195,7 +199,13 @@ func TestTest(t *testing.T) {
 
 			got := resps.Results()
 
-			diff := cmp.Diff(tc.want, got, ignoreGatorResultFields())
+			var diff string
+			if tc.cmpOption != nil {
+				diff = cmp.Diff(tc.want, got, tc.cmpOption)
+			} else {
+				diff = cmp.Diff(tc.want, got)
+			}
+
 			if diff != "" {
 				t.Errorf("diff in GatorResult objects (-want +got):\n%s", diff)
 			}


### PR DESCRIPTION
Re working some of these to be less brittle. It's going to help any time we make changes to the `Result` type in CF.

Signed-off-by: Alex Pana <8968914+acpana@users.noreply.github.com>