### PR TITLE
fix: Remove validation of constraint template rego

### DIFF
--- a/demo/k8s-validating-admission-policy/README.md
+++ b/demo/k8s-validating-admission-policy/README.md
@@ -5,6 +5,7 @@
 
 - Requires minimum Gatekeeper v3.14.0
 - Set `--experimental-enable-k8s-native-validation` in Gatekeeper deployments.
+- Set `--validate-template-rego=false` in Gatekeeper deployments if using Gatekeeper version 3.14.0 and later. This flag will be removed in v3.16.0, and will not be applicable in the future.
 
 ## Demo
 

--- a/demo/k8s-validating-admission-policy/README.md
+++ b/demo/k8s-validating-admission-policy/README.md
@@ -5,7 +5,6 @@
 
 - Requires minimum Gatekeeper v3.14.0
 - Set `--experimental-enable-k8s-native-validation` in Gatekeeper deployments.
-- Set `--validate-template-rego=false` in Gatekeeper deployments if using Gatekeeper version 3.14.0 and later. This flag will be removed in v3.16.0, and will not be applicable in the future.
 
 ## Demo
 

--- a/main.go
+++ b/main.go
@@ -405,12 +405,6 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, sw *watch.Controlle
 
 	cfArgs := []constraintclient.Opt{constraintclient.Targets(&target.K8sValidationTarget{})}
 
-	if *webhook.ValidateTemplateRego && *enableK8sCel {
-		err := fmt.Errorf("cannot validate template rego when K8s cel is enabled. Please disable K8s cel by setting --experimental-enable-k8s-native-validation=false or disable template rego validation by setting --validate-template-rego=false")
-		setupLog.Error(err, "unable to set up OPA and K8s native drivers")
-		return err
-	}
-
 	if *enableK8sCel {
 		// initialize K8sValidation
 		k8sDriver, err := k8scel.New()

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -68,9 +68,7 @@ import (
 // https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#response
 const httpStatusWarning = 299
 
-var (
-	maxServingThreads = flag.Int("max-serving-threads", -1, "cap the number of threads handling non-trivial requests, -1 caps the number of threads to GOMAXPROCS. Defaults to -1.")
-)
+var maxServingThreads = flag.Int("max-serving-threads", -1, "cap the number of threads handling non-trivial requests, -1 caps the number of threads to GOMAXPROCS. Defaults to -1.")
 
 func init() {
 	AddToManagerFuncs = append(AddToManagerFuncs, AddPolicyWebhook)

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -30,7 +30,6 @@ import (
 	externaldataUnversioned "github.com/open-policy-agent/frameworks/constraint/pkg/apis/externaldata/unversioned"
 	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers"
-	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/rego"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
 	rtypes "github.com/open-policy-agent/frameworks/constraint/pkg/types"
@@ -70,8 +69,7 @@ import (
 const httpStatusWarning = 299
 
 var (
-	ValidateTemplateRego = flag.Bool("validate-template-rego", true, "validate Rego code for constraint templates. Defaults to true. This flag will be removed in Gatekeeper v3.16 and cannot be used if `experimental-enable-k8s-native-validation` flag is set. Use Gator to validate in shift left manner to avoid impact with this behavior change.). Use Gator to validate in shift left manner to avoid impact with this behavior change.")
-	maxServingThreads    = flag.Int("max-serving-threads", -1, "cap the number of threads handling non-trivial requests, -1 caps the number of threads to GOMAXPROCS. Defaults to -1.")
+	maxServingThreads = flag.Int("max-serving-threads", -1, "cap the number of threads handling non-trivial requests, -1 caps the number of threads to GOMAXPROCS. Defaults to -1.")
 )
 
 func init() {
@@ -396,21 +394,6 @@ func (h *validationHandler) validateTemplate(ctx context.Context, req *admission
 	_, err = h.opa.CreateCRD(ctx, unversioned)
 	if err != nil {
 		return true, err
-	}
-
-	// TODO: This is a temporary check for rego to give enough time to users to migrate to gator for validation. To be removed before 3.16.
-	if *ValidateTemplateRego {
-		// Create a temporary Driver and attempt to add the Template to it. This
-		// ensures the Rego code both parses and compiles.
-		d, err := rego.New()
-		if err != nil {
-			return false, fmt.Errorf("unable to create Driver: %w", err)
-		}
-
-		err = d.AddTemplate(ctx, unversioned)
-		if err != nil {
-			return true, err
-		}
 	}
 
 	return false, nil

--- a/website/docs/constrainttemplates.md
+++ b/website/docs/constrainttemplates.md
@@ -8,7 +8,6 @@ ConstraintTemplates define a way to validate some set of Kubernetes objects in G
 1. [Rego](https://www.openpolicyagent.org/docs/latest/#rego) code that defines a policy violation
 2. The schema of the accompanying `Constraint` object, which represents an instantiation of a `ConstraintTemplate`
 
-> ❗ Validation of Rego for constraint templates is enabled by default. Set `validate-template-rego` flag to `false` to disable rego validation if you want to use `experimental-enable-k8s-native-validation` Kubernetes CEL based policies as well. This flag will be removed from Gatekeeper 3.16 and later, please make use of [Gator](https://open-policy-agent.github.io/gatekeeper/website/docs/gator) to validate constraint template in shift left manner to avoid any impact with this behavior change.
 
 ## `v1` Constraint Template
 

--- a/website/docs/validating-admission-policy.md
+++ b/website/docs/validating-admission-policy.md
@@ -6,7 +6,7 @@ title: Integration with Kubernetes Validating Admission Policy
 `Feature State`: Gatekeeper version v3.13+ (pre-alpha)
 
 > ❗ This feature is pre-alpha, subject to change (feedback is welcome!). It is disabled by default. To enable the feature,
-> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image). Do not use this feature with `validate-template-rego` flag enabled, as the policies with CEL would get rejected with Rego compilation error.
+> set the `experimental-enable-k8s-native-validation` flag to true and use the [development build of Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/#deploying-a-release-using-development-image).
 
 ## Description
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing the flag to validate rego in constraint template.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #3027

