### PR TITLE
chore: modify the typecheck as prompted

### DIFF
--- a/apis/status/v1beta1/constraintpodstatus_types_test.go
+++ b/apis/status/v1beta1/constraintpodstatus_types_test.go
@@ -1,7 +1,6 @@
 package v1beta1_test
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -53,7 +52,7 @@ func TestNewConstraintStatusForPod(t *testing.T) {
 			v1beta1.ConstraintNameLabel:         "a-constraint",
 			v1beta1.ConstraintKindLabel:         "AConstraintKind",
 			v1beta1.PodLabel:                    podName,
-			v1beta1.ConstraintTemplateNameLabel: strings.ToLower(cstrKind),
+			v1beta1.ConstraintTemplateNameLabel: "aconstraintkind",
 		})
 
 	err = controllerutil.SetOwnerReference(pod, wantStatus, scheme)

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -504,7 +504,7 @@ func Test_CollectDeleted(t *testing.T) {
 	type test struct {
 		description string
 		gvk         schema.GroupVersionKind
-		tracker     readiness.Expectations
+		tracker     *readiness.Expectations
 	}
 
 	g := gomega.NewWithT(t)
@@ -562,7 +562,7 @@ func Test_CollectDeleted(t *testing.T) {
 	// between them to keep the test short. Trackers are mostly independent per GVK.
 	tests := []test{
 		{description: "constraints", gvk: cgvk},
-		{description: "data (configmaps)", gvk: cmgvk, tracker: cmtracker},
+		{description: "data (configmaps)", gvk: cmgvk, tracker: &cmtracker},
 		{description: "templates", gvk: ctgvk},
 		// no need to check Config here since it is not actually Expected for readiness
 		// (the objects identified in a Config's syncOnly are Expected, tested in data case above)
@@ -572,7 +572,7 @@ func Test_CollectDeleted(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			var tt readiness.Expectations
 			if tc.tracker != nil {
-				tt = tc.tracker
+				tt = *tc.tracker
 			} else {
 				tt = tracker.For(tc.gvk)
 			}


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What this PR does / why we need it**:

```shell
➜  gatekeeper git:(master) golangci-lint run -c .golangci.yaml
apis/status/v1beta1/constraintpodstatus_types_test.go:4:2: "strings" imported but not used (typecheck)
        "strings"
        ^
pkg/readiness/ready_tracker_test.go:574:21: invalid operation: cannot compare tc.tracker != nil (operator != not defined on untyped nil) (typecheck)
                        if tc.tracker != nil {
                                         ^
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
