### PR TITLE
feat: add unconvert check for golang-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -45,5 +45,6 @@ linters:
     - revive # replacement for golint
     - staticcheck
     - typecheck
+    - unconvert
     - unused
     - whitespace

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -60,7 +60,7 @@ func newExporterSet(exporters map[string]StartExporter) *exporterSet {
 func (es *exporterSet) String() string {
 	contents := make([]string, 0)
 	for k := range es.assignedExporters {
-		contents = append(contents, string(k))
+		contents = append(contents, k)
 	}
 	return fmt.Sprintf("%s", contents)
 }


### PR DESCRIPTION
Signed-off-by: Fish-pro <zechun.chen@daocloud.io>

**What this PR does / why we need it**:

```shell
➜  gatekeeper git:(chore/unconvert) golangci-lint run -c .golangci.yaml
pkg/metrics/registry/registry.go:63:37: unnecessary conversion (unconvert)
                contents = append(contents, string(k))
                                                  ^
➜  gatekeeper git:(chore/unconvert) ✗ golangci-lint run -c .golangci.yaml
➜  gatekeeper git:(chore/unconvert) ✗ 

```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
