### PR TITLE
refactor: adder interface, rename data client

### DIFF
--- a/main.go
+++ b/main.go
@@ -410,7 +410,6 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, sw *watch.Controlle
 		cfArgs = append(cfArgs, constraintclient.Driver(k8sDriver))
 	}
 
-	// initialize OPA
 	driver, err := rego.New(args...)
 	if err != nil {
 		setupLog.Error(err, "unable to set up Driver")
@@ -478,7 +477,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, sw *watch.Controlle
 	}
 
 	opts := controller.Dependencies{
-		Opa:              client,
+		CFClient:         client,
 		WatchManger:      wm,
 		SyncEventsCh:     events,
 		CacheMgr:         cm,

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -19,15 +19,11 @@ import (
 	"context"
 	"fmt"
 
-	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
 	configv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/config/v1alpha1"
 	cm "github.com/open-policy-agent/gatekeeper/v3/pkg/cachemanager"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/cachemanager/aggregator"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/keys"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -66,10 +62,6 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	return add(mgr, r)
 }
 
-func (a *Adder) InjectOpa(_ *constraintclient.Client) {}
-
-func (a *Adder) InjectWatchManager(_ *watch.Manager) {}
-
 func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {
 	a.ControllerSwitch = cs
 }
@@ -77,12 +69,6 @@ func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {
 func (a *Adder) InjectTracker(t *readiness.Tracker) {
 	a.Tracker = t
 }
-
-func (a *Adder) InjectMutationSystem(mutationSystem *mutation.System) {}
-
-func (a *Adder) InjectExpansionSystem(expansionSystem *expansion.System) {}
-
-func (a *Adder) InjectProviderCache(providerCache *externaldata.ProviderCache) {}
 
 func (a *Adder) InjectCacheManager(cm *cm.CacheManager) {
 	a.CacheManager = cm

--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -27,10 +27,8 @@ import (
 	constraintstatusv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/constraintstatus"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/metrics"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
@@ -74,7 +72,7 @@ type Adder struct {
 	IfWatching func(schema.GroupVersionKind, func() error) (bool, error)
 }
 
-func (a *Adder) InjectOpa(o *constraintclient.Client) {
+func (a *Adder) InjectCFClient(o *constraintclient.Client) {
 	a.Opa = o
 }
 
@@ -89,10 +87,6 @@ func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {
 func (a *Adder) InjectTracker(t *readiness.Tracker) {
 	a.Tracker = t
 }
-
-func (a *Adder) InjectMutationSystem(mutationSystem *mutation.System) {}
-
-func (a *Adder) InjectExpansionSystem(expansionSystem *expansion.System) {}
 
 // Add creates a new Constraint Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/constraintstatus/constraintstatus_controller.go
+++ b/pkg/controller/constraintstatus/constraintstatus_controller.go
@@ -44,7 +44,7 @@ import (
 var log = logf.Log.WithName("controller").WithValues(logging.Process, "constraint_status_controller")
 
 type Adder struct {
-	Opa              *constraintclient.Client
+	CFClient         *constraintclient.Client
 	WatchManager     *watch.Manager
 	ControllerSwitch *watch.ControllerSwitch
 	Events           <-chan event.GenericEvent

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -24,15 +24,12 @@ import (
 	"github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
 	statusv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/constraint"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/constraintstatus"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/constrainttemplatestatus"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/metrics"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
@@ -91,7 +88,7 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	return add(mgr, r)
 }
 
-func (a *Adder) InjectOpa(o *constraintclient.Client) {
+func (a *Adder) InjectCFClient(o *constraintclient.Client) {
 	a.Opa = o
 }
 
@@ -110,12 +107,6 @@ func (a *Adder) InjectTracker(t *readiness.Tracker) {
 func (a *Adder) InjectGetPod(getPod func(context.Context) (*corev1.Pod, error)) {
 	a.GetPod = getPod
 }
-
-func (a *Adder) InjectMutationSystem(_ *mutation.System) {}
-
-func (a *Adder) InjectExpansionSystem(_ *expansion.System) {}
-
-func (a *Adder) InjectProviderCache(_ *externaldata.ProviderCache) {}
 
 // newReconciler returns a new reconcile.Reconciler
 // cstrEvents is the channel from which constraint controller will receive the events

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller.go
@@ -44,7 +44,7 @@ import (
 var log = logf.Log.WithName("controller").WithValues(logging.Process, "constraint_template_status_controller")
 
 type Adder struct {
-	Opa              *constraintclient.Client
+	CfClient         *constraintclient.Client
 	WatchManager     *watch.Manager
 	ControllerSwitch *watch.ControllerSwitch
 }

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
@@ -106,15 +106,14 @@ violation[{"msg": "denied!"}] {
 		t.Fatalf("want createGatekeeperNamespace(mgr.GetConfig()) error = nil, got %v", err)
 	}
 
-	// initialize OPA
 	driver, err := rego.New(rego.Tracing(true))
 	if err != nil {
 		t.Fatalf("unable to set up Driver: %v", err)
 	}
 
-	opaClient, err := constraintclient.NewClient(constraintclient.Targets(&target.K8sValidationTarget{}), constraintclient.Driver(driver))
+	cfClient, err := constraintclient.NewClient(constraintclient.Targets(&target.K8sValidationTarget{}), constraintclient.Driver(driver))
 	if err != nil {
-		t.Fatalf("unable to set up OPA client: %s", err)
+		t.Fatalf("unable to set up constraint framework client: %s", err)
 	}
 
 	testutils.Setenv(t, "POD_NAME", "no-pod")
@@ -130,7 +129,7 @@ violation[{"msg": "denied!"}] {
 	)
 
 	adder := constrainttemplate.Adder{
-		Opa:              opaClient,
+		CFClient:         cfClient,
 		WatchManager:     wm,
 		ControllerSwitch: cs,
 		Tracker:          tracker,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -47,13 +47,9 @@ import (
 var debugUseFakePod = flag.Bool("debug-use-fake-pod", false, "Use a fake pod name so the Gatekeeper executable can be run outside of Kubernetes")
 
 type Injector interface {
-	InjectOpa(*constraintclient.Client)
-	InjectWatchManager(*watch.Manager)
 	InjectControllerSwitch(*watch.ControllerSwitch)
 	InjectTracker(tracker *readiness.Tracker)
-	InjectMutationSystem(mutationSystem *mutation.System)
-	InjectExpansionSystem(expansionSystem *expansion.System)
-	InjectProviderCache(providerCache *externaldata.ProviderCache)
+
 	Add(mgr manager.Manager) error
 }
 
@@ -63,6 +59,26 @@ type GetPodInjector interface {
 
 type PubsubInjector interface {
 	InjectPubsubSystem(pubsubSystem *pubsub.System)
+}
+
+type DataClientInjector interface {
+	InjectCFClient(*constraintclient.Client)
+}
+
+type WatchManagerInjector interface {
+	InjectWatchManager(*watch.Manager)
+}
+
+type MutationSystemInjector interface {
+	InjectMutationSystem(mutationSystem *mutation.System)
+}
+
+type ExpansionSystemInjector interface {
+	InjectExpansionSystem(expansionSystem *expansion.System)
+}
+
+type ProviderCacheInjector interface {
+	InjectProviderCache(providerCache *externaldata.ProviderCache)
 }
 
 type CacheManagerInjector interface {
@@ -178,13 +194,24 @@ func AddToManager(m manager.Manager, deps *Dependencies) error {
 	}
 
 	for _, a := range Injectors {
-		a.InjectOpa(deps.Opa)
-		a.InjectWatchManager(deps.WatchManger)
 		a.InjectControllerSwitch(deps.ControllerSwitch)
 		a.InjectTracker(deps.Tracker)
-		a.InjectMutationSystem(deps.MutationSystem)
-		a.InjectExpansionSystem(deps.ExpansionSystem)
-		a.InjectProviderCache(deps.ProviderCache)
+
+		if a2, ok := a.(DataClientInjector); ok {
+			a2.InjectCFClient(deps.Opa)
+		}
+		if a2, ok := a.(WatchManagerInjector); ok {
+			a2.InjectWatchManager(deps.WatchManger)
+		}
+		if a2, ok := a.(MutationSystemInjector); ok {
+			a2.InjectMutationSystem(deps.MutationSystem)
+		}
+		if a2, ok := a.(ExpansionSystemInjector); ok {
+			a2.InjectExpansionSystem(deps.ExpansionSystem)
+		}
+		if a2, ok := a.(ProviderCacheInjector); ok {
+			a2.InjectProviderCache(deps.ProviderCache)
+		}
 		if a2, ok := a.(GetPodInjector); ok {
 			a2.InjectGetPod(deps.GetPod)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -94,7 +94,7 @@ var AddToManagerFuncs []func(manager.Manager) error
 
 // Dependencies are dependencies that can be injected into controllers.
 type Dependencies struct {
-	Opa              *constraintclient.Client
+	CFClient         *constraintclient.Client
 	WatchManger      *watch.Manager
 	ControllerSwitch *watch.ControllerSwitch
 	Tracker          *readiness.Tracker
@@ -198,7 +198,7 @@ func AddToManager(m manager.Manager, deps *Dependencies) error {
 		a.InjectTracker(deps.Tracker)
 
 		if a2, ok := a.(DataClientInjector); ok {
-			a2.InjectCFClient(deps.Opa)
+			a2.InjectCFClient(deps.CFClient)
 		}
 		if a2, ok := a.(WatchManagerInjector); ok {
 			a2.InjectWatchManager(deps.WatchManger)

--- a/pkg/controller/expansion/expansion_controller.go
+++ b/pkg/controller/expansion/expansion_controller.go
@@ -4,15 +4,12 @@ import (
 	"context"
 	"fmt"
 
-	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
 	"github.com/open-policy-agent/gatekeeper/v3/apis/expansion/unversioned"
 	expansionv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/expansion/v1beta1"
 	statusv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/metrics"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
@@ -52,17 +49,11 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	return add(mgr, r)
 }
 
-func (a *Adder) InjectOpa(_ *constraintclient.Client) {}
-
-func (a *Adder) InjectWatchManager(_ *watch.Manager) {}
-
 func (a *Adder) InjectControllerSwitch(_ *watch.ControllerSwitch) {}
 
 func (a *Adder) InjectTracker(tracker *readiness.Tracker) {
 	a.Tracker = tracker
 }
-
-func (a *Adder) InjectMutationSystem(_ *mutation.System) {}
 
 func (a *Adder) InjectExpansionSystem(expansionSystem *expansion.System) {
 	a.ExpansionSystem = expansionSystem
@@ -71,8 +62,6 @@ func (a *Adder) InjectExpansionSystem(expansionSystem *expansion.System) {
 func (a *Adder) InjectGetPod(getPod func(ctx context.Context) (*corev1.Pod, error)) {
 	a.GetPod = getPod
 }
-
-func (a *Adder) InjectProviderCache(_ *externaldata.ProviderCache) {}
 
 type Reconciler struct {
 	client.Client

--- a/pkg/controller/expansionstatus/expansionstatus_controller.go
+++ b/pkg/controller/expansionstatus/expansionstatus_controller.go
@@ -22,12 +22,10 @@ import (
 
 	"github.com/go-logr/logr"
 	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
 	expansionv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/expansion/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
@@ -50,19 +48,9 @@ type Adder struct {
 	WatchManager *watch.Manager
 }
 
-func (a *Adder) InjectOpa(o *constraintclient.Client) {}
-
-func (a *Adder) InjectWatchManager(w *watch.Manager) {}
-
 func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
 
 func (a *Adder) InjectTracker(t *readiness.Tracker) {}
-
-func (a *Adder) InjectMutationSystem(mutationSystem *mutation.System) {}
-
-func (a *Adder) InjectExpansionSystem(expansionSystem *expansion.System) {}
-
-func (a *Adder) InjectProviderCache(providerCache *externaldata.ProviderCache) {}
 
 // Add creates a new Constraint Status Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/expansionstatus/expansionstatus_controller.go
+++ b/pkg/controller/expansionstatus/expansionstatus_controller.go
@@ -44,7 +44,7 @@ import (
 var log = logf.Log.WithName("controller").WithValues(logging.Process, "expansion_template_status_controller")
 
 type Adder struct {
-	Opa          *constraintclient.Client
+	CFClient     *constraintclient.Client
 	WatchManager *watch.Manager
 }
 

--- a/pkg/controller/externaldata/externaldata_controller.go
+++ b/pkg/controller/externaldata/externaldata_controller.go
@@ -7,10 +7,8 @@ import (
 	externaldatav1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/v1beta1"
 	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	frameworksexternaldata "github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/externaldata"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -43,17 +41,11 @@ type Adder struct {
 	Tracker       *readiness.Tracker
 }
 
-func (a *Adder) InjectOpa(o *constraintclient.Client) {
+func (a *Adder) InjectCFClient(o *constraintclient.Client) {
 	a.Opa = o
 }
 
-func (a *Adder) InjectWatchManager(w *watch.Manager) {}
-
 func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
-
-func (a *Adder) InjectMutationSystem(mutationSystem *mutation.System) {}
-
-func (a *Adder) InjectExpansionSystem(expansionSystem *expansion.System) {}
 
 func (a *Adder) InjectTracker(t *readiness.Tracker) {
 	a.Tracker = t

--- a/pkg/controller/externaldata/externaldata_controller.go
+++ b/pkg/controller/externaldata/externaldata_controller.go
@@ -36,13 +36,13 @@ var (
 )
 
 type Adder struct {
-	Opa           *constraintclient.Client
+	CFClient      *constraintclient.Client
 	ProviderCache *frameworksexternaldata.ProviderCache
 	Tracker       *readiness.Tracker
 }
 
-func (a *Adder) InjectCFClient(o *constraintclient.Client) {
-	a.Opa = o
+func (a *Adder) InjectCFClient(c *constraintclient.Client) {
+	a.CFClient = c
 }
 
 func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
@@ -58,23 +58,23 @@ func (a *Adder) InjectProviderCache(providerCache *frameworksexternaldata.Provid
 // Add creates a new ExternalData Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (a *Adder) Add(mgr manager.Manager) error {
-	r := newReconciler(mgr, a.Opa, a.ProviderCache, a.Tracker)
+	r := newReconciler(mgr, a.CFClient, a.ProviderCache, a.Tracker)
 	return add(mgr, r)
 }
 
 // Reconciler reconciles a ExternalData object.
 type Reconciler struct {
 	client.Client
-	opa           *constraintclient.Client
+	cfClient      *constraintclient.Client
 	providerCache *frameworksexternaldata.ProviderCache
 	tracker       *readiness.Tracker
 	scheme        *runtime.Scheme
 }
 
 // newReconciler returns a new reconcile.Reconciler.
-func newReconciler(mgr manager.Manager, opa *constraintclient.Client, providerCache *frameworksexternaldata.ProviderCache, tracker *readiness.Tracker) *Reconciler {
+func newReconciler(mgr manager.Manager, client *constraintclient.Client, providerCache *frameworksexternaldata.ProviderCache, tracker *readiness.Tracker) *Reconciler {
 	r := &Reconciler{
-		opa:           opa,
+		cfClient:      client,
 		providerCache: providerCache,
 		Client:        mgr.GetClient(),
 		scheme:        mgr.GetScheme(),

--- a/pkg/controller/externaldata/externaldata_controller_test.go
+++ b/pkg/controller/externaldata/externaldata_controller_test.go
@@ -79,16 +79,15 @@ func TestReconcile(t *testing.T) {
 	*externaldata.ExternalDataEnabled = true
 	pc := frameworksexternaldata.NewCache()
 
-	// initialize OPA
 	args := []rego.Arg{rego.Tracing(false), rego.AddExternalDataProviderCache(pc)}
 	driver, err := rego.New(args...)
 	if err != nil {
 		t.Fatalf("unable to set up Driver: %v", err)
 	}
 
-	opa, err := constraintclient.NewClient(constraintclient.Targets(&target.K8sValidationTarget{}), constraintclient.Driver(driver))
+	cfClient, err := constraintclient.NewClient(constraintclient.Targets(&target.K8sValidationTarget{}), constraintclient.Driver(driver))
 	if err != nil {
-		t.Fatalf("unable to set up OPA client: %s", err)
+		t.Fatalf("unable to set up constraint framework client: %s", err)
 	}
 
 	cs := watch.NewSwitch()
@@ -97,7 +96,7 @@ func TestReconcile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rec := newReconciler(mgr, opa, pc, tracker)
+	rec := newReconciler(mgr, cfClient, pc, tracker)
 
 	recFn, requests := SetupTestReconcile(rec)
 	err = add(mgr, recFn)

--- a/pkg/controller/mutators/instances/mutator_controllers.go
+++ b/pkg/controller/mutators/instances/mutator_controllers.go
@@ -3,13 +3,10 @@ package instances
 import (
 	"context"
 
-	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
 	mutationsunversioned "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/unversioned"
 	mutationsv1 "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1"
 	"github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1alpha1"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/mutators/core"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/mutators"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
@@ -132,10 +129,6 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	return assignMetadata.Add(mgr)
 }
 
-func (a *Adder) InjectOpa(o *constraintclient.Client) {}
-
-func (a *Adder) InjectWatchManager(w *watch.Manager) {}
-
 func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
 
 func (a *Adder) InjectTracker(t *readiness.Tracker) {
@@ -149,7 +142,3 @@ func (a *Adder) InjectGetPod(getPod func(ctx context.Context) (*corev1.Pod, erro
 func (a *Adder) InjectMutationSystem(mutationSystem *mutation.System) {
 	a.MutationSystem = mutationSystem
 }
-
-func (a *Adder) InjectExpansionSystem(expansionSystem *expansion.System) {}
-
-func (a *Adder) InjectProviderCache(providerCache *externaldata.ProviderCache) {}

--- a/pkg/controller/mutatorstatus/mutatorstatus_controller.go
+++ b/pkg/controller/mutatorstatus/mutatorstatus_controller.go
@@ -22,14 +22,10 @@ import (
 	"sort"
 
 	"github.com/go-logr/logr"
-	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
 	mutationsv1 "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1"
 	mutationsv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1alpha1"
 	"github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
@@ -54,19 +50,9 @@ type Adder struct {
 	ControllerSwitch *watch.ControllerSwitch
 }
 
-func (a *Adder) InjectOpa(o *constraintclient.Client) {}
-
-func (a *Adder) InjectWatchManager(w *watch.Manager) {}
-
 func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
 
 func (a *Adder) InjectTracker(t *readiness.Tracker) {}
-
-func (a *Adder) InjectMutationSystem(mutationSystem *mutation.System) {}
-
-func (a *Adder) InjectExpansionSystem(expansionSystem *expansion.System) {}
-
-func (a *Adder) InjectProviderCache(providerCache *externaldata.ProviderCache) {}
 
 // Add creates a new Mutator Status Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/pubsub/pubsub_config_controller.go
+++ b/pkg/controller/pubsub/pubsub_config_controller.go
@@ -6,11 +6,7 @@ import (
 	"flag"
 	"fmt"
 
-	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/pubsub"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
@@ -46,19 +42,9 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	return add(mgr, r)
 }
 
-func (a *Adder) InjectOpa(_ *constraintclient.Client) {}
-
-func (a *Adder) InjectWatchManager(_ *watch.Manager) {}
-
 func (a *Adder) InjectControllerSwitch(_ *watch.ControllerSwitch) {}
 
 func (a *Adder) InjectTracker(_ *readiness.Tracker) {}
-
-func (a *Adder) InjectMutationSystem(_ *mutation.System) {}
-
-func (a *Adder) InjectExpansionSystem(_ *expansion.System) {}
-
-func (a *Adder) InjectProviderCache(_ *externaldata.ProviderCache) {}
 
 func (a *Adder) InjectPubsubSystem(pubsubSystem *pubsub.System) {
 	a.PubsubSystem = pubsubSystem


### PR DESCRIPTION
Following up on punted work items from: https://github.com/open-policy-agent/gatekeeper/pull/2852

* simplifies the `Injector` interface for controllers; many controllers don't implement the interface funcs
* renames references to (data) client 