### PR TITLE
fix: use log level 1 for debug

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -33,7 +33,7 @@ const (
 	RequestUsername       = "request_username"
 	MutationApplied       = "mutation_applied"
 	Mutator               = "mutator"
-	DebugLevel            = 2 // r.log.Debug(foo) == r.log.V(logging.DebugLevel).Info(foo)
+	DebugLevel            = 1 // r.log.Debug(foo) == r.log.V(logging.DebugLevel).Info(foo)
 	ExecutionStats        = "execution_stats"
 )
 


### PR DESCRIPTION
Verbosity log levels (V level) are additive so starting at 2 is actually a higher level than `Debug`. So in effect, today, if users use `log-level=DEBUG` any log line that uses `loggging.Debug` as its V level will not see the line since we don't have a control for higher verbosity (>1) yet.

Not sure why it was 2 to begin with but I think it may have been missed on the original PR that introduced it https://github.com/open-policy-agent/gatekeeper/pull/482.