### PR TITLE
fix: eliminate deadlock-on-exit

### DIFF
--- a/main.go
+++ b/main.go
@@ -297,6 +297,7 @@ func innerMain() int {
 			setupLog.Error(err, "problem running manager")
 			mgrErr <- err
 		}
+		close(mgrErr)
 	}()
 
 	// block until either setupControllers or mgr has an error, or mgr exits.


### PR DESCRIPTION
**What this PR does / why we need it**:

If manager exits without an error, then it's error channel is never closed, which causes blockingLoop to hang indefinitely.

This was papered over by Kubernetes' termination grace period behavior:

https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
