### PR TITLE
feat: introduce `gci` to unify the order of package import

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,6 +30,7 @@ linters:
     - errorlint
     - exportloopref
     - forcetypeassert
+    - gci
     - gocritic
     - goconst
     - godot

--- a/cmd/gator/expand/expand.go
+++ b/cmd/gator/expand/expand.go
@@ -10,10 +10,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/gator/expand"
 	"github.com/open-policy-agent/gatekeeper/pkg/gator/reader"
 	"github.com/spf13/cobra"
-
-	// yaml.v3 inserts a space before '-', which is inconsistent with standard
-	// kubernetes and kubebuilder format. yaml.v2 does not insert these spaces.
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2" // yaml.v3 inserts a space before '-', which is inconsistent with standard, kubernetes and kubebuilder format. yaml.v2 does not insert these spaces.
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 

--- a/main.go
+++ b/main.go
@@ -27,10 +27,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/open-policy-agent/gatekeeper/pkg/expansion"
-	// set GOMAXPROCS to the number of container cores, if known.
-	_ "go.uber.org/automaxprocs"
-
 	"github.com/go-logr/zapr"
 	"github.com/open-policy-agent/cert-controller/pkg/rotator"
 	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
@@ -44,6 +40,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/audit"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller"
 	"github.com/open-policy-agent/gatekeeper/pkg/controller/config/process"
+	"github.com/open-policy-agent/gatekeeper/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/pkg/externaldata"
 	"github.com/open-policy-agent/gatekeeper/pkg/metrics"
 	"github.com/open-policy-agent/gatekeeper/pkg/mutation"
@@ -56,6 +53,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/pkg/watch"
 	"github.com/open-policy-agent/gatekeeper/pkg/webhook"
 	"github.com/open-policy-agent/gatekeeper/third_party/sigs.k8s.io/controller-runtime/pkg/dynamiccache"
+	_ "go.uber.org/automaxprocs" // set GOMAXPROCS to the number of container cores, if known.
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/api/meta"

--- a/pkg/controller/config/config_controller_suite_test.go
+++ b/pkg/controller/config/config_controller_suite_test.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/open-policy-agent/gatekeeper/apis"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -30,8 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/open-policy-agent/gatekeeper/apis"
 )
 
 var cfg *rest.Config


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What this PR does / why we need it**:

The order of package import for some files in the code is not uniform, and this pr introduces `gci` to regulate package import order

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
