### PR TITLE
docs: Update install.md

### DIFF
--- a/website/versioned_docs/version-v3.14.x/install.md
+++ b/website/versioned_docs/version-v3.14.x/install.md
@@ -56,7 +56,7 @@ Currently the most reliable way of installing Gatekeeper is to build and install
    * Build and push Gatekeeper image:
       ```sh
       export DESTINATION_GATEKEEPER_IMAGE=<add registry like "myregistry.docker.io/gatekeeper">
-      make docker-buildx REPOSITORY=$DESTINATION_GATEKEEPER_DOCKER_IMAGE OUTPUT_TYPE=type=registry
+      make docker-buildx REPOSITORY=$DESTINATION_GATEKEEPER_IMAGE OUTPUT_TYPE=type=registry
       ```
 
       > If you want to use a local image, don't set OUTPUT_TYPE and it will default to `OUTPUT_TYPE=type=docker`.


### PR DESCRIPTION
Typo perhaps.

**What this PR does / why we need it**:

I encountered an error as below.

```
ubuntu@ubuntu-playground:~/gatekeeper$ export DESTINATION_GATEKEEPER_IMAGE=opa-test.sakuracr.jp/gatekeeper
ubuntu@ubuntu-playground:~/gatekeeper$ echo $DESTINATION_GATEKEEPER_IMAGE
opa-test.sakuracr.jp/gatekeeper
ubuntu@ubuntu-playground:~/gatekeeper$ echo $DESTINATION_GATEKEEPER_DOCKER_IMAGE

ubuntu@ubuntu-playground:~/gatekeeper$ make docker-buildx REPOSITORY=$DESTINATION_GATEKEEPER_DOCKER_IMAGE OUTPUT_TYPE=type=registry
if ! docker buildx ls | grep -q container-builder; then\
        docker buildx create --name container-builder --use --bootstrap;\
        docker buildx inspect;\
fi
docker buildx build \
         \
        --build-arg LDFLAGS="-X github.com/open-policy-agent/gatekeeper/v3/pkg/version.Version=v3.15.0-beta.0" \
        --platform="linux/amd64" \
        --output=type=registry \
        -t :latest .
[+] Building 0.0s (0/0)                                                              docker-container:container-builder
ERROR: invalid tag ":latest": invalid reference format
make: *** [Makefile:375: docker-buildx] Error 1
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:

The workaround(I use `REPOSITORY=$DESTINATION_GATEKEEPER_IMAGE` instead of  `REPOSITORY=$DESTINATION_GATEKEEPER_DOCKER_IMAGE`).

```
ubuntu@ubuntu-playground:~/gatekeeper$ make docker-buildx REPOSITORY=$DESTINATION_GATEKEEPER_IMAGE OUTPUT_TYPE=type=registry
if ! docker buildx ls | grep -q container-builder; then\
        docker buildx create --name container-builder --use --bootstrap;\
        docker buildx inspect;\
fi
docker buildx build \
         \
        --build-arg LDFLAGS="-X github.com/open-policy-agent/gatekeeper/v3/pkg/version.Version=v3.15.0-beta.0" \
        --platform="linux/amd64" \
        --output=type=registry \
        -t opa-test.sakuracr.jp/gatekeeper:latest .
[+] Building 4.9s (13/13) FINISHED                                                   docker-container:container-builder
 => [internal] load build definition from Dockerfile                                                               0.0s
 => => transferring dockerfile: 874B                                                                               0.0s
 => [internal] load metadata for gcr.io/distroless/static:nonroot                                                  0.7s
 => [internal] load metadata for docker.io/library/golang:1.21-bullseye                                            1.2s
 => [internal] load .dockerignore                                                                                  0.0s
 => => transferring context: 116B                                                                                  0.0s
 => [builder 1/4] FROM docker.io/library/golang:1.21-bullseye@sha256:ca78a56712ab89487123b3af2b30052824653730e7ff  0.0s
 => => resolve docker.io/library/golang:1.21-bullseye@sha256:ca78a56712ab89487123b3af2b30052824653730e7ff25271d2f  0.0s
 => [internal] load build context                                                                                  0.6s
 => => transferring context: 805.85kB                                                                              0.5s
 => [stage-1 1/3] FROM gcr.io/distroless/static:nonroot@sha256:91ca4720011393f4d4cab3a01fa5814ee2714b7d40e6c74f25  0.1s
 => => resolve gcr.io/distroless/static:nonroot@sha256:91ca4720011393f4d4cab3a01fa5814ee2714b7d40e6c74f2505f74168  0.1s
 => CACHED [builder 2/4] WORKDIR /go/src/github.com/open-policy-agent/gatekeeper                                   0.0s
 => CACHED [builder 3/4] COPY . .                                                                                  0.0s
 => CACHED [builder 4/4] RUN go build -mod vendor -a -ldflags "-X github.com/open-policy-agent/gatekeeper/v3/pkg/  0.0s
 => CACHED [stage-1 2/3] COPY --from=builder /go/src/github.com/open-policy-agent/gatekeeper/manager .             0.0s
 => exporting to image                                                                                             2.8s
 => => exporting layers                                                                                            0.0s
 => => exporting manifest sha256:961ae7b7d450515ebd5e4c735c2950524c4e4fcf1263763ec19a16d72d6698b0                  0.0s
 => => exporting config sha256:3279b3a6edb86f377366b37284ed6b4375b70f2ee2b0cfabf336217112b189d9                    0.0s
 => => exporting attestation manifest sha256:c65adc1064bf04b1ec20db025418a17a98f0c70f1f30755ea2b51affe12763a4      0.0s
 => => exporting manifest list sha256:effd91ac57d417da92e5dad9c10c6d9984a2776110d75c55e88354a0c581d26c             0.0s
 => => pushing layers                                                                                              1.7s
 => => pushing manifest for opa-test.sakuracr.jp/gatekeeper:latest@sha256:effd91ac57d417da92e5dad9c10c6d9984a2776  1.0s
 => [auth] gatekeeper:pull,push token for opa-test.sakuracr.jp                                                     0.0s
ubuntu@ubuntu-playground:~/gatekeeper$ echo $?
0

ubuntu@ubuntu-playground:~/gatekeeper$ docker pull opa-test.sakuracr.jp/gatekeeper:latest
latest: Pulling from gatekeeper
07a64a71e011: Pull complete
fe5ca62666f0: Pull complete
b02a7525f878: Pull complete
fcb6f6d2c998: Pull complete
e8c73c638ae9: Pull complete
1e3d9b7d1452: Pull complete
4aa0ea1413d3: Pull complete
7c881f9ab25e: Pull complete
5627a970d25e: Pull complete
7471572425a1: Pull complete
Digest: sha256:effd91ac57d417da92e5dad9c10c6d9984a2776110d75c55e88354a0c581d26c
Status: Downloaded newer image for opa-test.sakuracr.jp/gatekeeper:latest
opa-test.sakuracr.jp/gatekeeper:latest
```
