### PR TITLE
refactor: move util.Wildcard into its own package

### DIFF
--- a/apis/config/v1alpha1/config_types.go
+++ b/apis/config/v1alpha1/config_types.go
@@ -16,7 +16,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -63,8 +63,8 @@ type SyncOnlyEntry struct {
 }
 
 type MatchEntry struct {
-	Processes          []string        `json:"processes,omitempty"`
-	ExcludedNamespaces []util.Wildcard `json:"excludedNamespaces,omitempty"`
+	Processes          []string            `json:"processes,omitempty"`
+	ExcludedNamespaces []wildcard.Wildcard `json:"excludedNamespaces,omitempty"`
 }
 
 type ReadinessSpec struct {

--- a/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -149,7 +149,7 @@ func (in *MatchEntry) DeepCopyInto(out *MatchEntry) {
 	}
 	if in.ExcludedNamespaces != nil {
 		in, out := &in.ExcludedNamespaces, &out.ExcludedNamespaces
-		*out = make([]util.Wildcard, len(*in))
+		*out = make([]wildcard.Wildcard, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -30,8 +30,8 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/target"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	testclient "github.com/open-policy-agent/gatekeeper/v3/test/clients"
 	"github.com/open-policy-agent/gatekeeper/v3/test/testutils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -104,11 +104,11 @@ func TestReconcile(t *testing.T) {
 			},
 			Match: []configv1alpha1.MatchEntry{
 				{
-					ExcludedNamespaces: []util.Wildcard{"foo"},
+					ExcludedNamespaces: []wildcard.Wildcard{"foo"},
 					Processes:          []string{"*"},
 				},
 				{
-					ExcludedNamespaces: []util.Wildcard{"bar"},
+					ExcludedNamespaces: []wildcard.Wildcard{"bar"},
 					Processes:          []string{"audit", "webhook"},
 				},
 			},
@@ -719,7 +719,7 @@ func configFor(kinds []schema.GroupVersionKind) *configv1alpha1.Config {
 			},
 			Match: []configv1alpha1.MatchEntry{
 				{
-					ExcludedNamespaces: []util.Wildcard{"kube-system"},
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
 					Processes:          []string{"sync"},
 				},
 			},

--- a/pkg/controller/config/process/excluder_test.go
+++ b/pkg/controller/config/process/excluder_test.go
@@ -3,19 +3,19 @@ package process
 import (
 	"testing"
 
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 )
 
 func TestExactOrWildcardMatch(t *testing.T) {
 	tcs := []struct {
 		name     string
-		nsMap    map[util.Wildcard]bool
+		nsMap    map[wildcard.Wildcard]bool
 		ns       string
 		excluded bool
 	}{
 		{
 			name: "exact text match",
-			nsMap: map[util.Wildcard]bool{
+			nsMap: map[wildcard.Wildcard]bool{
 				"kube-system": true,
 				"foobar":      true,
 			},
@@ -24,7 +24,7 @@ func TestExactOrWildcardMatch(t *testing.T) {
 		},
 		{
 			name: "wildcard prefix match",
-			nsMap: map[util.Wildcard]bool{
+			nsMap: map[wildcard.Wildcard]bool{
 				"kube-*": true,
 				"foobar": true,
 			},
@@ -33,7 +33,7 @@ func TestExactOrWildcardMatch(t *testing.T) {
 		},
 		{
 			name: "wildcard suffix match",
-			nsMap: map[util.Wildcard]bool{
+			nsMap: map[wildcard.Wildcard]bool{
 				"*-system": true,
 				"foobar":   true,
 			},
@@ -42,7 +42,7 @@ func TestExactOrWildcardMatch(t *testing.T) {
 		},
 		{
 			name: "lack of asterisk prevents globbing",
-			nsMap: map[util.Wildcard]bool{
+			nsMap: map[wildcard.Wildcard]bool{
 				"kube-": true,
 			},
 			ns:       "kube-system",

--- a/pkg/mutation/match/match_test.go
+++ b/pkg/mutation/match/match_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -188,7 +188,7 @@ func TestMatch(t *testing.T) {
 			name:   "namespace matches",
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "namespace", "name"),
 			matcher: Match{
-				Namespaces: []util.Wildcard{"nonmatching", "namespace"},
+				Namespaces: []wildcard.Wildcard{"nonmatching", "namespace"},
 			},
 			namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "namespace"}},
 			source:    types.SourceTypeOriginal,
@@ -198,7 +198,7 @@ func TestMatch(t *testing.T) {
 			name:   "is a matching Namespace",
 			object: makeNamespace("matching"),
 			matcher: Match{
-				Namespaces: []util.Wildcard{"matching"},
+				Namespaces: []wildcard.Wildcard{"matching"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -208,7 +208,7 @@ func TestMatch(t *testing.T) {
 			name:   "is not a matching Namespace",
 			object: makeNamespace("non-matching"),
 			matcher: Match{
-				Namespaces: []util.Wildcard{"matching"},
+				Namespaces: []wildcard.Wildcard{"matching"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -219,7 +219,7 @@ func TestMatch(t *testing.T) {
 			name:   "namespaces configured, but cluster scoped",
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "", "name"),
 			matcher: Match{
-				Namespaces: []util.Wildcard{"nonmatching", "namespace"},
+				Namespaces: []wildcard.Wildcard{"nonmatching", "namespace"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -229,7 +229,7 @@ func TestMatch(t *testing.T) {
 			name:   "namespace prefix matches",
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "kube-system", "name"),
 			matcher: Match{
-				Namespaces: []util.Wildcard{"nonmatching", "kube-*"},
+				Namespaces: []wildcard.Wildcard{"nonmatching", "kube-*"},
 			},
 			namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
 			source:    types.SourceTypeOriginal,
@@ -239,7 +239,7 @@ func TestMatch(t *testing.T) {
 			name:   "namespace is not in the matches list",
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "namespace2", "name"),
 			matcher: Match{
-				Namespaces: []util.Wildcard{"nonmatching", "notmatchingeither"},
+				Namespaces: []wildcard.Wildcard{"nonmatching", "notmatchingeither"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -319,7 +319,7 @@ func TestMatch(t *testing.T) {
 			name:   "object's namespace is excluded",
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "namespace", "name"),
 			matcher: Match{
-				ExcludedNamespaces: []util.Wildcard{"namespace"},
+				ExcludedNamespaces: []wildcard.Wildcard{"namespace"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -329,7 +329,7 @@ func TestMatch(t *testing.T) {
 			name:   "object is an excluded Namespace",
 			object: makeNamespace("excluded"),
 			matcher: Match{
-				ExcludedNamespaces: []util.Wildcard{"excluded"},
+				ExcludedNamespaces: []wildcard.Wildcard{"excluded"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -339,7 +339,7 @@ func TestMatch(t *testing.T) {
 			name:   "object is not an excluded Namespace",
 			object: makeNamespace("not-excluded"),
 			matcher: Match{
-				ExcludedNamespaces: []util.Wildcard{"excluded"},
+				ExcludedNamespaces: []wildcard.Wildcard{"excluded"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -350,7 +350,7 @@ func TestMatch(t *testing.T) {
 			name:   "a namespace is excluded, but object is cluster scoped",
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "", "name"),
 			matcher: Match{
-				ExcludedNamespaces: []util.Wildcard{"namespace"},
+				ExcludedNamespaces: []wildcard.Wildcard{"namespace"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -360,7 +360,7 @@ func TestMatch(t *testing.T) {
 			name:   "namespace is excluded by wildcard match",
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "kube-system", "name"),
 			matcher: Match{
-				ExcludedNamespaces: []util.Wildcard{"kube-*"},
+				ExcludedNamespaces: []wildcard.Wildcard{"kube-*"},
 			},
 			namespace: &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kube-system"}},
 			source:    types.SourceTypeOriginal,
@@ -598,7 +598,7 @@ func TestMatch(t *testing.T) {
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "namespace", "name-foo"),
 			matcher: Match{
 				Name:       "name-foo",
-				Namespaces: []util.Wildcard{"other-namespace"},
+				Namespaces: []wildcard.Wildcard{"other-namespace"},
 			},
 			namespace: nil,
 			source:    types.SourceTypeOriginal,
@@ -609,7 +609,7 @@ func TestMatch(t *testing.T) {
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "namespace", "name-foo"),
 			matcher: Match{
 				Name:       "name-foo",
-				Namespaces: []util.Wildcard{"my-ns"},
+				Namespaces: []wildcard.Wildcard{"my-ns"},
 				Source:     string(types.SourceTypeGenerated),
 			},
 			source: types.SourceTypeGenerated,
@@ -625,7 +625,7 @@ func TestMatch(t *testing.T) {
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "namespace", "name-foo"),
 			matcher: Match{
 				Name:       "name-foo",
-				Namespaces: []util.Wildcard{"my-ns"},
+				Namespaces: []wildcard.Wildcard{"my-ns"},
 			},
 			source: types.SourceTypeGenerated,
 			namespace: &corev1.Namespace{
@@ -640,7 +640,7 @@ func TestMatch(t *testing.T) {
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "namespace", "name-foo"),
 			matcher: Match{
 				Name:       "name-foo",
-				Namespaces: []util.Wildcard{"my-ns"},
+				Namespaces: []wildcard.Wildcard{"my-ns"},
 				Source:     string(types.SourceTypeOriginal),
 			},
 			source: types.SourceTypeGenerated,
@@ -656,7 +656,7 @@ func TestMatch(t *testing.T) {
 			object: makeObject(schema.GroupVersionKind{Kind: "kind", Group: "group"}, "namespace", "name-foo"),
 			matcher: Match{
 				Name:       "name-foo",
-				Namespaces: []util.Wildcard{"my-ns"},
+				Namespaces: []wildcard.Wildcard{"my-ns"},
 				Source:     string(types.SourceTypeOriginal),
 			},
 			namespace: &corev1.Namespace{

--- a/pkg/mutation/match/match_types.go
+++ b/pkg/mutation/match/match_types.go
@@ -3,7 +3,7 @@
 package match
 
 import (
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -26,14 +26,14 @@ type Match struct {
 	// prefix or suffix based glob.  For example, `namespaces: [kube-*]` matches both
 	// `kube-system` and `kube-public`, and `namespaces: [*-system]` matches both
 	// `kube-system` and `gatekeeper-system`.
-	Namespaces []util.Wildcard `json:"namespaces,omitempty"`
+	Namespaces []wildcard.Wildcard `json:"namespaces,omitempty"`
 	// ExcludedNamespaces is a list of namespace names. If defined, a
 	// constraint only applies to resources not in a listed namespace.
 	// ExcludedNamespaces also supports a prefix or suffix based glob.  For example,
 	// `excludedNamespaces: [kube-*]` matches both `kube-system` and
 	// `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
 	// `gatekeeper-system`.
-	ExcludedNamespaces []util.Wildcard `json:"excludedNamespaces,omitempty"`
+	ExcludedNamespaces []wildcard.Wildcard `json:"excludedNamespaces,omitempty"`
 	// LabelSelector is the combination of two optional fields: `matchLabels`
 	// and `matchExpressions`.  These two fields provide different methods of
 	// selecting or excluding k8s objects based on the label keys and values
@@ -47,7 +47,7 @@ type Match struct {
 	// Name is the name of an object.  If defined, it will match against objects with the specified
 	// name.  Name also supports a prefix or suffix glob.  For example, `name: pod-*` would match
 	// both `pod-a` and `pod-b`, and `name: *-pod` would match both `a-pod` and `b-pod`.
-	Name util.Wildcard `json:"name,omitempty"`
+	Name wildcard.Wildcard `json:"name,omitempty"`
 }
 
 // Kinds accepts a list of objects with apiGroups and kinds fields

--- a/pkg/mutation/match/zz_generated.deepcopy.go
+++ b/pkg/mutation/match/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package match
 
 import (
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -110,12 +110,12 @@ func (in *Match) DeepCopyInto(out *Match) {
 	}
 	if in.Namespaces != nil {
 		in, out := &in.Namespaces, &out.Namespaces
-		*out = make([]util.Wildcard, len(*in))
+		*out = make([]wildcard.Wildcard, len(*in))
 		copy(*out, *in)
 	}
 	if in.ExcludedNamespaces != nil {
 		in, out := &in.ExcludedNamespaces, &out.ExcludedNamespaces
-		*out = make([]util.Wildcard, len(*in))
+		*out = make([]wildcard.Wildcard, len(*in))
 		copy(*out, *in)
 	}
 	if in.LabelSelector != nil {

--- a/pkg/mutation/mutators/conversion_test.go
+++ b/pkg/mutation/mutators/conversion_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/match"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/path/tester"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -241,7 +241,7 @@ func TestAssignMetadataHasDiff(t *testing.T) {
 		{
 			"differentMatch",
 			func(a *mutationsunversioned.AssignMetadata) {
-				a.Spec.Match.Namespaces = []util.Wildcard{"foo", "bar"}
+				a.Spec.Match.Namespaces = []wildcard.Wildcard{"foo", "bar"}
 			},
 			true,
 		},

--- a/pkg/syncutil/cachemanager/cachemanager_test.go
+++ b/pkg/syncutil/cachemanager/cachemanager_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/syncutil"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	"github.com/open-policy-agent/gatekeeper/v3/test/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +65,7 @@ func TestCacheManager_processExclusion(t *testing.T) {
 	processExcluder := process.Get()
 	processExcluder.Add([]configv1alpha1.MatchEntry{
 		{
-			ExcludedNamespaces: []util.Wildcard{"test-ns-excluded"},
+			ExcludedNamespaces: []wildcard.Wildcard{"test-ns-excluded"},
 			Processes:          []string{"sync"},
 		},
 	})

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/apis/mutations/unversioned"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/match"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -512,7 +512,7 @@ func fooMatch() *match.Match {
 			},
 		},
 		Scope:              "Namespaced",
-		Namespaces:         []util.Wildcard{"my-ns"},
+		Namespaces:         []wildcard.Wildcard{"my-ns"},
 		ExcludedNamespaces: nil,
 		LabelSelector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{

--- a/pkg/webhook/policy_test.go
+++ b/pkg/webhook/policy_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/target"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	testclients "github.com/open-policy-agent/gatekeeper/v3/test/clients"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -347,7 +347,7 @@ func TestReviewDefaultNS(t *testing.T) {
 		Spec: v1alpha1.ConfigSpec{
 			Match: []v1alpha1.MatchEntry{
 				{
-					ExcludedNamespaces: []util.Wildcard{"default"},
+					ExcludedNamespaces: []wildcard.Wildcard{"default"},
 					Processes:          []string{"*"},
 				},
 			},

--- a/pkg/wildcard/wildcard.go
+++ b/pkg/wildcard/wildcard.go
@@ -1,4 +1,4 @@
-package util
+package wildcard
 
 import "strings"
 

--- a/pkg/wildcard/wildcard_test.go
+++ b/pkg/wildcard/wildcard_test.go
@@ -1,4 +1,4 @@
-package util
+package wildcard
 
 import "testing"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We ran into an issue when updating our product to controller-runtime 0.15. We tried gatekeeper v3.13.0-beta.1 and ended up with

```
github.com/open-policy-agent/gatekeeper/v3/pkg/util
# github.com/open-policy-agent/gatekeeper/v3/pkg/util
../../github.com/open-policy-agent/gatekeeper/pkg/util/pack.go:44:9: cannot use func(obj client.Object) []reconcile.Request {…} (value of type func(obj client.Object) []reconcile.Request) as handler.MapFunc value in return statement
../../github.com/open-policy-agent/gatekeeper/pkg/util/pack.go:70:9: cannot use func(obj client.Object) []reconcile.Request {…} (value of type func(obj client.Object) []reconcile.Request) as handler.MapFunc value in return statement
../../github.com/open-policy-agent/gatekeeper/pkg/util/pack.go:75:13: not enough arguments in call to mf
        have (*unstructured.Unstructured)
        want (context.Context, client.Object)
```

This is because the signature for MapFuncs has changed to include a `context.Context` now.

To solve this issue, this PR moves the `util.Wildcard` type into its own package (analogous to `pkg/version`). This removes the dependency from `apis/config/v1alpha1` to `pkg/util`, thereby removing the need to compile-in a full-blown controller-runtime library for anyone who wants to use Gatekeeper's `config/v1alpha1` API.