### PR TITLE
fix: fixing error reporting for templates without CEL

### DIFF
--- a/pkg/controller/constraint/constraint_controller_test.go
+++ b/pkg/controller/constraint/constraint_controller_test.go
@@ -443,14 +443,14 @@ func TestShouldGenerateVAP(t *testing.T) {
 			},
 			vapDefault: true,
 			expected:   false,
-			wantErr:    false,
+			wantErr:    true,
 		},
 		{
 			name:       "template with only Rego engine",
 			template:   makeTemplateWithRegoEngine(),
 			vapDefault: true,
 			expected:   false,
-			wantErr:    false,
+			wantErr:    true,
 		},
 		{
 			name:       "Rego and CEL template with generateVAP set to true",

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -379,7 +379,7 @@ func (r *ReconcileConstraintTemplate) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 	generateVap, err := constraint.ShouldGenerateVAP(unversionedCT)
-	if err != nil {
+	if err != nil || !errors.Is(err, celSchema.ErrCodeNotDefined) {
 		logger.Error(err, "generateVap error")
 	}
 	logger.Info("generateVap", "r.generateVap", generateVap)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes sure that VAPBinding generation error are reported only on constraint that belong to CT where `Code[_].engine == K8sNativeValidation`


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #3492 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
