### PR TITLE
feat: Add support for delaying webhook shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ var (
 	disabledBuiltins                     = util.NewFlagSet()
 	enableK8sCel                         = flag.Bool("experimental-enable-k8s-native-validation", false, "PROTOTYPE (not stable): enable the validating admission policy driver")
 	externaldataProviderResponseCacheTTL = flag.Duration("external-data-provider-response-cache-ttl", 3*time.Minute, "TTL for the external data provider response cache. Specify the duration in 'h', 'm', or 's' for hours, minutes, or seconds respectively. Defaults to 3 minutes if unspecified. Setting the TTL to 0 disables the cache.")
-	shutdownWaitPeriod                   = flag.Duration("shutdown-wait-period", 10*time.Second, "time to wait before shutting down")
+	shutdownWaitPeriod                   = flag.Duration("shutdown-wait-period", 10*time.Second, "The amount of time to wait before shutting down")
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ var (
 	disabledBuiltins                     = util.NewFlagSet()
 	enableK8sCel                         = flag.Bool("experimental-enable-k8s-native-validation", false, "PROTOTYPE (not stable): enable the validating admission policy driver")
 	externaldataProviderResponseCacheTTL = flag.Duration("external-data-provider-response-cache-ttl", 3*time.Minute, "TTL for the external data provider response cache. Specify the duration in 'h', 'm', or 's' for hours, minutes, or seconds respectively. Defaults to 3 minutes if unspecified. Setting the TTL to 0 disables the cache.")
-	shutdownDelayDuration                = flag.Duration("shutdown-delay-duration", 10*time.Second, "The amount of time to wait before shutting down gracefully. This can be used to delay webhook shutdown until the API Server stops trying to make new connections")
+	shutdownDelayDuration                = flag.Duration("shutdown-delay-duration", 10*time.Second, "The amount of time to wait before shutting down gracefully. This can be used to delay webhook shutdown until the Kubernetes API Server stops trying to make new connections")
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -117,7 +117,7 @@ var (
 	disabledBuiltins                     = util.NewFlagSet()
 	enableK8sCel                         = flag.Bool("experimental-enable-k8s-native-validation", false, "PROTOTYPE (not stable): enable the validating admission policy driver")
 	externaldataProviderResponseCacheTTL = flag.Duration("external-data-provider-response-cache-ttl", 3*time.Minute, "TTL for the external data provider response cache. Specify the duration in 'h', 'm', or 's' for hours, minutes, or seconds respectively. Defaults to 3 minutes if unspecified. Setting the TTL to 0 disables the cache.")
-	shutdownWaitPeriod                   = flag.Duration("shutdown-wait-period", 10*time.Second, "The amount of time to wait before shutting down")
+	shutdownWaitPeriod                   = flag.Duration("shutdown-wait-period", 10*time.Second, "The amount of time to wait before shutting down gracefully. This is used to delay webhook shutdown until the API Server stops sending new connections")
 )
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -596,7 +596,8 @@ func setupSignalHandler(waitPeriod time.Duration) context.Context {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		// Cancel the context once the wait period expires
+		// Cancel the context once the wait period expires but avoid blocking if
+		// a second signal is received
 		go func() {
 			<-time.After(waitPeriod)
 			cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, as far as I can tell, Gatekeeper shuts down immediately after a TERM signal is received. If a Gatekeeper Pod happens to shutdown just as the API server is setting up a connection for a webhook request (but before it realises the Pod has been terminated) then the request might fail trying to connect to a server that is no longer accepting connections.

To fix this, this PR adds a `--shutdown-delay-duration` flag with a default of 10 seconds. This matches with the similar API Server flag

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:

- I wasn't sure how best to unit test this given it interacts with signals
- It reimplements the controller-runtime signal handler but does not differentiate between [Windows](https://github.com/kubernetes-sigs/controller-runtime/blob/2154ffbc22e26ffd8c3b713927f0df2fa40841f2/pkg/manager/signals/signal_windows.go#L23) and [Unix](https://github.com/kubernetes-sigs/controller-runtime/blob/2154ffbc22e26ffd8c3b713927f0df2fa40841f2/pkg/manager/signals/signal_posix.go#L27)
- Very happy to completely reimplement this or remove it depending on the opinions of the reviewer, but just thought I'd give it a go first as it's a small change
