### PR TITLE
fix: adding flag to validate rego for templates

### DIFF
--- a/demo/k8s-validating-admission-policy/README.md
+++ b/demo/k8s-validating-admission-policy/README.md
@@ -1,7 +1,7 @@
 This is a demo of a prototype-stage feature and is subject to change.
 
 The demo will not work unless the `--experimental-enable-k8s-native-validation`` is
-set. Please set `--validate-template-rego` to `false` if using gatekeeper version 3.13.1/3.14.0 or onwards.
+set. Please set `--validate-template-rego` to `false` if using gatekeeper version 3.13.1+ but before 3.16.0.
 
 Note that the contents of the constraint template have changed since cutting
 Gatekeeper's v3.13.0 release. To try this with the development build of

--- a/demo/k8s-validating-admission-policy/README.md
+++ b/demo/k8s-validating-admission-policy/README.md
@@ -1,7 +1,7 @@
 This is a demo of a prototype-stage feature and is subject to change.
 
 The demo will not work unless the `--experimental-enable-k8s-native-validation`` is
-set. Please set `--validate-template-rego` to `false` if using gatekeeper version 3.13.1+ but before 3.16.0.
+set. Please set `--validate-template-rego` to `false` if using Gatekeeper version 3.13.1+ but before 3.16.0.
 
 Note that the contents of the constraint template have changed since cutting
 Gatekeeper's v3.13.0 release. To try this with the development build of

--- a/demo/k8s-validating-admission-policy/README.md
+++ b/demo/k8s-validating-admission-policy/README.md
@@ -1,7 +1,7 @@
 This is a demo of a prototype-stage feature and is subject to change.
 
-The demo will not work unless the --experimental-enable-k8s-native-validation is
-set.
+The demo will not work unless the `--experimental-enable-k8s-native-validation`` is
+set. Please set `--validate-template-rego` to `false` if using gatekeeper version 3.13.1/3.14.0 or onwards.
 
 Note that the contents of the constraint template have changed since cutting
 Gatekeeper's v3.13.0 release. To try this with the development build of

--- a/main.go
+++ b/main.go
@@ -400,6 +400,12 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, sw *watch.Controlle
 
 	cfArgs := []constraintclient.Opt{constraintclient.Targets(&target.K8sValidationTarget{})}
 
+	if *webhook.ValidateTemplateRego && *enableK8sCel {
+		err := fmt.Errorf("cannot validate template rego when K8s cel is enabled. Please disable K8s cel by setting --experimental-enable-k8s-native-validation=false or disable template rego validation by setting --validate-template-rego=false")
+		setupLog.Error(err, "unable to set up OPA and K8s native drivers")
+		return err
+	}
+
 	if *enableK8sCel {
 		// initialize K8sValidation
 		k8sDriver, err := k8scel.New()

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -70,7 +70,7 @@ import (
 const httpStatusWarning = 299
 
 var (
-	validateTemplateRego = flag.Bool("validate-template-rego", true, "validate rego code for constraints template. Defaults to true. To be removed before 3.16. Not to be used with `experimental-enable-k8s-native-validation` is set to true.")
+	ValidateTemplateRego = flag.Bool("validate-template-rego", true, "validate rego code for constraints template. Defaults to true. To be removed in 3.16. Use gator to validate in shift left manner to avoid impact with this behavior change. Not to be used when `experimental-enable-k8s-native-validation` is set to true.")
 	maxServingThreads    = flag.Int("max-serving-threads", -1, "cap the number of threads handling non-trivial requests, -1 caps the number of threads to GOMAXPROCS. Defaults to -1.")
 )
 
@@ -387,7 +387,7 @@ func (h *validationHandler) validateTemplate(ctx context.Context, req *admission
 	}
 
 	// TODO: This is a temporary check for rego to give enough time to users to migrate to gator for validation. To be removed before 3.16.
-	if *validateTemplateRego {
+	if *ValidateTemplateRego {
 		// Create a temporary Driver and attempt to add the Template to it. This
 		// ensures the Rego code both parses and compiles.
 		d, err := rego.New()

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -70,7 +70,7 @@ import (
 const httpStatusWarning = 299
 
 var (
-	ValidateTemplateRego = flag.Bool("validate-template-rego", true, "validate rego code for constraints template. Defaults to true. To be removed in 3.16. Use gator to validate in shift left manner to avoid impact with this behavior change. Not to be used when `experimental-enable-k8s-native-validation` is set to true.")
+	ValidateTemplateRego = flag.Bool("validate-template-rego", true, "validate Rego code for constraint templates. Defaults to true. This flag will be removed in Gatekeeper v3.16 and cannot be used if `experimental-enable-k8s-native-validation` flag is set. Use Gator to validate in shift left manner to avoid impact with this behavior change.). Use Gator to validate in shift left manner to avoid impact with this behavior change.")
 	maxServingThreads    = flag.Int("max-serving-threads", -1, "cap the number of threads handling non-trivial requests, -1 caps the number of threads to GOMAXPROCS. Defaults to -1.")
 )
 

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -30,6 +30,7 @@ import (
 	externaldataUnversioned "github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/unversioned"
 	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/rego"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
 	rtypes "github.com/open-policy-agent/frameworks/constraint/pkg/types"
@@ -68,7 +69,10 @@ import (
 // https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#response
 const httpStatusWarning = 299
 
-var maxServingThreads = flag.Int("max-serving-threads", -1, "cap the number of threads handling non-trivial requests, -1 caps the number of threads to GOMAXPROCS. Defaults to -1.")
+var (
+	validateTemplateRego = flag.Bool("validate-template-rego", true, "validate rego code for constraints template. Defaults to true. To be removed before 3.16. Not to be used with `experimental-enable-k8s-native-validation` is set to true.")
+	maxServingThreads    = flag.Int("max-serving-threads", -1, "cap the number of threads handling non-trivial requests, -1 caps the number of threads to GOMAXPROCS. Defaults to -1.")
+)
 
 func init() {
 	AddToManagerFuncs = append(AddToManagerFuncs, AddPolicyWebhook)
@@ -380,6 +384,21 @@ func (h *validationHandler) validateTemplate(ctx context.Context, req *admission
 	_, err = h.opa.CreateCRD(ctx, unversioned)
 	if err != nil {
 		return true, err
+	}
+
+	// TODO: This is a temporary check for rego to give enough time to users to migrate to gator for validation. To be removed before 3.16.
+	if *validateTemplateRego {
+		// Create a temporary Driver and attempt to add the Template to it. This
+		// ensures the Rego code both parses and compiles.
+		d, err := rego.New()
+		if err != nil {
+			return false, fmt.Errorf("unable to create Driver: %w", err)
+		}
+
+		err = d.AddTemplate(ctx, unversioned)
+		if err != nil {
+			return true, err
+		}
 	}
 
 	return false, nil

--- a/website/docs/constrainttemplates.md
+++ b/website/docs/constrainttemplates.md
@@ -8,6 +8,8 @@ ConstraintTemplates define a way to validate some set of Kubernetes objects in G
 1. [Rego](https://www.openpolicyagent.org/docs/latest/#rego) code that defines a policy violation
 2. The schema of the accompanying `Constraint` object, which represents an instantiation of a `ConstraintTemplate`
 
+> ❗ Validation of rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation and to use kubernetes cel based policies as well. This flag will be removed from gatekeeper 3.16 and onwards, please make use of gator to validate constraint template in shift left manner to avoid any impact with this behavior change.
+
 ## `v1` Constraint Template
 
 In release version 3.6.0, Gatekeeper included the `v1` version of `ConstraintTemplate`.  Unlike past versions of `ConstraintTemplate`, `v1` requires the Constraint schema section to be [structural](https://kubernetes.io/blog/2019/06/20/crd-structural-schema/).

--- a/website/docs/constrainttemplates.md
+++ b/website/docs/constrainttemplates.md
@@ -8,7 +8,7 @@ ConstraintTemplates define a way to validate some set of Kubernetes objects in G
 1. [Rego](https://www.openpolicyagent.org/docs/latest/#rego) code that defines a policy violation
 2. The schema of the accompanying `Constraint` object, which represents an instantiation of a `ConstraintTemplate`
 
-> ❗ Validation of rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation and to use kubernetes cel based policies as well. This flag will be removed from gatekeeper 3.16 and onwards, please make use of gator to validate constraint template in shift left manner to avoid any impact with this behavior change.
+> ❗ Validation of rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation if you want to use `experimental-enable-k8s-native-validation` kubernetes cel based policies as well. This flag will be removed from gatekeeper 3.16 and onwards, please make use of gator to validate constraint template in shift left manner to avoid any impact with this behavior change.
 
 ## `v1` Constraint Template
 

--- a/website/docs/constrainttemplates.md
+++ b/website/docs/constrainttemplates.md
@@ -8,7 +8,7 @@ ConstraintTemplates define a way to validate some set of Kubernetes objects in G
 1. [Rego](https://www.openpolicyagent.org/docs/latest/#rego) code that defines a policy violation
 2. The schema of the accompanying `Constraint` object, which represents an instantiation of a `ConstraintTemplate`
 
-> ❗ Validation of rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation if you want to use `experimental-enable-k8s-native-validation` kubernetes cel based policies as well. This flag will be removed from gatekeeper 3.16 and onwards, please make use of gator to validate constraint template in shift left manner to avoid any impact with this behavior change.
+> ❗ Validation of Rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation if you want to use `experimental-enable-k8s-native-validation` Kubernetes CEL based policies as well. This flag will be removed from Gatekeeper 3.16 and later, please make use of [Gator](https://open-policy-agent.github.io/gatekeeper/website/docs/gator) to validate constraint template in shift left manner to avoid any impact with this behavior change.
 
 ## `v1` Constraint Template
 

--- a/website/docs/validating-admission-policy.md
+++ b/website/docs/validating-admission-policy.md
@@ -6,7 +6,7 @@ title: Integration with Kubernetes Validating Admission Policy
 `Feature State`: Gatekeeper version v3.13+ (pre-alpha)
 
 > ❗ This feature is pre-alpha, subject to change (feedback is welcome!). It is disabled by default. To enable the feature,
-> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image).
+> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image). Do not use this feature with `validate-template-rego` flag enabled, as the policies with cel would get rejected with rego compilation error.
 
 ## Description
 

--- a/website/docs/validating-admission-policy.md
+++ b/website/docs/validating-admission-policy.md
@@ -6,7 +6,7 @@ title: Integration with Kubernetes Validating Admission Policy
 `Feature State`: Gatekeeper version v3.13+ (pre-alpha)
 
 > ❗ This feature is pre-alpha, subject to change (feedback is welcome!). It is disabled by default. To enable the feature,
-> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image). Do not use this feature with `validate-template-rego` flag enabled, as the policies with cel would get rejected with rego compilation error.
+> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image). Do not use this feature with `validate-template-rego` flag enabled, as the policies with CEL would get rejected with Rego compilation error.
 
 ## Description
 

--- a/website/versioned_docs/version-v3.13.x/constrainttemplates.md
+++ b/website/versioned_docs/version-v3.13.x/constrainttemplates.md
@@ -8,6 +8,8 @@ ConstraintTemplates define a way to validate some set of Kubernetes objects in G
 1. [Rego](https://www.openpolicyagent.org/docs/latest/#rego) code that defines a policy violation
 2. The schema of the accompanying `Constraint` object, which represents an instantiation of a `ConstraintTemplate`
 
+> ❗ Validation of rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation and to use kubernetes cel based policies as well. This flag will be removed from gatekeeper 3.16 and onwards, please make use of gator to validate constraint template in shift left manner to avoid any impact with this behavior change.
+
 ## `v1` Constraint Template
 
 In release version 3.6.0, Gatekeeper included the `v1` version of `ConstraintTemplate`.  Unlike past versions of `ConstraintTemplate`, `v1` requires the Constraint schema section to be [structural](https://kubernetes.io/blog/2019/06/20/crd-structural-schema/).

--- a/website/versioned_docs/version-v3.13.x/constrainttemplates.md
+++ b/website/versioned_docs/version-v3.13.x/constrainttemplates.md
@@ -8,7 +8,7 @@ ConstraintTemplates define a way to validate some set of Kubernetes objects in G
 1. [Rego](https://www.openpolicyagent.org/docs/latest/#rego) code that defines a policy violation
 2. The schema of the accompanying `Constraint` object, which represents an instantiation of a `ConstraintTemplate`
 
-> ❗ Validation of rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation and to use kubernetes cel based policies as well. This flag will be removed from gatekeeper 3.16 and onwards, please make use of gator to validate constraint template in shift left manner to avoid any impact with this behavior change.
+> ❗ Validation of rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation if you want to use `experimental-enable-k8s-native-validation` kubernetes cel based policies as well. This flag will be removed from gatekeeper 3.16 and onwards, please make use of gator to validate constraint template in shift left manner to avoid any impact with this behavior change.
 
 ## `v1` Constraint Template
 

--- a/website/versioned_docs/version-v3.13.x/constrainttemplates.md
+++ b/website/versioned_docs/version-v3.13.x/constrainttemplates.md
@@ -8,7 +8,7 @@ ConstraintTemplates define a way to validate some set of Kubernetes objects in G
 1. [Rego](https://www.openpolicyagent.org/docs/latest/#rego) code that defines a policy violation
 2. The schema of the accompanying `Constraint` object, which represents an instantiation of a `ConstraintTemplate`
 
-> ❗ Validation of rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation if you want to use `experimental-enable-k8s-native-validation` kubernetes cel based policies as well. This flag will be removed from gatekeeper 3.16 and onwards, please make use of gator to validate constraint template in shift left manner to avoid any impact with this behavior change.
+> ❗ Validation of Rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation if you want to use `experimental-enable-k8s-native-validation` Kubernetes CEL based policies as well. This flag will be removed from Gatekeeper 3.16 and later, please make use of [Gator](https://open-policy-agent.github.io/gatekeeper/website/docs/gator) to validate constraint template in shift left manner to avoid any impact with this behavior change.
 
 ## `v1` Constraint Template
 

--- a/website/versioned_docs/version-v3.13.x/validating-admission-policy.md
+++ b/website/versioned_docs/version-v3.13.x/validating-admission-policy.md
@@ -6,7 +6,7 @@ title: Integration with Kubernetes Validating Admission Policy
 `Feature State`: Gatekeeper version v3.13+ (pre-alpha)
 
 > ❗ This feature is pre-alpha, subject to change (feedback is welcome!). It is disabled by default. To enable the feature,
-> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image).  Do not use this feature with `validate-template-rego` flag enabled, as the policies with cel would get rejected with rego compilation error.
+> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image).  Do not use this feature with `validate-template-rego` flag enabled, as the policies with CEL would get rejected with Rego compilation error.
 
 ## Description
 

--- a/website/versioned_docs/version-v3.13.x/validating-admission-policy.md
+++ b/website/versioned_docs/version-v3.13.x/validating-admission-policy.md
@@ -6,7 +6,7 @@ title: Integration with Kubernetes Validating Admission Policy
 `Feature State`: Gatekeeper version v3.13+ (pre-alpha)
 
 > ❗ This feature is pre-alpha, subject to change (feedback is welcome!). It is disabled by default. To enable the feature,
-> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image).
+> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image).  Do not use this feature with `validate-template-rego` flag enabled, as the policies with cel would get rejected with rego compilation error.
 
 ## Description
 


### PR DESCRIPTION
**What this PR does / why we need it**: Introducing flag to validate rego in constraint template. 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #3008 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
I am not erroring out if `experimental-enable-k8s-native-validation` and `validate-template-rego` both are enabled at the same time as we discussed. Instead, the behavior is if `validate-template-rego` is enabled then any templates with cel will be rejected with the error "invalid rego", but the templates that exist in the cluster already with cel will still work (feels like less breaking change with this approach). Additionally, updates on cel templates will throw an "invalid rego" error as well. I do not have any issue with erroring out, so let me know if this is not the desired approach and I will make changes accordingly to error out if both are enabled at the same time.

