### PR TITLE
fix: include cel flags on audit deployment

### DIFF
--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -184,6 +184,8 @@ spec:
             - HELMSUBST_DEPLOYMENT_AUDIT_LOGFILE
             - --disable-cert-rotation={{ or .Values.audit.disableCertRotation .Values.externalCertInjection.enabled }}
             - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL }}
+            - --experimental-enable-k8s-native-validation={{ .Values.enableK8sNativeValidation }}
+            - --vap-enforcement={{ .Values.vapEnforcement }}
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
           HELMSUBST_AUDIT_CONTROLLER_MANAGER_DEPLOYMENT_IMAGE_RELEASE: ""
           ports:

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -87,6 +87,8 @@ spec:
         {{- end }}
         - --disable-cert-rotation={{ or .Values.audit.disableCertRotation .Values.externalCertInjection.enabled }}
         - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL }}
+        - --experimental-enable-k8s-native-validation={{ .Values.enableK8sNativeValidation }}
+        - --vap-enforcement={{ .Values.vapEnforcement }}
         command:
         - /manager
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:
Noticed when testing the oss chart with Helm, the cel enablement flags were not available on Audit

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
