### PR TITLE
chore: cleanup disk usage before release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-policy-agent/gatekeeper'
     timeout-minutes: 45
     steps:
+      - name: Cleanup disk
+        run: |
+          docker system prune -a -f
+
       - name: Harden Runner
         uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

release is blocked due to running out of disk space https://github.com/open-policy-agent/gatekeeper/actions/runs/6423263625
seems like GHA runners starts with a 78% full disk 🤷‍♂️

removing [cached images](https://github.com/actions/runner-images/blob/releases/ubuntu22/20231001/images/linux/Ubuntu2204-Readme.md#cached-docker-images) (~6gigs) that we don't use 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
