### PR TITLE
docs: removing quotes from the title in expansion template doc

### DIFF
--- a/website/docs/expansion.md
+++ b/website/docs/expansion.md
@@ -1,6 +1,6 @@
 ---
 id: expansion
-title: Validating Workload Resources using `ExpansionTemplate`s
+title: Validating Workload Resources using ExpansionTemplate
 ---
 
 `Feature State:` Gatekeeper version v3.10+ (alpha), version 3.13+ (beta)
@@ -14,7 +14,7 @@ A workload resource is a resource that creates other resources, such as a
 [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) or [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/). Gatekeeper can be configured to reject workload resources
 that create a resource that violates a constraint. 
 
-## `ExpansionTemplate`s explained
+## `ExpansionTemplate` explained
 
 An `ExpansionTemplate` is a custom resource that Gatekeeper will use to create temporary, fake resources and validate the constraints against them. We refer to these resources that Gatekeeper creates for validation purposes as `expanded resources`. We refer to the `Deployment` or other workload resource as the `parent resource` and the act of creating those `expanded` resources as `expansion`.
 

--- a/website/versioned_docs/version-v3.13.x/expansion.md
+++ b/website/versioned_docs/version-v3.13.x/expansion.md
@@ -1,6 +1,6 @@
 ---
 id: expansion
-title: Validating Workload Resources using `ExpansionTemplate`s
+title: Validating Workload Resources using ExpansionTemplate
 ---
 
 `Feature State:` Gatekeeper version v3.10+ (alpha), version 3.13+ (beta)
@@ -14,7 +14,7 @@ A workload resource is a resource that creates other resources, such as a
 [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) or [Job](https://kubernetes.io/docs/concepts/workloads/controllers/job/). Gatekeeper can be configured to reject workload resources
 that create a resource that violates a constraint. 
 
-## `ExpansionTemplate`s explained
+## `ExpansionTemplate` explained
 
 An `ExpansionTemplate` is a custom resource that Gatekeeper will use to create temporary, fake resources and validate the constraints against them. We refer to these resources that Gatekeeper creates for validation purposes as `expanded resources`. We refer to the `Deployment` or other workload resource as the `parent resource` and the act of creating those `expanded` resources as `expansion`.
 


### PR DESCRIPTION
**What this PR does / why we need it**: Right now, quotes are visible on the website in the title instead of being rendered and looking appropriate.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
