### PR TITLE
fix: helm warning when setting NetworkPolicy ingress rule(s)

### DIFF
--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -224,7 +224,7 @@ controllerManager:
   extraRules: []
   networkPolicy:
     enabled: false
-    ingress: { }
+    ingress: []
       # - from:
       #   - ipBlock:
       #       cidr: 0.0.0.0/0

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -224,7 +224,7 @@ controllerManager:
   extraRules: []
   networkPolicy:
     enabled: false
-    ingress: { }
+    ingress: []
       # - from:
       #   - ipBlock:
       #       cidr: 0.0.0.0/0


### PR DESCRIPTION
**What this PR does / why we need it**:

When setting custom ingress rules for the NetworkPolicy via `controllerManager.networkPolicy.ingress`, helm spits out a warning, because the default value is set to `{ }` instead of an array.

Example Values:
```yaml
controllerManager:
  networkPolicy:
    enabled: true
    ingress:
      - from:
        - ipBlock:
          cidr: 0.0.0.0/0
```

Helm Warning:
```
coalesce.go:286: warning: cannot overwrite table with non table for gatekeeper.controllerManager.networkPolicy.ingress (map[])
```

This fixes it by setting the default value to an empty array.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
