### PR TITLE
chore: the linter `structcheck` `varcheck` and `deadcode` are deprecated (since v1.49.0)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,7 +25,6 @@ linters-settings:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - errorlint
     - exportloopref
@@ -44,8 +43,6 @@ linters:
     - misspell
     - revive # replacement for golint
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - whitespace


### PR DESCRIPTION
… abandoned the linter.  Replaced by unused.

Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
