### PR TITLE
feat: disables provider response cache when TTL is set to 0

### DIFF
--- a/main.go
+++ b/main.go
@@ -113,7 +113,7 @@ var (
 	enableTLSHealthcheck                 = flag.Bool("enable-tls-healthcheck", false, "enable probing webhook API with certificate stored in certDir")
 	disabledBuiltins                     = util.NewFlagSet()
 	enableK8sCel                         = flag.Bool("experimental-enable-k8s-native-validation", false, "PROTOTYPE (not stable): enable the validating admission policy driver")
-	externaldataProviderResponseCacheTTL = flag.Duration("external-data-provider-response-cache-ttl", 3*time.Minute, "TTL for the external data provider response cache. Specify the duration in 'h', 'm', or 's' for hours, minutes, or seconds respectively. Defaults to 3 minutes if unspecified.")
+	externaldataProviderResponseCacheTTL = flag.Duration("external-data-provider-response-cache-ttl", 3*time.Minute, "TTL for the external data provider response cache. Specify the duration in 'h', 'm', or 's' for hours, minutes, or seconds respectively. Defaults to 3 minutes if unspecified. Setting the TTL to 0 disables the cache.")
 )
 
 func init() {
@@ -367,13 +367,17 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, sw *watch.Controlle
 		args = append(args, rego.AddExternalDataProviderCache(providerCache))
 		mutationOpts.ProviderCache = providerCache
 
-		if *externaldataProviderResponseCacheTTL <= 0 {
+		switch {
+		case *externaldataProviderResponseCacheTTL > 0:
+			providerResponseCache := frameworksexternaldata.NewProviderResponseCache(ctx, *externaldataProviderResponseCacheTTL)
+			args = append(args, rego.AddExternalDataProviderResponseCache(providerResponseCache))
+		case *externaldataProviderResponseCacheTTL == 0:
+			setupLog.Info("external data provider response cache is disabled")
+		default:
 			err := fmt.Errorf("invalid value for external-data-provider-response-cache-ttl: %d", *externaldataProviderResponseCacheTTL)
 			setupLog.Error(err, "unable to create external data provider response cache")
 			return err
 		}
-		providerResponseCache := frameworksexternaldata.NewProviderResponseCache(ctx, *externaldataProviderResponseCacheTTL)
-		args = append(args, rego.AddExternalDataProviderResponseCache(providerResponseCache))
 
 		certFile := filepath.Join(*certDir, certName)
 		keyFile := filepath.Join(*certDir, keyName)

--- a/website/docs/externaldata.md
+++ b/website/docs/externaldata.md
@@ -146,8 +146,8 @@ If there is a system error, the provider should return the system error message 
 
 Example provider implementation: https://github.com/open-policy-agent/gatekeeper/blob/master/test/externaldata/dummy-provider/provider.go
 
-#### Audit Provider Response Caching
-Starting with v3.13+, Gatekeeper supports caching of responses from external data providers. It caches the response based on the `Key` and `Value` received as part of the [`ProviderResponse`](#providerresponse). By default, the cache is invalidated after 3 minutes, which is the default Time-to-Live (TTL). You can configure the TTL using the `--external-data-provider-response-cache-ttl` flag.
+#### Provider Response Caching
+Starting with v3.13+, Gatekeeper supports caching of responses from external data providers for both audit and validating webhook. It caches the response based on the `Key` and `Value` received as part of the [`ProviderResponse`](#providerresponse). By default, the cache is invalidated after 3 minutes, which is the default Time-to-Live (TTL). You can configure the TTL using the `--external-data-provider-response-cache-ttl` flag. Setting the flag to 0 disables this cache.
 
 ## External data for Gatekeeper validating webhook
 

--- a/website/versioned_docs/version-v3.13.x/externaldata.md
+++ b/website/versioned_docs/version-v3.13.x/externaldata.md
@@ -146,8 +146,8 @@ If there is a system error, the provider should return the system error message 
 
 Example provider implementation: https://github.com/open-policy-agent/gatekeeper/blob/master/test/externaldata/dummy-provider/provider.go
 
-#### Audit Provider Response Caching
-Starting with v3.13+, Gatekeeper supports caching of responses from external data providers. It caches the response based on the `Key` and `Value` received as part of the [`ProviderResponse`](#providerresponse). By default, the cache is invalidated after 3 minutes, which is the default Time-to-Live (TTL). You can configure the TTL using the `--external-data-provider-response-cache-ttl` flag.
+#### Provider Response Caching
+Starting with v3.13+, Gatekeeper supports caching of responses from external data providers for both audit and validating webhook. It caches the response based on the `Key` and `Value` received as part of the [`ProviderResponse`](#providerresponse). By default, the cache is invalidated after 3 minutes, which is the default Time-to-Live (TTL). You can configure the TTL using the `--external-data-provider-response-cache-ttl` flag. Setting the flag to 0 disables this cache.
 
 ## External data for Gatekeeper validating webhook
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Disables provider response cache when TTL is set to 0

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes https://github.com/open-policy-agent/gatekeeper/issues/3024

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
