### PR TITLE
docs: remove old redirect on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,4 +2,4 @@
 <meta charset="utf-8">
 <title>Redirecting to https://open-policy-agent.github.io/gatekeeper/website/docs/</title>
 <meta http-equiv="refresh" content="0; URL=https://open-policy-agent.github.io/gatekeeper/website/docs/">
-<link rel="canonical" href="https://open-policy-agent.github.io/gatekeeper/website/docs/">
+<link rel="canonical" href="https://open-policy-agent.github.io/gatekeeper/website/">


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes the redirect to `/docs` on the website so it lands on the homepage by default
