### PR TITLE
fix: overwrite the default namespace slector for gke autopilot

### DIFF
--- a/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -34,6 +34,9 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
+      {{- if .Values.enableGkeAutopilot.enabled -}}
+      {{ toYaml .Values.enableGkeAutopilot.exemptNamespaces | nindent 6 }}
+      {{- end }}
     
     {{- range $key, $value := .Values.mutatingWebhookExemptNamespacesLabels}}
     - key: {{ $key }}

--- a/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -34,7 +34,9 @@ webhooks:
       operator: NotIn
       values:
       - {{ .Release.Namespace }}
-    
+      {{- if .Values.enableGkeAutopilot.enabled -}}
+      {{ toYaml .Values.enableGkeAutopilot.exemptNamespaces | nindent 6 }}
+      {{- end }}
     {{- range $key, $value := .Values.validatingWebhookExemptNamespacesLabels}}
     - key: {{ $key }}
       operator: NotIn

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -271,3 +271,10 @@ rbac:
 externalCertInjection:
   enabled: false
   secretName: gatekeeper-webhook-server-cert
+# Gke Autopilot Does not Support patching kube-system,kube-node-lease namespaces.
+# Gke autopilot also does not support "*" value in validating/mutation webhook resource rules  
+enableGkeAutopilot:
+ enabled: false
+ exemptNamespaces:
+  - kube-system
+  - kube-node-lease


### PR DESCRIPTION
GKE Autopilot and Standard throwing Warning When kube-system, kube-node-lease  is part of gatekeeper validation/mutation web-hook Scope. For GKE autopilot its not possible to patch kube-* namespaces  with pre/post install jobs as well by manually with kubectl so we have only option use existing labels comes with Kubernetes such as _name_.

#issue https://github.com/open-policy-agent/gatekeeper/issues/3046
<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

**Are you making changes to Gatekeeper Helm chart?**  **yes**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.

**Special notes for your reviewer**:
