### PR TITLE
fix: license lint for container-runtime fork

### DIFF
--- a/third_party/k8s.io/kubernetes/hack/verify-licenses.sh
+++ b/third_party/k8s.io/kubernetes/hack/verify-licenses.sh
@@ -74,7 +74,12 @@ do
 	then
 		if [[ "${LICENSE_URL}" == 'Unknown' ]];
 		then
-			if  [[ "${GO_PACKAGE}" != k8s.io/* ]];
+            if [[ "${GO_PACKAGE}" == "sigs.k8s.io/controller-runtime" ]] && [[ "${LICENSE_NAME}" == "Apache-2.0" ]];
+            then
+                # temporary for our latest fork changes
+                LICENSE_URL='https://github.com/kubernetes-sigs/controller-runtime'
+                echo "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses.dump
+            elif  [[ "${GO_PACKAGE}" != k8s.io/* ]];
 			then
 				echo "${GO_PACKAGE}  ${LICENSE_NAME}  ${LICENSE_URL}" >> "${KUBE_TEMP}"/approved_licenses_with_missing_urls.dump
 				packages_url_missing+=("${GO_PACKAGE}")


### PR DESCRIPTION
This is a left over from https://github.com/open-policy-agent/gatekeeper/pull/2819 to fix the license lint script by overwriting the license url.

We should make this change as any go.mod change will trigger the `license-lint` job, which will fail without this fix

Sample failed job today: https://github.com/open-policy-agent/gatekeeper/actions/runs/5294608872/jobs/9584136207