### PR TITLE
feat:fix: support readiness-retries for config

### DIFF
--- a/pkg/fakes/reader.go
+++ b/pkg/fakes/reader.go
@@ -9,7 +9,15 @@ import (
 
 type SpyReader struct {
 	client.Reader
+	GetFunc  func(ctx context.Context, key client.ObjectKey, get client.Object, opts ...client.GetOption) error
 	ListFunc func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error
+}
+
+func (r SpyReader) Get(ctx context.Context, key client.ObjectKey, get client.Object, opts ...client.GetOption) error {
+	if r.GetFunc != nil {
+		return r.GetFunc(ctx, key, get, opts...)
+	}
+	return r.Reader.Get(ctx, key, get, opts...)
 }
 
 func (r SpyReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {

--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -124,7 +124,7 @@ func AssignedStringList() []string {
 }
 
 // HasValidationOperations returns `true` if there
-// are any operations that would require a constraint/template controller.
+// are any operations that would require a constraint/template/config controller.
 func HasValidationOperations() bool {
 	return IsAssigned(Audit) || IsAssigned(Status) || IsAssigned(Webhook)
 }

--- a/pkg/readiness/objset.go
+++ b/pkg/readiness/objset.go
@@ -61,5 +61,5 @@ func (o *objData) decrementRetries() bool {
 type objDataFactory func() objData
 
 func objDataFromFlags() objData {
-	return objData{retries: *readinessRetries}
+	return objData{retries: *ReadinessRetries}
 }


### PR DESCRIPTION
It seems like we didn't implement the `readiness-retries` feat for the config tracker. This change adds that in. Also, it moves the Observe() call in the controller for a config singleton. Finally, there's a small refactor to use `logging.DebugLevel`.