### PR TITLE
feat(gator): print object name on test output

### DIFF
--- a/cmd/gator/test/gatortest_test.go
+++ b/cmd/gator/test/gatortest_test.go
@@ -41,7 +41,7 @@ func Test_formatOutput(t *testing.T) {
 				ViolatingObject: barObject,
 				Trace:           nil,
 			}},
-			expectedOutput: `[""] Message: ""
+			expectedOutput: `/ : [""] Message: ""
 `,
 		},
 		{

--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -174,7 +174,24 @@ func formatOutput(flagOutput string, results []*test.GatorResult, stats []*instr
 		var buf bytes.Buffer
 		if len(results) > 0 {
 			for _, result := range results {
-				buf.WriteString(fmt.Sprintf("[%q] Message: %q\n", result.Constraint.GetName(), result.Msg))
+				obj := fmt.Sprintf("%s/%s %s",
+					result.ViolatingObject.GetAPIVersion(),
+					result.ViolatingObject.GetKind(),
+					result.ViolatingObject.GetName(),
+				)
+				if result.ViolatingObject.GetNamespace() != "" {
+					obj = fmt.Sprintf("%s/%s %s/%s",
+						result.ViolatingObject.GetAPIVersion(),
+						result.ViolatingObject.GetKind(),
+						result.ViolatingObject.GetNamespace(),
+						result.ViolatingObject.GetName(),
+					)
+				}
+				buf.WriteString(fmt.Sprintf("%s: [%q] Message: %q\n",
+					obj,
+					result.Constraint.GetName(),
+					result.Msg,
+				))
 
 				if result.Trace != nil {
 					buf.WriteString(fmt.Sprintf("Trace: %v", *result.Trace))


### PR DESCRIPTION
**What this PR does / why we need it**:

When running `gator test -f="directory/"`, it doesn't tell which file is violating the constraint. This may be fine for a small set of manifests but becomes annoying when validating large sets.

**Special notes for your reviewer**:

This is my first contribution here. The attempt I'm making aims to have a small footprint but that may be the completely wrong approach for this.