### PR TITLE
ci: remove k8s 1.23 from matrix

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -109,7 +109,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        KUBERNETES_VERSION: ["1.23.13", "1.24.7", "1.25.3", "1.26.0"]
+        KUBERNETES_VERSION: ["1.24.7", "1.25.3", "1.26.0"]
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c

--- a/Tiltfile
+++ b/Tiltfile
@@ -74,7 +74,7 @@ def build_crds():
         context=".staging/crds/",
         target="build",
         only="crds",
-        build_args={"KUBE_VERSION": "1.23.0"},
+        build_args={"KUBE_VERSION": "1.26.0"},
         live_update=[
             sync(".staging/crds/", "/crds"),
         ],


### PR DESCRIPTION
**What this PR does / why we need it**:
K8s 1.23 is EOL

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
