### PR TITLE
fix: only validate gk res

### DIFF
--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -99,6 +99,8 @@ func (h *webhookHandler) isGatekeeperResource(req *admission.Request) bool {
 		req.AdmissionRequest.Kind.Group == "constraints.gatekeeper.sh" ||
 		req.AdmissionRequest.Kind.Group == mutationsGroup ||
 		req.AdmissionRequest.Kind.Group == "config.gatekeeper.sh" ||
+		req.AdmissionRequest.Kind.Group == externalDataGroup ||
+		req.AdmissionRequest.Kind.Group == "expansion.gatekeeper.sh" ||
 		req.AdmissionRequest.Kind.Group == "status.gatekeeper.sh" {
 		return true
 	}

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -336,6 +336,10 @@ func (h *validationHandler) getValidationMessages(res []*rtypes.Result, req *adm
 // validateGatekeeperResources returns whether an issue is user error (vs internal) and any errors
 // validating internal resources.
 func (h *validationHandler) validateGatekeeperResources(ctx context.Context, req *admission.Request) (bool, error) {
+	if !h.isGatekeeperResource(req) {
+		return false, nil
+	}
+
 	if req.Operation == admissionv1.Delete && req.Name == "" {
 		// Allow the general DELETE of resources like "/apis/config.gatekeeper.sh/v1alpha1/namespaces/<ns>/configs"
 		return true, nil


### PR DESCRIPTION
Follow up to https://github.com/open-policy-agent/gatekeeper/pull/3094 -- only check name len if the resources is a gatekepeer resource