### PR TITLE
feat, gator: validate enforcement action

### DIFF
--- a/pkg/gator/test/test.go
+++ b/pkg/gator/test/test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/k8scel"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/rego"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/gator"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/gator/expand"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/gator/reader"
 	mutationtypes "github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
@@ -80,8 +81,11 @@ func Test(objs []*unstructured.Unstructured, tOpts Opts) (*GatorResponses, error
 			continue
 		}
 
-		_, err := client.AddConstraint(context.Background(), obj)
-		if err != nil {
+		if err := gator.ValidateConstraint(obj); err != nil {
+			return nil, err
+		}
+
+		if _, err := client.AddConstraint(context.Background(), obj); err != nil {
 			return nil, fmt.Errorf("adding constraint %q: %w", obj.GetName(), err)
 		}
 	}

--- a/pkg/gator/verify/runner.go
+++ b/pkg/gator/verify/runner.go
@@ -161,6 +161,10 @@ func (r *Runner) tryAddConstraint(ctx context.Context, suiteDir string, t Test) 
 		return err
 	}
 
+	if err := gator.ValidateConstraint(cObj); err != nil {
+		return err
+	}
+
 	_, err = client.AddConstraint(ctx, cObj)
 	return err
 }


### PR DESCRIPTION
wip don't review

* validate the enforcement action
  * this cannot be done easily (or at all)  as part of the target K8sValidationTarget bc of the `disableEnforcementActionValidation` flag


gator verify eg:

```
$ gator verify test/gator/verify
--- FAIL: foo-is-bar    (0.004s)
  error validating constraint "foo-is-bar": unrecognized enforcementAction: "ola" is not within the supported list [deny dryrun warn]
FAIL    test/gator/verify/suite.yaml    0.004s
FAIL

Error: FAIL

$ cat constraint.yaml
apiVersion: constraints.gatekeeper.sh/v1beta1
kind: K8sFooIs
metadata:
  name: foo-is-bar
spec:
  match:
    kinds:
      - apiGroups: [""]
        kinds: ["FooIsBar"]
  parameters:
    foo: "bar"
  enforcementAction: ola

```

