### PR TITLE
chore: fixing deprecating function in dapr fake test client

### DIFF
--- a/pkg/pubsub/dapr/fake_dapr_client.go
+++ b/pkg/pubsub/dapr/fake_dapr_client.go
@@ -32,7 +32,7 @@ const (
 
 var logger = log.New(os.Stdout, "", 0)
 
-func getTestClient(ctx context.Context) (client daprClient.Client, closer func()) {
+func getTestClient(_ context.Context) (client daprClient.Client, closer func()) {
 	s := grpc.NewServer()
 	pb.RegisterDaprServer(s, &testDaprServer{
 		state:                       make(map[string][]byte),
@@ -46,11 +46,15 @@ func getTestClient(ctx context.Context) (client daprClient.Client, closer func()
 		}
 	}()
 
+	const serviceAddress = "localhost:50051"
+
 	d := grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
 		return l.Dial()
 	})
 
-	c, err := grpc.DialContext(ctx, "", d, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	opts := []grpc.DialOption{d, grpc.WithTransportCredentials(insecure.NewCredentials())}
+	// Replace "" with `serviceAddress` to specify the service to connect to
+	c, err := grpc.NewClient(serviceAddress, opts...)
 	if err != nil {
 		logger.Fatalf("failed to dial test context: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
updating dapr fake client to use non deprecated function for initializing clients. Should fix ci-error on #3446 

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
