### PR TITLE
fix: add missing namespace to static Helm templates

### DIFF
--- a/cmd/build/helmify/static/templates/namespace-post-install.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-install.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: gatekeeper-update-namespace-label
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'
@@ -96,6 +97,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gatekeeper-update-namespace-label
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/cmd/build/helmify/static/templates/namespace-post-upgrade.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-upgrade.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: gatekeeper-update-namespace-label-post-upgrade
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
+++ b/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: gatekeeper-delete-webhook-configs
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'
@@ -65,6 +66,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gatekeeper-delete-webhook-configs
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: gatekeeper-update-namespace-label
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'
@@ -96,6 +97,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gatekeeper-update-namespace-label
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-upgrade.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-upgrade.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: gatekeeper-update-namespace-label-post-upgrade
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: gatekeeper-delete-webhook-configs
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'
@@ -65,6 +66,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: gatekeeper-delete-webhook-configs
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}


### PR DESCRIPTION
**What this PR does / why we need it**:
A few static templates for the Helm chart are missing a namespace when rendered using `helm template`, causing failure when applied this way with a non-default namespace:
```shell
helm template gatekeeper gatekeeper/gatekeeper -n kube-system | kubectl apply -f -
```

```shell
# Resources created in default namespace:
kubectl get jobs
NAME                                         COMPLETIONS   DURATION   AGE
gatekeeper-update-namespace-label            0/1           39s        39s

kubectl get serviceaccounts
NAME                                  SECRETS   AGE
gatekeeper-update-namespace-label     0         87s

# Reference to service account in chart namespace:
kubectl get clusterrolebinding gatekeeper-update-namespace-label -o yaml
...
subjects:
- kind: ServiceAccount
  name: gatekeeper-update-namespace-label
  namespace: kube-system

# Pod failure in wrong namespace
kubectl describe gatekeeper-update-namespace-label-zrld4
...
  Warning  FailedMount  102s                 kubelet            Unable to attach or mount volumes: unmounted volumes=[cert], unattached volumes=[cert kube-api-access-dnn7h]: timed out waiting for the condition
  Warning  FailedMount  97s (x9 over 3m45s)  kubelet            MountVolume.SetUp failed for volume "cert" : secret "gatekeeper-webhook-server-cert" not found
```