### PR TITLE
docs: fix link coloring issue in dark mode

### DIFF
--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -1,8 +1,3 @@
-a {
-  text-decoration: none;
-  color: #000;
-}
-
 .section {
   padding: 72px 0;
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Links are not readable in dark mode

**Which issue(s) this PR fixes**:
Fixes #2778

**Special notes for your reviewer**:

![image](https://github.com/open-policy-agent/gatekeeper/assets/812618/c6c0a04b-aa4d-4326-baa4-d09ed8b942bb)
![Untitled 2](https://github.com/open-policy-agent/gatekeeper/assets/812618/6a9dd532-dc25-43cc-9b3e-e29c413341d3)

**Home page**
![image](https://github.com/open-policy-agent/gatekeeper/assets/812618/2a05b3e4-b85d-4c88-9d76-dd6dcdcd73bb)

