### PR TITLE
refactor: use buildinfo to get opa and frameworks version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ENV GO111MODULE=on \
 WORKDIR /go/src/github.com/open-policy-agent/gatekeeper
 COPY . .
 
-RUN go build -mod vendor -a -ldflags "${LDFLAGS:--X github.com/open-policy-agent/gatekeeper/pkg/version.Version=latest}" -o manager
+RUN go build -mod vendor -a -ldflags "${LDFLAGS}" -o manager
 
 FROM $BASEIMAGE
 

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,6 @@ BATS_TESTS_FILE ?= test/bats/test.bats
 HELM_VERSION ?= 3.7.2
 NODE_VERSION ?= 16-bullseye-slim
 YQ_VERSION ?= 4.30.6
-FRAMEWORKS_VERSION ?= $(shell go list -f '{{ .Version }}' -m github.com/open-policy-agent/frameworks/constraint)
-OPA_VERSION ?= $(shell go list -f '{{ .Version }}' -m github.com/open-policy-agent/opa)
 
 HELM_ARGS ?=
 GATEKEEPER_NAMESPACE ?= gatekeeper-system
@@ -45,9 +43,7 @@ FAKE_SUBSCRIBER_IMAGE ?= fake-subscriber:latest
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 BIN_DIR := $(abspath $(ROOT_DIR)/bin)
 
-LDFLAGS := "-X github.com/open-policy-agent/gatekeeper/pkg/version.Version=$(VERSION) \
-	-X main.frameworksVersion=$(FRAMEWORKS_VERSION) \
-	-X main.opaVersion=$(OPA_VERSION)"
+LDFLAGS := "-X github.com/open-policy-agent/gatekeeper/v3/pkg/version.Version=$(VERSION)"
 
 PLATFORM ?= linux/amd64
 OUTPUT_TYPE ?= type=docker
@@ -284,11 +280,11 @@ e2e-publisher-deploy:
 
 # Build manager binary
 manager: generate
-	GO111MODULE=on go build -mod vendor -o bin/manager -ldflags $(LDFLAGS) main.go
+	GO111MODULE=on go build -mod vendor -o bin/manager -ldflags $(LDFLAGS)
 
 # Build manager binary
 manager-osx: generate
-	GO111MODULE=on go build -mod vendor -o bin/manager GOOS=darwin -ldflags $(LDFLAGS) main.go
+	GO111MODULE=on go build -mod vendor -o bin/manager GOOS=darwin -ldflags $(LDFLAGS)
 
 # Run against the configured Kubernetes cluster in ~/.kube/config
 run: generate manifests

--- a/cmd/gator/gator.go
+++ b/cmd/gator/gator.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/open-policy-agent/gatekeeper/v3/cmd/gator/expand"
@@ -10,13 +9,6 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/version"
 	"github.com/spf13/cobra"
 	k8sVersion "sigs.k8s.io/release-utils/version"
-)
-
-const state = "beta"
-
-var (
-	frameworksVersion string
-	opaVersion        string
 )
 
 var commands = []*cobra.Command{
@@ -28,12 +20,12 @@ var commands = []*cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(commands...)
+	rootCmd.Version = version.GetUserAgent("gator")
 }
 
 var rootCmd = &cobra.Command{
-	Use:     "gator subcommand",
-	Short:   "gator is a suite of authorship tools for Gatekeeper",
-	Version: fmt.Sprintf("%s (Feature State: %s), OPA version: %s, Framework version: %s", version.Version, state, opaVersion, frameworksVersion),
+	Use:   "gator subcommand",
+	Short: "gator is a suite of authorship tools for Gatekeeper",
 }
 
 func main() {

--- a/gator.Dockerfile
+++ b/gator.Dockerfile
@@ -21,7 +21,7 @@ ENV GO111MODULE=on \
 COPY . /go/src/github.com/open-policy-agent/gatekeeper
 WORKDIR /go/src/github.com/open-policy-agent/gatekeeper/cmd/gator
 
-RUN go build -mod vendor -a -ldflags "${LDFLAGS:--X github.com/open-policy-agent/gatekeeper/pkg/version.Version=latest -X main.frameworksVersion=latest -X main.opaVersion=latest}" -o /gator
+RUN go build -mod vendor -a -ldflags "${LDFLAGS}" -o /gator
 
 FROM --platform=$BUILDPLATFORM $BASEIMAGE as build
 USER 65532:65532

--- a/main.go
+++ b/main.go
@@ -204,7 +204,8 @@ func innerMain() int {
 	}
 
 	config := ctrl.GetConfigOrDie()
-	config.UserAgent = version.GetUserAgent()
+	config.UserAgent = version.GetUserAgent("gatekeeper")
+	setupLog.Info("setting up manager", "user agent", config.UserAgent)
 
 	var webhooks []rotator.WebhookInfo
 	webhooks = webhook.AppendValidationWebhookIfEnabled(webhooks)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,18 +6,21 @@ import (
 	"runtime/debug"
 )
 
-const gatorState = "beta"
+const (
+	gatorState = "beta"
+	unknown    = "unknown"
+)
 
 // Version is the gatekeeper version.
 var Version string
 
 // GetUserAgent returns Gatekeeper and Gator version information.
 func GetUserAgent(name string) string {
-	vcsrevision := "unknown"
-	vcstimestamp := "unknown"
+	vcsrevision := unknown
+	vcstimestamp := unknown
 	vcsdirty := ""
-	opaVersion := "unknown"
-	frameworksVersion := "unknown"
+	opaVersion := unknown
+	frameworksVersion := unknown
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, v := range info.Settings {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,14 +6,18 @@ import (
 	"runtime/debug"
 )
 
+const gatorState = "beta"
+
 // Version is the gatekeeper version.
 var Version string
 
-// GetUserAgent returns a user agent of the format: gatekeeper/<version> (<goos>/<goarch>) <vcsrevision><-vcsdirty>/<vcstimestamp>.
-func GetUserAgent() string {
+// GetUserAgent returns Gatekeeper and Gator version information.
+func GetUserAgent(name string) string {
 	vcsrevision := "unknown"
 	vcstimestamp := "unknown"
 	vcsdirty := ""
+	opaVersion := "unknown"
+	frameworksVersion := "unknown"
 
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, v := range info.Settings {
@@ -28,7 +32,28 @@ func GetUserAgent() string {
 				vcstimestamp = v.Value
 			}
 		}
+
+		for _, v := range info.Deps {
+			switch v.Path {
+			case "github.com/open-policy-agent/opa":
+				opaVersion = v.Version
+			case "github.com/open-policy-agent/frameworks/constraint":
+				frameworksVersion = v.Version
+			}
+		}
 	}
 
-	return fmt.Sprintf("gatekeeper/%s (%s/%s) %s%s/%s", Version, runtime.GOOS, runtime.GOARCH, vcsrevision, vcsdirty, vcstimestamp)
+	// OPA and Frameworks version used by Gatekeeper and Gator
+	opaFrameworksVersion := fmt.Sprintf("opa/%s, frameworks/%s", opaVersion, frameworksVersion)
+
+	// if LDFLAGS are not set, use revision info
+	if Version == "" {
+		Version = fmt.Sprintf("devel (%s)", vcsrevision)
+	}
+
+	if name == "gator" {
+		return fmt.Sprintf("%s (Feature State: %s), %s", Version, gatorState, opaFrameworksVersion)
+	}
+
+	return fmt.Sprintf("%s/%s (%s/%s) %s%s/%s, %s", name, Version, runtime.GOOS, runtime.GOARCH, vcsrevision, vcsdirty, vcstimestamp, opaFrameworksVersion)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Uses buildinfo to bake in opa and frameworks version so these will be visible in gator installed from homebrew. Unfortunately, we cannot do this for tag since Go doesn't support that (since tags are mutable?), so we have to keep `LDFLAGS` for version.
- Printing OPA version inside manager too since we are getting questions about this
- Fixes version bug that we missed to add /v3

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #2534 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
