### PR TITLE
fix: Remove readiness tracker deadlock caused by duplicate syncs

### DIFF
--- a/pkg/readiness/object_tracker.go
+++ b/pkg/readiness/object_tracker.go
@@ -108,6 +108,11 @@ func (t *objectTracker) Expect(o runtime.Object) {
 		return
 	}
 
+	// Satisfied objects cannot be expected again.
+	if _, ok := t.satisfied[k]; ok {
+		return
+	}
+
 	// We may have seen it before starting to expect it
 	if _, ok := t.seen[k]; ok {
 		delete(t.seen, k)

--- a/pkg/readiness/object_tracker_test.go
+++ b/pkg/readiness/object_tracker_test.go
@@ -178,6 +178,28 @@ func Test_ObjectTracker_Duplicate_Expectations(t *testing.T) {
 	}
 }
 
+// Verify that that satisfied expectations cannot be re-established.
+func Test_ObjectTracker_Satisfaction_Final(t *testing.T) {
+	ot := newObjTracker(schema.GroupVersionKind{}, nil)
+
+	const count = 10
+	ct := makeCTSlice("ct-", count)
+	for i := 0; i < len(ct); i++ {
+		ot.Expect(ct[i])
+		ot.Observe(ct[i])
+		ot.Expect(ct[i])
+	}
+	if ot.Satisfied() {
+		t.Fatal("should not be satisfied before ExpectationsDone")
+	}
+
+	ot.ExpectationsDone()
+
+	if !ot.Satisfied() {
+		t.Fatal("should be satisfied")
+	}
+}
+
 // Verify that an expectation can be canceled before it's first expected.
 func Test_ObjectTracker_CancelBeforeExpect(t *testing.T) {
 	ot := newObjTracker(schema.GroupVersionKind{}, nil)

--- a/pkg/readiness/tracker_map.go
+++ b/pkg/readiness/tracker_map.go
@@ -66,6 +66,10 @@ func (t *trackerMap) Get(gvk schema.GroupVersionKind) Expectations {
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	// re-retrieve map entry in case it was added after releasing the read lock.
+	if e, ok := t.m[gvk]; ok {
+		return e
+	}
 	entry := newObjTracker(gvk, t.fn)
 	t.m[gvk] = entry
 	return entry


### PR DESCRIPTION
**What this PR does / why we need it**:

The following sync config would cause readiness tracker to hang:

```yaml
apiVersion: config.gatekeeper.sh/v1alpha1
kind: Config
metadata:
  name: config
  namespace: gatekeeper-system
spec:
  sync:
    syncOnly:
    - group: ""
      kind: Namespace
      version: v1
    - group: networking.k8s.io
      kind: NetworkPolicy
      version: v1
    - group: networking.k8s.io
      kind: NetworkPolicy
      version: v1
```

this PR fixes that.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
