### PR TITLE
ci: drop arm/v7 builds for crd image

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -51,8 +51,8 @@ jobs:
           if [[ $exists == null ]]
           then
             make docker-buildx-crds-dev \
-              DEV_TAG=${GITHUB_SHA::7}
-              PLATFORM="linux/amd64,linux/arm64,linux/arm/v7" \
+              DEV_TAG=${GITHUB_SHA::7} \
+              PLATFORM="linux/amd64,linux/arm64" \
               OUTPUT_TYPE=type=registry \
               GENERATE_ATTESTATIONS=true
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
           then
             make docker-buildx-crds-release \
               VERSION=${TAG} \
-              PLATFORM="linux/amd64,linux/arm64,linux/arm/v7" \
+              PLATFORM="linux/amd64,linux/arm64" \
               OUTPUT_TYPE=type=registry \
               GENERATE_ATTESTATIONS=true
           fi


### PR DESCRIPTION
**What this PR does / why we need it**:

`registry.k8s.io/kubectl:v1.28.2` does not include 32-bit arm/v7 kubectl, which blocks us from building gatekeeper-crds image for arm/v7

Also fixes a bug in the pre-release CI where we omitted `\`, this should have been caught there

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
This is blocking v3.14.0 release so needs to be cherry picked there after merge
