### PR TITLE
docs: add docs on how to contribute templates

### DIFF
--- a/website/docs/help.md
+++ b/website/docs/help.md
@@ -113,3 +113,7 @@ If you want to contribute to Helm chart, Gatekeeper auto-generates versioned Hel
 ## Contributing to Code
 
 If you want to contribute code, check out the [Developers](developers.md) guide to get started.
+
+## Contributing Templates
+
+If you'd like to contribute a Constraint Template to the [Gatekeeper Policy Library](https://open-policy-agent.github.io/gatekeeper-library/website/), you can find documentation on how to do that [here in the library's README](https://github.com/open-policy-agent/gatekeeper-library?tab=readme-ov-file#how-to-contribute-to-the-library).

--- a/website/versioned_docs/version-v3.14.x/help.md
+++ b/website/versioned_docs/version-v3.14.x/help.md
@@ -113,3 +113,7 @@ If you want to contribute to Helm chart, Gatekeeper auto-generates versioned Hel
 ## Contributing to Code
 
 If you want to contribute code, check out the [Developers](developers.md) guide to get started.
+
+## Contributing Templates
+
+If you'd like to contribute a Constraint Template to the [Gatekeeper Policy Library](https://open-policy-agent.github.io/gatekeeper-library/website/), you can find documentation on how to do that [here in the library's README](https://github.com/open-policy-agent/gatekeeper-library?tab=readme-ov-file#how-to-contribute-to-the-library).


### PR DESCRIPTION
**What this PR does / why we need it**: Issue #66 mentions needing docs on how to contribute templates upstream. This is documented in the library README, so this PR provides a link from the Gatekeeper 'contributing' docs to those docs.

