### PR TITLE
feat: Include oldObject and admission request metadata in expansion

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -704,7 +704,7 @@ func (am *Manager) reviewObjects(ctx context.Context, kind string, folderCount i
 			}
 
 			// Expand object and review any resultant resources
-			base := &mutationtypes.Mutable{
+			base := &expansion.Expandable{
 				Object:    objFile,
 				Namespace: ns,
 				Username:  "",

--- a/pkg/expansion/fixtures/fixtures.go
+++ b/pkg/expansion/fixtures/fixtures.go
@@ -622,4 +622,61 @@ spec:
     ports:
     - containerPort: '80'
 `
+
+	GeneratorOldCronJob = `
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: my-cronjob
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - args:
+            - "/bin/sh"
+            image: nginx:1.14.0
+            imagePullPolicy: Always
+            name: nginx
+            ports:
+            - containerPort: '8080'
+`
+
+	ResultantOldJob = `
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-cronjob-job
+  namespace: default
+spec:
+  template:
+    spec:
+      containers:
+      - args:
+        - "/bin/sh"
+        image: nginx:1.14.0
+        imagePullPolicy: Always
+        name: nginx
+        ports:
+        - containerPort: '8080'
+`
+
+	ResultantRecursiveOldPod = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-cronjob-job-pod
+  namespace: default
+spec:
+  containers:
+  - args:
+    - "/bin/sh"
+    image: nginx:1.14.0
+    imagePullPolicy: Always
+    name: nginx
+    ports:
+    - containerPort: '8080'
+`
 )

--- a/pkg/expansion/types.go
+++ b/pkg/expansion/types.go
@@ -1,0 +1,33 @@
+package expansion
+
+import (
+	mutationtypes "github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// Expandable represents an expandable object and its metadata.
+type Expandable struct {
+	// Object is the object to be expanded.
+	Object *unstructured.Unstructured
+
+	// OldObject is the old version of the object (if applicable) to be expanded.
+	OldObject *unstructured.Unstructured
+
+	// Namespace is the namespace of the expandable object.
+	Namespace *corev1.Namespace
+
+	// Username is the name of the user who initiates
+	// admission request of the expandable object.
+	Username string
+
+	// Source specifies which types of resources the mutator should be applied to
+	Source mutationtypes.SourceType
+}
+
+type Resultant struct {
+	Obj               *unstructured.Unstructured
+	OldObj            *unstructured.Unstructured
+	TemplateName      string
+	EnforcementAction string
+}

--- a/pkg/gator/expand/expand.go
+++ b/pkg/gator/expand/expand.go
@@ -86,18 +86,24 @@ func NewExpander(resources []*unstructured.Unstructured) (*Expander, error) {
 func (er *Expander) Expand(resource *unstructured.Unstructured) ([]*expansion.Resultant, error) {
 	ns, _ := er.NamespaceForResource(resource)
 
-	// Mutate the base resource before expanding it
-	base := &types.Mutable{
+	// Mutate the mutable resource before expanding it
+	mutable := &types.Mutable{
 		Object:    resource,
 		Namespace: ns,
 		Username:  "",
 		Source:    types.SourceTypeOriginal,
 	}
-	if _, err := er.mutSystem.Mutate(base); err != nil {
+	if _, err := er.mutSystem.Mutate(mutable); err != nil {
 		return nil, fmt.Errorf("error mutating base resource %s: %w", resource.GetName(), err)
 	}
 
-	resultants, err := er.expSystem.Expand(base)
+	expandable := &expansion.Expandable{
+		Object:    mutable.Object,
+		Namespace: mutable.Namespace,
+		Username:  mutable.Username,
+		Source:    mutable.Source,
+	}
+	resultants, err := er.expSystem.Expand(expandable)
 	if err != nil {
 		return nil, fmt.Errorf("error expanding resource %s: %w", resource.GetName(), err)
 	}

--- a/pkg/readiness/ready_tracker_test.go
+++ b/pkg/readiness/ready_tracker_test.go
@@ -385,7 +385,7 @@ func Test_ExpansionTemplate(t *testing.T) {
 		panic(fmt.Errorf("error converting deployment to unstructured: %w", err))
 	}
 	u := unstructured.Unstructured{Object: o}
-	m := mutationtypes.Mutable{
+	m := expansion.Expandable{
 		Object:    &u,
 		Namespace: testNS,
 		Username:  "",


### PR DESCRIPTION
**What this PR does / why we need it**: Update the expansion logic to propagate the `oldObject` and `userInfo` fields from the admission request (along with a few other fields)

I've been trying to set up a policy that allows users to edit fields of a specific workload resource (eg. a `Deployment`) but prevents them from modifying the `Pod` template within that resource, as that could allow them to alter the workload and lead to security issues (eg. modifying the container image that is executed)

Currently, the expansion logic only expands the `object` field, meaning it's not possibly to detect if a policy is operating on a `CREATE` or an `UPDATE` request, and act accordingly. Additionally, because it doesn't propagate the `userInfo` field, it's not possible to make policies that depend on which user made the change

**Special notes for your reviewer**: I've tried to add tests to `pkg/expansion`, but wasn't sure how to go about setting up a test in `pkg/webhook` to confirm all fields from the admission request are propagated as expected