### PR TITLE
chore: update golangci-lint v1.55.2

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51.2
+          version: v1.55.2
 
   test:
     name: "Unit test"


### PR DESCRIPTION
**What this PR does / why we need it**: update golangci-lint v1.55.2