### PR TITLE
fix: statically link gator binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,7 +538,7 @@ gator: bin/gator-$(GOOS)-$(GOARCH)
 	mv bin/gator-$(GOOS)-$(GOARCH) bin/gator
 
 bin/gator-$(GOOS)-$(GOARCH):
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BIN_DIR)/gator-$(GOOS)-$(GOARCH) -ldflags $(LDFLAGS) ./cmd/gator
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 GO111MODULE=on go build -o $(BIN_DIR)/gator-$(GOOS)-$(GOARCH) -ldflags $(LDFLAGS) ./cmd/gator
 
 tilt-prepare:
 	mkdir -p .tiltbuild/charts


### PR DESCRIPTION
fixes https://github.com/open-policy-agent/gatekeeper/issues/2825

After changes:

```bash
$ make gator && file ./bin/gator
./bin/gator: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=RCa34m4KxNkndGrvlkby/dC7Eydt9Mi5d0rOW8JKV/kC4hP7hRpgDaw8-aOUy2/J8nfYbCPMRkaGM8wTFgV, with debug_info, not stripped
```

Notice `statically linked`. Before changes:

```bash
$ make gator && file ./bin/gator
./bin/gator: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=6O50_OD8mTvb3GOw2xK7/YBG9hxjCyAmV2a510vXp/M1QQS4iPBdcfFKct_6Ff/v7D7mRXcr-XX9wI2Ei72, with debug_info, not stripped
```