### PR TITLE
fix: liniting error in gatekeeper-controller-manager-poddisruptionbudget.yaml, cherry-pick (#3519)

### DIFF
--- a/cmd/build/helmify/main.go
+++ b/cmd/build/helmify/main.go
@@ -157,7 +157,7 @@ func (ks *kindSet) Write() error {
 			}
 
 			if name == "gatekeeper-controller-manager" && kind == "PodDisruptionBudget" {
-				obj = strings.Replace(obj, "apiVersion: policy/v1", "{{- $v1 := .Capabilities.APIVersions.Has \"policy/v1/PodDisruptionBudget\" -}}\n{{- $v1beta1 := .Capabilities.APIVersions.Has \"policy/v1beta1/PodDisruptionBudget\" -}}\napiVersion: policy/v1{{- if and (not $v1) $v1beta1 -}}beta1{{- end }}", 1)
+				obj = strings.Replace(obj, "apiVersion: policy/v1", "{{ $v1 := .Capabilities.APIVersions.Has \"policy/v1/PodDisruptionBudget\" -}}\n{{ $v1beta1 := .Capabilities.APIVersions.Has \"policy/v1beta1/PodDisruptionBudget\" -}}\napiVersion: policy/v1{{- if and (not $v1) $v1beta1 -}}beta1{{- end }}", 1)
 			}
 
 			if name == "gatekeeper-manager-role" && kind == "ClusterRole" {

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 ---
-{{- $v1 := .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
-{{- $v1beta1 := .Capabilities.APIVersions.Has "policy/v1beta1/PodDisruptionBudget" -}}
+{{ $v1 := .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" -}}
+{{ $v1beta1 := .Capabilities.APIVersions.Has "policy/v1beta1/PodDisruptionBudget" -}}
 apiVersion: policy/v1{{- if and (not $v1) $v1beta1 -}}beta1{{- end }}
 kind: PodDisruptionBudget
 metadata:


### PR DESCRIPTION
Signed-off-by: Thomas Berreis <thomas@berreis.de>
Co-authored-by: Jaydipkumar Arvindbhai Gabani <gabanijaydip@gmail.com>
(cherry picked from commit 3f457329ebacdb248f2ab2135b188e530362bcf0)

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
