### PR TITLE
ci: pin golang image to unblock ci

### DIFF
--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-bullseye as builder
+FROM golang@sha256:bb9811fad43a7d6fd2173248d8331b2dcf5ac9af20976b1937ecd214c5b8c383 as builder
 
 ARG BATS_VERSION
 ARG ORAS_VERSION
@@ -8,7 +8,7 @@ ARG KUSTOMIZE_VERSION
 ARG TARGETARCH
 
 RUN apt-get update && \
-    apt-get install -y make jq
+    apt-get install -y make jq apt-utils
 
 # Install kustomize
 RUN curl -L -O "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz" &&\


### PR DESCRIPTION
Signed-off-by: Sertac Ozercan <sozercan@gmail.com>

**What this PR does / why we need it**:
This pins the golang image (used for test tooling) to a digest that contains Go 1.19.5 but without the git update to unblock pr tests

see #2569 for more details (keeping this open so we can use that for a longer-term fix)

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
