### PR TITLE
fix: fixing metrics views

### DIFF
--- a/pkg/audit/stats_reporter.go
+++ b/pkg/audit/stats_reporter.go
@@ -23,6 +23,17 @@ const (
 
 var auditDurationM metric.Float64Histogram
 
+func init() {
+	view.Register(sdkmetric.NewView(
+		sdkmetric.Instrument{Name: auditDurationMetricName},
+		sdkmetric.Stream{
+			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: []float64{1 * 60, 3 * 60, 5 * 60, 10 * 60, 15 * 60, 20 * 60, 40 * 60, 80 * 60, 160 * 60, 320 * 60},
+			},
+		},
+	))
+}
+
 func (r *reporter) observeTotalViolations(_ context.Context, o metric.Int64Observer) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -116,14 +127,6 @@ func newStatsReporter() (*reporter, error) {
 		return nil, err
 	}
 
-	view.Register(sdkmetric.NewView(
-		sdkmetric.Instrument{Name: auditDurationMetricName},
-		sdkmetric.Stream{
-			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{1 * 60, 3 * 60, 5 * 60, 10 * 60, 15 * 60, 20 * 60, 40 * 60, 80 * 60, 160 * 60, 320 * 60},
-			},
-		},
-	))
 	return r, nil
 }
 

--- a/pkg/controller/constrainttemplate/stats_reporter.go
+++ b/pkg/controller/constrainttemplate/stats_reporter.go
@@ -28,6 +28,17 @@ var (
 	ingestDurationM metric.Float64Histogram
 )
 
+func init() {
+	view.Register(sdkmetric.NewView(
+		sdkmetric.Instrument{Name: ingestDuration},
+		sdkmetric.Stream{
+			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 1, 2, 3, 4, 5},
+			},
+		},
+	))
+}
+
 func (r *reporter) reportIngestDuration(ctx context.Context, status metrics.Status, d time.Duration) error {
 	ingestDurationM.Record(ctx, d.Seconds(), metric.WithAttributes(attribute.String(statusKey, string(status))))
 	ingestCountM.Add(ctx, 1, metric.WithAttributes(attribute.String(statusKey, string(status))))
@@ -65,14 +76,6 @@ func newStatsReporter() *reporter {
 	if err != nil {
 		panic(err)
 	}
-	view.Register(sdkmetric.NewView(
-		sdkmetric.Instrument{Name: ingestDuration},
-		sdkmetric.Stream{
-			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 1, 2, 3, 4, 5},
-			},
-		},
-	))
 	return r
 }
 

--- a/pkg/controller/mutators/stats_reporter.go
+++ b/pkg/controller/mutators/stats_reporter.go
@@ -49,6 +49,17 @@ type reporter struct {
 	mutatorsInConflict  int
 }
 
+func init() {
+	view.Register(sdkmetric.NewView(
+		sdkmetric.Instrument{Name: mutatorIngestionDurationMetricName},
+		sdkmetric.Stream{
+			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+				Boundaries: []float64{0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05},
+			},
+		},
+	))
+}
+
 // NewStatsReporter creates a reporter for webhook metrics.
 func NewStatsReporter() StatsReporter {
 	r := &reporter{}
@@ -90,14 +101,6 @@ func NewStatsReporter() StatsReporter {
 		panic(err)
 	}
 
-	view.Register(sdkmetric.NewView(
-		sdkmetric.Instrument{Name: mutatorIngestionDurationMetricName},
-		sdkmetric.Stream{
-			Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-				Boundaries: []float64{0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05},
-			},
-		},
-	))
 	return r
 }
 

--- a/pkg/syncutil/stats_reporter.go
+++ b/pkg/syncutil/stats_reporter.go
@@ -147,6 +147,18 @@ type Reporter struct {
 	now        func() float64
 }
 
+func init() {
+	view.Register(
+		sdkmetric.NewView(
+			sdkmetric.Instrument{Name: syncDurationMetricName},
+			sdkmetric.Stream{
+				Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+					Boundaries: []float64{0.0001, 0.0002, 0.0003, 0.0004, 0.0005, 0.0006, 0.0007, 0.0008, 0.0009, 0.001, 0.002, 0.003, 0.004, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05},
+				},
+			},
+		))
+}
+
 // NewStatsReporter creates a reporter for sync metrics.
 func NewStatsReporter() (*Reporter, error) {
 	if r == nil {
@@ -166,16 +178,6 @@ func NewStatsReporter() (*Reporter, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		view.Register(
-			sdkmetric.NewView(
-				sdkmetric.Instrument{Name: syncDurationMetricName},
-				sdkmetric.Stream{
-					Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-						Boundaries: []float64{0.0001, 0.0002, 0.0003, 0.0004, 0.0005, 0.0006, 0.0007, 0.0008, 0.0009, 0.001, 0.002, 0.003, 0.004, 0.005, 0.01, 0.02, 0.03, 0.04, 0.05},
-					},
-				},
-			))
 	}
 	return r, nil
 }

--- a/pkg/webhook/stats_reporter.go
+++ b/pkg/webhook/stats_reporter.go
@@ -40,6 +40,27 @@ type StatsReporter interface {
 // reporter implements StatsReporter interface.
 type reporter struct{}
 
+func init() {
+	view.Register(
+		sdkmetric.NewView(
+			sdkmetric.Instrument{Name: validationRequestDurationMetricName},
+			sdkmetric.Stream{
+				Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+					Boundaries: []float64{0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 2.5, 3},
+				},
+			},
+		),
+		sdkmetric.NewView(
+			sdkmetric.Instrument{Name: mutationRequestDurationMetricName},
+			sdkmetric.Stream{
+				Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
+					Boundaries: []float64{0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 2.5, 3},
+				},
+			},
+		),
+	)
+}
+
 // newStatsReporter creaters a reporter for webhook metrics.
 func newStatsReporter() (StatsReporter, error) {
 	if r == nil {
@@ -74,25 +95,6 @@ func newStatsReporter() (StatsReporter, error) {
 		if err != nil {
 			return nil, err
 		}
-
-		view.Register(
-			sdkmetric.NewView(
-				sdkmetric.Instrument{Name: validationRequestDurationMetricName},
-				sdkmetric.Stream{
-					Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-						Boundaries: []float64{0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 2.5, 3},
-					},
-				},
-			),
-			sdkmetric.NewView(
-				sdkmetric.Instrument{Name: mutationRequestDurationMetricName},
-				sdkmetric.Stream{
-					Aggregation: sdkmetric.AggregationExplicitBucketHistogram{
-						Boundaries: []float64{0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008, 0.009, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.5, 2, 2.5, 3},
-					},
-				},
-			),
-		)
 	}
 	return r, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Order of registering views in otel metrics was no in orientation and is causing views to used default configurations instead of custom.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #3303

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
