### PR TITLE
refactor: Move SetObjOnDelete to target handler

### DIFF
--- a/pkg/gator/verify/runner.go
+++ b/pkg/gator/verify/runner.go
@@ -361,7 +361,7 @@ func (r *Runner) validateAndReviewAdmissionReviewRequest(ctx context.Context, c 
 	}
 
 	req := &admission.Request{AdmissionRequest: *ar.Request}
-	if err := util.SetObjectOnDelete(req); err != nil {
+	if err := target.SetObjectOnDelete(req); err != nil {
 		return nil, fmt.Errorf("%w: %w", gator.ErrInvalidK8sAdmissionReview, err)
 	}
 

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -149,6 +149,12 @@ func (h *validationHandler) Handle(ctx context.Context, req admission.Request) a
 		return vResp
 	}
 
+	if err := target.SetObjectOnDelete(&req); err != nil {
+		vResp := admission.Denied(err.Error())
+		vResp.Result.Code = http.StatusInternalServerError
+		return vResp
+	}
+
 	if userErr, err := h.validateGatekeeperResources(ctx, &req); err != nil {
 		var code int32
 		if userErr {


### PR DESCRIPTION
**What this PR does / why we need it**:
refactor: Move the obj == oldObject on DELETE logic to the TargetHandler instead of the webhook validation handler

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #
fixes #3441 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
