### PR TITLE
feat: Add `external_data` function to Gator Test command

### DIFF
--- a/cmd/gator/expand/expand.go
+++ b/cmd/gator/expand/expand.go
@@ -67,7 +67,7 @@ func init() {
 }
 
 func run(cmd *cobra.Command, args []string) {
-	unstrucs, err := reader.ReadSources(flagFilenames, flagImages, flagTempDir)
+	unstrucs, err := reader.ReadSources(flagFilenames, flagImages, flagTempDir, []string{})
 	if err != nil {
 		util.ErrFatalf("reading: %v", err)
 	}

--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -46,13 +46,15 @@ var Cmd = &cobra.Command{
 }
 
 var (
-	flagFilenames    []string
-	flagOutput       string
-	flagIncludeTrace bool
-	flagGatherStats  bool
-	flagImages       []string
-	flagTempDir      string
-	flagEnableK8sCel bool
+	flagFilenames             []string
+	flagOutput                string
+	flagIncludeTrace          bool
+	flagGatherStats           bool
+	flagEnableExternalData    bool
+	flagExternalDataProviders []string
+	flagImages                []string
+	flagTempDir               string
+	flagEnableK8sCel          bool
 )
 
 const (
@@ -74,12 +76,14 @@ func init() {
 	Cmd.Flags().BoolVarP(&flagIncludeTrace, "trace", "t", false, "include a trace for the underlying Constraint Framework evaluation.")
 	Cmd.Flags().BoolVarP(&flagGatherStats, "stats", "", false, "include performance stats returned from the Constraint Framework.")
 	Cmd.Flags().BoolVarP(&flagEnableK8sCel, "experimental-enable-k8s-native-validation", "", false, "PROTOTYPE (not stable): enable the validating admission policy driver")
+	Cmd.Flags().BoolVarP(&flagEnableExternalData, "enable-external-data", "", false, "explicit flag to enable external_data() function. Defaults to false.")
+	Cmd.Flags().StringArrayVarP(&flagExternalDataProviders, "external-data-providers", "", []string{}, "a file or directory containing External Data Provider manifests. Can be specified multiple times. Any External Data Provider manifests in --filename directory will be ignored.")
 	Cmd.Flags().StringArrayVarP(&flagImages, flagNameImage, "i", []string{}, "a URL to an OCI image containing policies. Can be specified multiple times.")
 	Cmd.Flags().StringVarP(&flagTempDir, flagNameTempDir, "d", "", fmt.Sprintf("Specifies the temporary directory to download and unpack images to, if using the --%s flag. Optional.", flagNameImage))
 }
 
 func run(cmd *cobra.Command, args []string) {
-	unstrucs, err := reader.ReadSources(flagFilenames, flagImages, flagTempDir)
+	unstrucs, err := reader.ReadSources(flagFilenames, flagImages, flagTempDir, flagExternalDataProviders)
 	if err != nil {
 		cmdutils.ErrFatalf("reading: %v", err)
 	}
@@ -87,7 +91,7 @@ func run(cmd *cobra.Command, args []string) {
 		cmdutils.ErrFatalf("no input data identified")
 	}
 
-	responses, err := test.Test(unstrucs, test.Opts{IncludeTrace: flagIncludeTrace, GatherStats: flagGatherStats, UseK8sCEL: flagEnableK8sCel})
+	responses, err := test.Test(unstrucs, test.Opts{IncludeTrace: flagIncludeTrace, GatherStats: flagGatherStats, UseK8sCEL: flagEnableK8sCel, EnableExternalData: flagEnableExternalData})
 	if err != nil {
 		cmdutils.ErrFatalf("auditing objects: %v", err)
 	}

--- a/website/docs/gator.md
+++ b/website/docs/gator.md
@@ -94,6 +94,30 @@ a `1` exit status with an error message printed to stderr.
 Policy violations will generate a `1` exit status as well, but violation
 information will be printed to stdout.
 
+#### External Data
+In order to use `gator test` command with policies that use the `external_data()` function, `--enable-external-data` 
+along with `--external-data-providers` flags can be used. The former flag explicitly enables/disables this feature while
+the latter flag loads the External Data Provider manifests (`externaldata.gatekeeper.sh` group) from a dedicated
+directory/file for security purposes (to avoid loading malicious configurations). For example:
+
+```
+cat my-manifest.yaml | gator test --filename=template-and-constraints/ --enable-external-data --external-data-providers=external-data-providers/provider.yaml
+```
+
+provider.yaml:
+```
+apiVersion: externaldata.gatekeeper.sh/v1beta1
+kind: Provider
+metadata:
+  name: my-provider
+spec:
+  url: https://localhost:8090/
+  timeout: 5
+  caBundle: ...
+```
+This requires the External Data Provider server to be available at `https://localhost:8090/` when `gator test` command
+is executed.
+
 ##### Enforcement Actions
 
 While violation data will always be returned when an object is found to be


### PR DESCRIPTION
Signed-off-by: Fardin Khanjani <fardin.khanjani@tradeshift.com>

**What this PR does / why we need it**:
`gator test` should be able to handle external data providers.

`gator test` returns `undefined function external_data` if `external_data` is being used in a ConstraintTemplate. This means that policies that query an external data source cannot be tested except for manual tests against a live cluster. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #2659

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
