### PR TITLE
docs: Add status tag for expansion metric

### DIFF
--- a/website/docs/metrics.md
+++ b/website/docs/metrics.md
@@ -134,6 +134,10 @@ Below are the list of metrics provided by Gatekeeper:
 
   Description: `Number of observed expansion templates`
 
+  Tags:
+
+  - `status`: [`active`, `error`]
+
   Aggregation: `LastValue`
 
 ### Webhook


### PR DESCRIPTION
**What this PR does / why we need it**:

`status` tag for the expansion metric was added https://github.com/open-policy-agent/gatekeeper/commit/7c519b47ad37b577ff1eec433b3691c4b53096b2#diff-f0449d86125583f31ed617705320bfdea120325b261a3eb252431dd691340b04R28 and it will only be available as part of the 3.13.0 release. so no need to add to older docs. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
