### PR TITLE
chore: fix golanglint, checkout prior to setup-go

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -36,20 +36,21 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: "1.21"
           check-latest: true
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       # source: https://github.com/golangci/golangci-lint-action
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
           # version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51.2
+          version: v1.54.2
 
   test:
     name: "Unit test"
@@ -61,13 +62,14 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: "1.21"
           check-latest: true
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Unit test
         run: make native-test
@@ -90,7 +92,8 @@ jobs:
           egress-policy: audit
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v3.5.2
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
@@ -114,13 +117,14 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: "1.21"
           check-latest: true
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Download e2e dependencies
         run: |
@@ -145,13 +149,14 @@ jobs:
           egress-policy: audit
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
           go-version: "1.21"
           check-latest: true
+
       - name: Bootstrap e2e
         run: |
           mkdir -p $GITHUB_WORKSPACE/bin
@@ -203,7 +208,7 @@ jobs:
           egress-policy: audit
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Bootstrap e2e
         run: |
@@ -265,13 +270,14 @@ jobs:
         egress-policy: audit
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Set up Go
       uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       with:
         go-version: "1.21"
         check-latest: true
+
     - name: Bootstrap e2e
       run: |
         mkdir -p $GITHUB_WORKSPACE/bin

--- a/apis/status/v1beta1/util.go
+++ b/apis/status/v1beta1/util.go
@@ -21,10 +21,9 @@ func dashExtractor(val string) []string {
 				b.WriteRune(chr)
 				prevDash = false
 				continue
-			} else {
-				prevDash = true
-				continue
 			}
+			prevDash = true
+			continue
 		}
 		b.WriteRune(chr)
 	}

--- a/cmd/gator/expand/expand.go
+++ b/cmd/gator/expand/expand.go
@@ -66,7 +66,7 @@ func init() {
 	Cmd.Flags().StringVarP(&flagTempDir, flagNameTempDir, "d", "", fmt.Sprintf("Specifies the temporary directory to download and unpack images to, if using the --%s flag. Optional.", flagNameImage))
 }
 
-func run(cmd *cobra.Command, args []string) {
+func run(_ *cobra.Command, _ []string) {
 	unstrucs, err := reader.ReadSources(flagFilenames, flagImages, flagTempDir)
 	if err != nil {
 		util.ErrFatalf("reading: %v", err)

--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -78,7 +78,7 @@ func init() {
 	Cmd.Flags().StringVarP(&flagTempDir, flagNameTempDir, "d", "", fmt.Sprintf("Specifies the temporary directory to download and unpack images to, if using the --%s flag. Optional.", flagNameImage))
 }
 
-func run(cmd *cobra.Command, args []string) {
+func run(_ *cobra.Command, _ []string) {
 	unstrucs, err := reader.ReadSources(flagFilenames, flagImages, flagTempDir)
 	if err != nil {
 		cmdutils.ErrFatalf("reading: %v", err)

--- a/pkg/cachemanager/cachemanager_test.go
+++ b/pkg/cachemanager/cachemanager_test.go
@@ -245,6 +245,7 @@ func TestCacheManager_AddObject(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.cm.AddObject(context.Background(), &unstructured.Unstructured{Object: unstructuredPod})
 			if tc.expectedMetricStatus == metrics.ActiveStatus {
@@ -762,7 +763,7 @@ type fakeRegistrar struct {
 	generalErr        error
 }
 
-func (f *fakeRegistrar) ReplaceWatch(ctx context.Context, gvks []schema.GroupVersionKind) error {
+func (f *fakeRegistrar) ReplaceWatch(_ context.Context, _ []schema.GroupVersionKind) error {
 	err := watch.NewErrorList()
 	if f.generalErr != nil {
 		err.Err(f.generalErr)

--- a/pkg/controller/expansion/expansion_controller_test.go
+++ b/pkg/controller/expansion/expansion_controller_test.go
@@ -174,6 +174,7 @@ func TestAddStatusError(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			setStatusError(&tc.inputStatus, tc.etErr)
 			if diff := cmp.Diff(tc.inputStatus, tc.wantStatus); diff != "" {

--- a/pkg/controller/expansionstatus/expansionstatus_controller.go
+++ b/pkg/controller/expansionstatus/expansionstatus_controller.go
@@ -48,9 +48,9 @@ type Adder struct {
 	WatchManager *watch.Manager
 }
 
-func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
+func (a *Adder) InjectControllerSwitch(_ *watch.ControllerSwitch) {}
 
-func (a *Adder) InjectTracker(t *readiness.Tracker) {}
+func (a *Adder) InjectTracker(_ *readiness.Tracker) {}
 
 // Add creates a new Constraint Status Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/externaldata/externaldata_controller.go
+++ b/pkg/controller/externaldata/externaldata_controller.go
@@ -45,7 +45,7 @@ func (a *Adder) InjectCFClient(c *constraintclient.Client) {
 	a.CFClient = c
 }
 
-func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
+func (a *Adder) InjectControllerSwitch(_ *watch.ControllerSwitch) {}
 
 func (a *Adder) InjectTracker(t *readiness.Tracker) {
 	a.Tracker = t

--- a/pkg/controller/mutators/core/reconciler.go
+++ b/pkg/controller/mutators/core/reconciler.go
@@ -223,7 +223,7 @@ func (r *Reconciler) defaultGetPod(_ context.Context) (*corev1.Pod, error) {
 	panic("GetPod must be injected to Reconciler")
 }
 
-func (r *Reconciler) reportMutator(id types.ID, ingestionStatus ctrlmutators.MutatorIngestionStatus, startTime time.Time, deleted bool) {
+func (r *Reconciler) reportMutator(_ types.ID, ingestionStatus ctrlmutators.MutatorIngestionStatus, startTime time.Time, deleted bool) {
 	if r.reporter == nil {
 		return
 	}

--- a/pkg/controller/mutators/instances/mutator_controllers.go
+++ b/pkg/controller/mutators/instances/mutator_controllers.go
@@ -129,7 +129,7 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	return assignMetadata.Add(mgr)
 }
 
-func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
+func (a *Adder) InjectControllerSwitch(_ *watch.ControllerSwitch) {}
 
 func (a *Adder) InjectTracker(t *readiness.Tracker) {
 	a.Tracker = t

--- a/pkg/controller/mutatorstatus/mutatorstatus_controller.go
+++ b/pkg/controller/mutatorstatus/mutatorstatus_controller.go
@@ -50,9 +50,9 @@ type Adder struct {
 	ControllerSwitch *watch.ControllerSwitch
 }
 
-func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {}
+func (a *Adder) InjectControllerSwitch(_ *watch.ControllerSwitch) {}
 
-func (a *Adder) InjectTracker(t *readiness.Tracker) {}
+func (a *Adder) InjectTracker(_ *readiness.Tracker) {}
 
 // Add creates a new Mutator Status Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.

--- a/pkg/controller/syncset/syncset_controller.go
+++ b/pkg/controller/syncset/syncset_controller.go
@@ -56,7 +56,7 @@ func (a *Adder) InjectCacheManager(o *cm.CacheManager) {
 	a.CacheManager = o
 }
 
-func (a *Adder) InjectControllerSwitch(cs *watch.ControllerSwitch) {
+func (a *Adder) InjectControllerSwitch(_ *watch.ControllerSwitch) {
 }
 
 func (a *Adder) InjectTracker(t *readiness.Tracker) {

--- a/pkg/expansion/system_test.go
+++ b/pkg/expansion/system_test.go
@@ -417,6 +417,7 @@ func TestValidateTemplate(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tc.errFn(ValidateTemplate(&tc.temp), t)
 		})

--- a/pkg/fakes/fakecfdataclient.go
+++ b/pkg/fakes/fakecfdataclient.go
@@ -52,7 +52,7 @@ func KeyFor(obj interface{}) (CfDataKey, error) {
 	return CfDataKey{Gvk: gvk, Key: fmt.Sprintf("%s/%s", ns, o.GetName())}, nil
 }
 
-func (f *FakeCfClient) AddData(ctx context.Context, data interface{}) (*constraintTypes.Responses, error) {
+func (f *FakeCfClient) AddData(_ context.Context, data interface{}) (*constraintTypes.Responses, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -73,7 +73,7 @@ func (f *FakeCfClient) AddData(ctx context.Context, data interface{}) (*constrai
 	return &constraintTypes.Responses{}, nil
 }
 
-func (f *FakeCfClient) RemoveData(ctx context.Context, data interface{}) (*constraintTypes.Responses, error) {
+func (f *FakeCfClient) RemoveData(_ context.Context, data interface{}) (*constraintTypes.Responses, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 

--- a/pkg/gator/verify/filter.go
+++ b/pkg/gator/verify/filter.go
@@ -10,7 +10,7 @@ import (
 
 type Filter interface {
 	// MatchesTest returns true if the Test should be run.
-	MatchesTest(Test) bool
+	MatchesTest(*Test) bool
 	// MatchesCase returns true if Case caseName in Test testName should be run.
 	MatchesCase(testName, caseName string) bool
 }
@@ -68,7 +68,7 @@ type nilFilter struct{}
 
 var _ Filter = &nilFilter{}
 
-func (f *nilFilter) MatchesTest(Test) bool {
+func (f *nilFilter) MatchesTest(*Test) bool {
 	return true
 }
 
@@ -93,7 +93,7 @@ func newOrFilter(filter string) (Filter, error) {
 	return &orFilter{regex: regex}, nil
 }
 
-func (f *orFilter) MatchesTest(t Test) bool {
+func (f *orFilter) MatchesTest(t *Test) bool {
 	if f.regex.MatchString(t.Name) {
 		return true
 	}
@@ -134,7 +134,7 @@ func newAndFilter(testFilter, caseFilter string) (Filter, error) {
 	return &andFilter{testRegex: testRegex, caseRegex: caseRegex}, nil
 }
 
-func (f *andFilter) MatchesTest(t Test) bool {
+func (f *andFilter) MatchesTest(t *Test) bool {
 	return f.testRegex.MatchString(t.Name)
 }
 

--- a/pkg/gator/verify/filter_test.go
+++ b/pkg/gator/verify/filter_test.go
@@ -168,7 +168,7 @@ func TestFilter_MatchesTest(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			got := filter.MatchesTest(tc.test)
+			got := filter.MatchesTest(&tc.test)
 			if got != tc.want {
 				t.Errorf("got MatchesTest(%q) = %t, want %t", tc.test.Name, got, tc.want)
 			}

--- a/pkg/metrics/exporter.go
+++ b/pkg/metrics/exporter.go
@@ -17,11 +17,11 @@ type runner struct {
 }
 
 func AddToManager(m manager.Manager) error {
-	mr := new(m)
+	mr := create(m)
 	return m.Add(mr)
 }
 
-func new(mgr manager.Manager) *runner {
+func create(mgr manager.Manager) *runner {
 	mr := &runner{
 		mgr: mgr,
 	}

--- a/pkg/metrics/registry/registry.go
+++ b/pkg/metrics/registry/registry.go
@@ -69,11 +69,11 @@ func (es *exporterSet) Set(s string) error {
 	splt := strings.Split(s, ",")
 	for _, v := range splt {
 		lower := strings.ToLower(v)
-		new, ok := es.registeredExporters[lower]
+		newExporter, ok := es.registeredExporters[lower]
 		if !ok {
 			return fmt.Errorf("exporter %s is not a valid exporter: %v", v, es.validExporters)
 		}
-		es.assignedExporters[lower] = new
+		es.assignedExporters[lower] = newExporter
 	}
 	return nil
 }

--- a/pkg/mutation/match/match_test.go
+++ b/pkg/mutation/match/match_test.go
@@ -670,6 +670,7 @@ func TestMatch(t *testing.T) {
 	}
 
 	for _, tc := range table {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			m := &Matchable{Object: tc.object, Namespace: tc.namespace, Source: tc.source}
 			matches, err := Matches(&tc.matcher, m)

--- a/pkg/mutation/mutators/core/mutation_function_setter_test.go
+++ b/pkg/mutation/mutators/core/mutation_function_setter_test.go
@@ -17,7 +17,7 @@ func (s *notKeyedSetter) KeyedListValue() (map[string]interface{}, error) {
 	panic("notKeyedSetter setter does not handle keyed lists")
 }
 
-func (s *notKeyedSetter) SetValue(obj map[string]interface{}, key string) error {
+func (s *notKeyedSetter) SetValue(_ map[string]interface{}, _ string) error {
 	panic("NOT IMPLEMENTED")
 }
 

--- a/pkg/mutation/mutators/core/mutation_function_test.go
+++ b/pkg/mutation/mutators/core/mutation_function_test.go
@@ -579,7 +579,7 @@ func testAssignMetadataMutation(
 	return testMutation(mutator, unstructured, testFunc, t)
 }
 
-func testMutation(mutator types.Mutator, unstructured *unstructured.Unstructured, testFunc func(*unstructured.Unstructured), t *testing.T) error {
+func testMutation(mutator types.Mutator, unstructured *unstructured.Unstructured, testFunc func(*unstructured.Unstructured), _ *testing.T) error {
 	_, err := mutator.Mutate(&types.Mutable{Object: unstructured})
 	if err != nil {
 		return err

--- a/pkg/mutation/system_external_data.go
+++ b/pkg/mutation/system_external_data.go
@@ -54,11 +54,7 @@ func (s *System) resolvePlaceholders(obj *unstructured.Unstructured) error {
 	}
 
 	externalData, errors := s.sendRequests(providerKeys, clientCert)
-	if err := s.mutateWithExternalData(obj, externalData, errors); err != nil {
-		return err
-	}
-
-	return nil
+	return s.mutateWithExternalData(obj, externalData, errors)
 }
 
 // sendRequests sends requests to all providers in parallel.

--- a/pkg/pubsub/dapr/dapr.go
+++ b/pkg/pubsub/dapr/dapr.go
@@ -27,7 +27,7 @@ const (
 	Name = "dapr"
 )
 
-func (r *Dapr) Publish(ctx context.Context, data interface{}, topic string) error {
+func (r *Dapr) Publish(_ context.Context, data interface{}, topic string) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("error marshaling data: %w", err)

--- a/pkg/pubsub/dapr/fake_dapr_client.go
+++ b/pkg/pubsub/dapr/fake_dapr_client.go
@@ -71,19 +71,19 @@ type testDaprServer struct {
 	configurationSubscriptionID       map[string]chan struct{}
 }
 
-func (s *testDaprServer) TryLockAlpha1(ctx context.Context, req *pb.TryLockRequest) (*pb.TryLockResponse, error) {
+func (s *testDaprServer) TryLockAlpha1(_ context.Context, _ *pb.TryLockRequest) (*pb.TryLockResponse, error) {
 	return &pb.TryLockResponse{
 		Success: true,
 	}, nil
 }
 
-func (s *testDaprServer) UnlockAlpha1(ctx context.Context, req *pb.UnlockRequest) (*pb.UnlockResponse, error) {
+func (s *testDaprServer) UnlockAlpha1(_ context.Context, _ *pb.UnlockRequest) (*pb.UnlockResponse, error) {
 	return &pb.UnlockResponse{
 		Status: pb.UnlockResponse_SUCCESS,
 	}, nil
 }
 
-func (s *testDaprServer) InvokeService(ctx context.Context, req *pb.InvokeServiceRequest) (*commonv1pb.InvokeResponse, error) {
+func (s *testDaprServer) InvokeService(_ context.Context, req *pb.InvokeServiceRequest) (*commonv1pb.InvokeResponse, error) {
 	if req.Message == nil {
 		return &commonv1pb.InvokeResponse{
 			ContentType: "text/plain",
@@ -98,14 +98,14 @@ func (s *testDaprServer) InvokeService(ctx context.Context, req *pb.InvokeServic
 	}, nil
 }
 
-func (s *testDaprServer) GetState(ctx context.Context, req *pb.GetStateRequest) (*pb.GetStateResponse, error) {
+func (s *testDaprServer) GetState(_ context.Context, req *pb.GetStateRequest) (*pb.GetStateResponse, error) {
 	return &pb.GetStateResponse{
 		Data: s.state[req.Key],
 		Etag: "1",
 	}, nil
 }
 
-func (s *testDaprServer) GetBulkState(ctx context.Context, in *pb.GetBulkStateRequest) (*pb.GetBulkStateResponse, error) {
+func (s *testDaprServer) GetBulkState(_ context.Context, in *pb.GetBulkStateRequest) (*pb.GetBulkStateResponse, error) {
 	items := make([]*pb.BulkStateItem, 0)
 	for _, k := range in.GetKeys() {
 		if v, found := s.state[k]; found {
@@ -122,14 +122,14 @@ func (s *testDaprServer) GetBulkState(ctx context.Context, in *pb.GetBulkStateRe
 	}, nil
 }
 
-func (s *testDaprServer) SaveState(ctx context.Context, req *pb.SaveStateRequest) (*empty.Empty, error) {
+func (s *testDaprServer) SaveState(_ context.Context, req *pb.SaveStateRequest) (*empty.Empty, error) {
 	for _, item := range req.States {
 		s.state[item.Key] = item.Value
 	}
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) QueryStateAlpha1(ctx context.Context, req *pb.QueryStateRequest) (*pb.QueryStateResponse, error) {
+func (s *testDaprServer) QueryStateAlpha1(_ context.Context, req *pb.QueryStateRequest) (*pb.QueryStateResponse, error) {
 	var v map[string]interface{}
 	if err := json.Unmarshal([]byte(req.Query), &v); err != nil {
 		return nil, err
@@ -144,19 +144,19 @@ func (s *testDaprServer) QueryStateAlpha1(ctx context.Context, req *pb.QueryStat
 	return ret, nil
 }
 
-func (s *testDaprServer) DeleteState(ctx context.Context, req *pb.DeleteStateRequest) (*empty.Empty, error) {
+func (s *testDaprServer) DeleteState(_ context.Context, req *pb.DeleteStateRequest) (*empty.Empty, error) {
 	delete(s.state, req.Key)
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) DeleteBulkState(ctx context.Context, req *pb.DeleteBulkStateRequest) (*empty.Empty, error) {
+func (s *testDaprServer) DeleteBulkState(_ context.Context, req *pb.DeleteBulkStateRequest) (*empty.Empty, error) {
 	for _, item := range req.States {
 		delete(s.state, item.Key)
 	}
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) ExecuteStateTransaction(ctx context.Context, in *pb.ExecuteStateTransactionRequest) (*empty.Empty, error) {
+func (s *testDaprServer) ExecuteStateTransaction(_ context.Context, in *pb.ExecuteStateTransactionRequest) (*empty.Empty, error) {
 	for _, op := range in.GetOperations() {
 		item := op.GetRequest()
 		switch opType := op.GetOperationType(); opType {
@@ -171,11 +171,11 @@ func (s *testDaprServer) ExecuteStateTransaction(ctx context.Context, in *pb.Exe
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) PublishEvent(ctx context.Context, req *pb.PublishEventRequest) (*empty.Empty, error) {
+func (s *testDaprServer) PublishEvent(_ context.Context, _ *pb.PublishEventRequest) (*empty.Empty, error) {
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) InvokeBinding(ctx context.Context, req *pb.InvokeBindingRequest) (*pb.InvokeBindingResponse, error) {
+func (s *testDaprServer) InvokeBinding(_ context.Context, req *pb.InvokeBindingRequest) (*pb.InvokeBindingResponse, error) {
 	if req.Data == nil {
 		return &pb.InvokeBindingResponse{
 			Data:     []byte("test"),
@@ -188,7 +188,7 @@ func (s *testDaprServer) InvokeBinding(ctx context.Context, req *pb.InvokeBindin
 	}, nil
 }
 
-func (s *testDaprServer) GetSecret(ctx context.Context, req *pb.GetSecretRequest) (*pb.GetSecretResponse, error) {
+func (s *testDaprServer) GetSecret(_ context.Context, _ *pb.GetSecretRequest) (*pb.GetSecretResponse, error) {
 	d := make(map[string]string)
 	d["test"] = "value"
 	return &pb.GetSecretResponse{
@@ -196,7 +196,7 @@ func (s *testDaprServer) GetSecret(ctx context.Context, req *pb.GetSecretRequest
 	}, nil
 }
 
-func (s *testDaprServer) GetBulkSecret(ctx context.Context, req *pb.GetBulkSecretRequest) (*pb.GetBulkSecretResponse, error) {
+func (s *testDaprServer) GetBulkSecret(_ context.Context, _ *pb.GetBulkSecretRequest) (*pb.GetBulkSecretResponse, error) {
 	d := make(map[string]*pb.SecretResponse)
 	d["test"] = &pb.SecretResponse{
 		Secrets: map[string]string{
@@ -208,15 +208,15 @@ func (s *testDaprServer) GetBulkSecret(ctx context.Context, req *pb.GetBulkSecre
 	}, nil
 }
 
-func (s *testDaprServer) RegisterActorReminder(ctx context.Context, req *pb.RegisterActorReminderRequest) (*empty.Empty, error) {
+func (s *testDaprServer) RegisterActorReminder(_ context.Context, _ *pb.RegisterActorReminderRequest) (*empty.Empty, error) {
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) UnregisterActorReminder(ctx context.Context, req *pb.UnregisterActorReminderRequest) (*empty.Empty, error) {
+func (s *testDaprServer) UnregisterActorReminder(_ context.Context, _ *pb.UnregisterActorReminderRequest) (*empty.Empty, error) {
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) RenameActorReminder(ctx context.Context, req *pb.RenameActorReminderRequest) (*empty.Empty, error) {
+func (s *testDaprServer) RenameActorReminder(_ context.Context, _ *pb.RenameActorReminderRequest) (*empty.Empty, error) {
 	return &empty.Empty{}, nil
 }
 
@@ -234,11 +234,11 @@ func (s *testDaprServer) UnregisterActorTimer(context.Context, *pb.UnregisterAct
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) Shutdown(ctx context.Context, req *empty.Empty) (*empty.Empty, error) {
+func (s *testDaprServer) Shutdown(_ context.Context, _ *empty.Empty) (*empty.Empty, error) {
 	return &empty.Empty{}, nil
 }
 
-func (s *testDaprServer) GetConfiguration(ctx context.Context, in *pb.GetConfigurationRequest) (*pb.GetConfigurationResponse, error) {
+func (s *testDaprServer) GetConfiguration(_ context.Context, in *pb.GetConfigurationRequest) (*pb.GetConfigurationResponse, error) {
 	if in.GetStoreName() == "" {
 		return &pb.GetConfigurationResponse{}, errors.New("store name notfound")
 	}
@@ -290,7 +290,7 @@ func (s *testDaprServer) SubscribeConfiguration(in *pb.SubscribeConfigurationReq
 	return nil
 }
 
-func (s *testDaprServer) UnsubscribeConfiguration(ctx context.Context, in *pb.UnsubscribeConfigurationRequest) (*pb.UnsubscribeConfigurationResponse, error) {
+func (s *testDaprServer) UnsubscribeConfiguration(_ context.Context, in *pb.UnsubscribeConfigurationRequest) (*pb.UnsubscribeConfigurationResponse, error) {
 	s.configurationSubscriptionIDMapLoc.Lock()
 	defer s.configurationSubscriptionIDMapLoc.Unlock()
 	ch, ok := s.configurationSubscriptionID[in.Id]
@@ -305,7 +305,7 @@ func (s *testDaprServer) UnsubscribeConfiguration(ctx context.Context, in *pb.Un
 // BulkPublishEventAlpha1 mocks the BulkPublishEventAlpha1 API.
 // It will fail to publish events that start with "fail".
 // It will fail the entire request if an event starts with "failall".
-func (s *testDaprServer) BulkPublishEventAlpha1(ctx context.Context, req *pb.BulkPublishRequest) (*pb.BulkPublishResponse, error) {
+func (s *testDaprServer) BulkPublishEventAlpha1(_ context.Context, req *pb.BulkPublishRequest) (*pb.BulkPublishResponse, error) {
 	failedEntries := make([]*pb.BulkPublishResponseFailedEntry, 0)
 	for _, entry := range req.Entries {
 		if bytes.HasPrefix(entry.Event, []byte("failall")) {
@@ -342,7 +342,7 @@ type FakeDapr struct {
 	f func()
 }
 
-func (r *FakeDapr) Publish(ctx context.Context, data interface{}, topic string) error {
+func (r *FakeDapr) Publish(_ context.Context, _ interface{}, _ string) error {
 	return nil
 }
 

--- a/pkg/pubsub/system.go
+++ b/pkg/pubsub/system.go
@@ -19,7 +19,7 @@ func NewSystem() *System {
 	return &System{}
 }
 
-func (s *System) Publish(ctx context.Context, connection string, topic string, msg interface{}) error {
+func (s *System) Publish(_ context.Context, connection string, topic string, msg interface{}) error {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 	if len(s.connections) > 0 {

--- a/pkg/readiness/noop_expectations.go
+++ b/pkg/readiness/noop_expectations.go
@@ -20,17 +20,17 @@ import "k8s.io/apimachinery/pkg/runtime"
 // noopExpectations returns an Expectations that is always satisfied.
 type noopExpectations struct{}
 
-func (n noopExpectations) Expect(o runtime.Object) {}
+func (n noopExpectations) Expect(_ runtime.Object) {}
 
-func (n noopExpectations) CancelExpect(o runtime.Object) {}
+func (n noopExpectations) CancelExpect(_ runtime.Object) {}
 
-func (n noopExpectations) TryCancelExpect(o runtime.Object) bool {
+func (n noopExpectations) TryCancelExpect(_ runtime.Object) bool {
 	return false
 }
 
 func (n noopExpectations) ExpectationsDone() {}
 
-func (n noopExpectations) Observe(o runtime.Object) {}
+func (n noopExpectations) Observe(_ runtime.Object) {}
 
 func (n noopExpectations) Satisfied() bool {
 	return true

--- a/pkg/readiness/pruner/pruner_test.go
+++ b/pkg/readiness/pruner/pruner_test.go
@@ -49,7 +49,7 @@ type testResources struct {
 	k8sClient          client.Client
 }
 
-func setupTest(ctx context.Context, t *testing.T, readyTrackerClient readiness.Lister) *testResources {
+func setupTest(_ context.Context, t *testing.T, readyTrackerClient readiness.Lister) *testResources {
 	t.Helper()
 
 	mgr, wm := testutils.SetupManager(t, cfg)

--- a/pkg/watch/manager.go
+++ b/pkg/watch/manager.go
@@ -207,7 +207,7 @@ func (wm *Manager) removeWatch(ctx context.Context, r *Registrar, gvk schema.Gro
 	return wm.doRemoveWatch(ctx, r, gvk)
 }
 
-func (wm *Manager) doRemoveWatch(ctx context.Context, r *Registrar, gvk schema.GroupVersionKind) error {
+func (wm *Manager) doRemoveWatch(_ context.Context, r *Registrar, gvk schema.GroupVersionKind) error {
 	// lock acquired by caller
 
 	v, ok := wm.watchedKinds[gvk]

--- a/pkg/watch/manager_test.go
+++ b/pkg/watch/manager_test.go
@@ -50,15 +50,15 @@ func (f *fakeCacheInformer) AddEventHandler(h kcache.ResourceEventHandler) (kcac
 	return nil, nil
 }
 
-func (f *fakeCacheInformer) RemoveEventHandler(handle kcache.ResourceEventHandlerRegistration) error {
+func (f *fakeCacheInformer) RemoveEventHandler(_ kcache.ResourceEventHandlerRegistration) error {
 	return nil
 }
 
-func (f *fakeCacheInformer) AddEventHandlerWithResyncPeriod(h kcache.ResourceEventHandler, resyncPeriod time.Duration) (kcache.ResourceEventHandlerRegistration, error) {
+func (f *fakeCacheInformer) AddEventHandlerWithResyncPeriod(h kcache.ResourceEventHandler, _ time.Duration) (kcache.ResourceEventHandlerRegistration, error) {
 	return f.AddEventHandler(h)
 }
 
-func (f *fakeCacheInformer) AddIndexers(indexers kcache.Indexers) error {
+func (f *fakeCacheInformer) AddIndexers(_ kcache.Indexers) error {
 	return errors.New("not implemented")
 }
 
@@ -85,11 +85,11 @@ type fakeRemovableCache struct {
 	removeCounter int
 }
 
-func (f *fakeRemovableCache) GetInformer(_ context.Context, obj client.Object, opts ...cache.InformerGetOption) (cache.Informer, error) {
+func (f *fakeRemovableCache) GetInformer(_ context.Context, _ client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
 	return f.informer, nil
 }
 
-func (f *fakeRemovableCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+func (f *fakeRemovableCache) List(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 	switch v := list.(type) {
 	case *unstructured.UnstructuredList:
 		v.Items = f.items
@@ -99,7 +99,7 @@ func (f *fakeRemovableCache) List(ctx context.Context, list client.ObjectList, o
 	return nil
 }
 
-func (f *fakeRemovableCache) Remove(obj client.Object) error {
+func (f *fakeRemovableCache) Remove(_ client.Object) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.removeCounter++
@@ -117,7 +117,7 @@ type funcCache struct {
 	GetInformerNonBlockingFunc func(ctx context.Context, obj client.Object) (cache.Informer, error)
 }
 
-func (f *funcCache) GetInformer(ctx context.Context, obj client.Object, opts ...cache.InformerGetOption) (cache.Informer, error) {
+func (f *funcCache) GetInformer(ctx context.Context, obj client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
 	if f.GetInformerNonBlockingFunc != nil {
 		return f.GetInformerNonBlockingFunc(ctx, obj)
 	}
@@ -131,7 +131,7 @@ func (f *funcCache) List(ctx context.Context, list client.ObjectList, opts ...cl
 	return errors.New("ListFunc not initialized")
 }
 
-func (f *funcCache) Remove(obj client.Object) error {
+func (f *funcCache) Remove(_ client.Object) error {
 	return nil
 }
 

--- a/pkg/webhook/namespacelabel.go
+++ b/pkg/webhook/namespacelabel.go
@@ -45,7 +45,7 @@ var _ admission.Handler = &namespaceLabelHandler{}
 type namespaceLabelHandler struct{}
 
 //nolint:gocritic // Must accept admission.Request as a struct to satisfy Handler interface.
-func (h *namespaceLabelHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
+func (h *namespaceLabelHandler) Handle(_ context.Context, req admission.Request) admission.Response {
 	if req.Operation == admissionv1.Delete {
 		return admission.Allowed("Delete is always allowed")
 	}

--- a/pkg/webhook/policy_benchmark_test.go
+++ b/pkg/webhook/policy_benchmark_test.go
@@ -77,11 +77,11 @@ func getFiles(dir string) ([]string, error) {
 	return filePaths, nil
 }
 
-func (f *fakeNsGetter) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+func (f *fakeNsGetter) IsObjectNamespaced(_ runtime.Object) (bool, error) {
 	return false, nil
 }
 
-func (f *fakeNsGetter) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+func (f *fakeNsGetter) GroupVersionKindFor(_ runtime.Object) (schema.GroupVersionKind, error) {
 	return schema.GroupVersionKind{}, nil
 }
 

--- a/pkg/webhook/policy_test.go
+++ b/pkg/webhook/policy_test.go
@@ -213,11 +213,11 @@ type nsGetter struct {
 	testclients.NoopClient
 }
 
-func (f *nsGetter) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+func (f *nsGetter) IsObjectNamespaced(_ runtime.Object) (bool, error) {
 	return false, nil
 }
 
-func (f *nsGetter) GroupVersionKindFor(obj runtime.Object) (k8schema.GroupVersionKind, error) {
+func (f *nsGetter) GroupVersionKindFor(_ runtime.Object) (k8schema.GroupVersionKind, error) {
 	return k8schema.GroupVersionKind{}, nil
 }
 
@@ -240,11 +240,11 @@ type errorNSGetter struct {
 	testclients.NoopClient
 }
 
-func (f *errorNSGetter) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+func (f *errorNSGetter) IsObjectNamespaced(_ runtime.Object) (bool, error) {
 	return false, nil
 }
 
-func (f *errorNSGetter) GroupVersionKindFor(obj runtime.Object) (k8schema.GroupVersionKind, error) {
+func (f *errorNSGetter) GroupVersionKindFor(_ runtime.Object) (k8schema.GroupVersionKind, error) {
 	return k8schema.GroupVersionKind{}, nil
 }
 

--- a/test/clients/noop_client.go
+++ b/test/clients/noop_client.go
@@ -25,31 +25,31 @@ import (
 
 type NoopClient struct{}
 
-func (f *NoopClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+func (f *NoopClient) Get(_ context.Context, _ client.ObjectKey, _ runtime.Object) error {
 	return nil
 }
 
-func (f *NoopClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+func (f *NoopClient) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
 	return nil
 }
 
-func (f *NoopClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+func (f *NoopClient) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
 	return nil
 }
 
-func (f *NoopClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+func (f *NoopClient) Delete(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
 	return nil
 }
 
-func (f *NoopClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+func (f *NoopClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
 	return nil
 }
 
-func (f *NoopClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+func (f *NoopClient) Patch(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 	return nil
 }
 
-func (f *NoopClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+func (f *NoopClient) DeleteAllOf(_ context.Context, _ client.Object, _ ...client.DeleteAllOfOption) error {
 	return nil
 }
 
@@ -67,14 +67,14 @@ func (f *NoopClient) Scheme() *runtime.Scheme {
 
 type SubResourceNoopClient struct{}
 
-func (f *SubResourceNoopClient) Create(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+func (f *SubResourceNoopClient) Create(_ context.Context, _, _ client.Object, _ ...client.SubResourceCreateOption) error {
 	return nil
 }
 
-func (f *SubResourceNoopClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+func (f *SubResourceNoopClient) Update(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
 	return nil
 }
 
-func (f *SubResourceNoopClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+func (f *SubResourceNoopClient) Patch(_ context.Context, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
 	return nil
 }

--- a/test/clients/retry_client.go
+++ b/test/clients/retry_client.go
@@ -68,7 +68,7 @@ func retry(ctx context.Context, limiter *rate.Limiter, f func() error) error {
 	}
 }
 
-func (c *RetryClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+func (c *RetryClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 	return retry(ctx, c.Limiter, func() error {
 		return c.Client.Get(ctx, key, obj)
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
- Checkout repo prior to setup-go so `go.sum` is found and cache works as expected
- `golanglint-ci` v1.54 added support for GO 1.21
- lint fixes for `golanglint-ci` v1.54
- convert the inaccessible `ErrOldObjectIsNil` test to an `error` specific test