### PR TITLE
fix(helm): avoid GitOps diff on matchConditions

### DIFF
--- a/cmd/build/helmify/main.go
+++ b/cmd/build/helmify/main.go
@@ -109,14 +109,14 @@ func (ks *kindSet) Write() error {
 
 			if name == "validation.gatekeeper.sh" {
 				matchConditions := "  matchConditions: {{ toYaml .Values.validatingWebhookMatchConditions | nindent 4 }}"
-				replace := fmt.Sprintf("  {{- if ge (int .Capabilities.KubeVersion.Minor) 28 }}\n%s\n  {{- end }}", matchConditions)
+				replace := fmt.Sprintf("  {{- if and .Values.validatingWebhookMatchConditions (ge (int .Capabilities.KubeVersion.Minor) 28) }}\n%s\n  {{- end }}", matchConditions)
 				obj = "{{- if not .Values.disableValidatingWebhook }}\n" + strings.Replace(obj, matchConditions, replace, 1) + end + "\n"
 				fileName = fmt.Sprintf("gatekeeper-validating-webhook-configuration-%s.yaml", strings.ToLower(kind))
 			}
 
 			if name == "mutation.gatekeeper.sh" {
 				matchConditions := "  matchConditions: {{ toYaml .Values.mutatingWebhookMatchConditions | nindent 4 }}"
-				replace := fmt.Sprintf("  {{- if ge (int .Capabilities.KubeVersion.Minor) 28 }}\n%s\n  {{- end }}", matchConditions)
+				replace := fmt.Sprintf("  {{- if and .Values.mutatingWebhookMatchConditions and (ge (int .Capabilities.KubeVersion.Minor) 28) }}\n%s\n  {{- end }}", matchConditions)
 				obj = "{{- if not .Values.disableMutation }}\n" + strings.Replace(obj, matchConditions, replace, 1) + end + "\n"
 				fileName = fmt.Sprintf("gatekeeper-mutating-webhook-configuration-%s.yaml", strings.ToLower(kind))
 			}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -24,7 +24,7 @@ webhooks:
       path: /v1/mutate
     {{- end }}
   failurePolicy: {{ .Values.mutatingWebhookFailurePolicy }}
-  {{- if ge (int .Capabilities.KubeVersion.Minor) 28 }}
+  {{- if and .Values.mutatingWebhookMatchConditions and (ge (int .Capabilities.KubeVersion.Minor) 28) }}
   matchConditions: {{ toYaml .Values.mutatingWebhookMatchConditions | nindent 4 }}
   {{- end }}
   matchPolicy: Exact

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -24,7 +24,7 @@ webhooks:
       path: /v1/admit
     {{- end }}
   failurePolicy: {{ .Values.validatingWebhookFailurePolicy }}
-  {{- if ge (int .Capabilities.KubeVersion.Minor) 28 }}
+  {{- if and .Values.validatingWebhookMatchConditions (ge (int .Capabilities.KubeVersion.Minor) 28) }}
   matchConditions: {{ toYaml .Values.validatingWebhookMatchConditions | nindent 4 }}
   {{- end }}
   matchPolicy: Exact


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/open-policy-agent/gatekeeper/pull/3343 introduced `matchConditions` support in webhooks, which is great.

However for Kubernetes < 1.30, this feature is behind a feature gate, not enabled by default.

in our setup, this causes ArgoCD to show a diff, and the app is `OutOfSync`

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
