### PR TITLE
chore: adding annotation to generate VAPB right away once the waiting window is over to protect against clock skews

### DIFF
--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -65,7 +65,7 @@ import (
 
 const (
 	BlockVAPBGenerationUntilAnnotation = "gatekeeper.sh/block-vapb-generation-until"
-	VAPBGenerationAnnotation           = "gatekeeper.sh/vapb-generation"
+	VAPBGenerationAnnotation           = "gatekeeper.sh/vapb-generation-state"
 	ErrGenerateVAPBState               = "error"
 	GeneratedVAPBState                 = "generated"
 	WaitVAPBState                      = "waiting"

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -304,7 +304,7 @@ func TestReconcile(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		logger.Info("Running Test: block-vapb-generation-until annotation should not be present")
+		logger.Info("Running Test: vapb annotation should not be present on constraint template")
 		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
 			return true
 		}, func() error {
@@ -314,6 +314,9 @@ func TestReconcile(t *testing.T) {
 			}
 			if _, ok := ct.GetAnnotations()[constraint.BlockVAPBGenerationUntilAnnotation]; ok {
 				return fmt.Errorf("unexpected %s annotations on CT", constraint.BlockVAPBGenerationUntilAnnotation)
+			}
+			if _, ok := ct.GetAnnotations()[constraint.VAPBGenerationAnnotation]; ok {
+				return fmt.Errorf("unexpected %s annotations on CT", constraint.VAPBGenerationAnnotation)
 			}
 			return nil
 		})
@@ -726,7 +729,6 @@ func TestReconcile(t *testing.T) {
 			if timestamp == "" {
 				return fmt.Errorf("expected %s annotations on CT", constraint.BlockVAPBGenerationUntilAnnotation)
 			}
-			// check if vapbinding resource exists now
 			if err := c.Get(ctx, types.NamespacedName{Name: cstr.GetName()}, cstr); err != nil {
 				return err
 			}
@@ -742,6 +744,9 @@ func TestReconcile(t *testing.T) {
 			vapBindingCreationTime := vapBinding.GetCreationTimestamp().Time
 			if vapBindingCreationTime.Before(blockTime) {
 				return fmt.Errorf("VAPBinding should be created after default wait")
+			}
+			if ct.GetAnnotations()[constraint.VAPBGenerationAnnotation] == constraint.VAPBGenerationUnblocked {
+				return fmt.Errorf("expected %s annotations on CT to be unblocked", constraint.VAPBGenerationAnnotation)
 			}
 			return nil
 		})
@@ -810,7 +815,7 @@ func TestReconcile(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		logger.Info("Running test: VAP ConstraintTemplate should have block-VAPB-generation-until annotation")
+		logger.Info("Running test: VAP ConstraintTemplate should have VAPB annotation")
 		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
 			return true
 		}, func() error {
@@ -820,6 +825,9 @@ func TestReconcile(t *testing.T) {
 			}
 			if ct.GetAnnotations()[constraint.BlockVAPBGenerationUntilAnnotation] == "" {
 				return fmt.Errorf("expected %s annotations on CT", constraint.BlockVAPBGenerationUntilAnnotation)
+			}
+			if ct.GetAnnotations()[constraint.VAPBGenerationAnnotation] == "" {
+				return fmt.Errorf("expected %s annotations on CT", constraint.VAPBGenerationAnnotation)
 			}
 			return nil
 		})
@@ -870,6 +878,9 @@ func TestReconcile(t *testing.T) {
 			vapBindingCreationTime := vapBinding.GetCreationTimestamp().Time
 			if vapBindingCreationTime.Before(blockTime) {
 				return fmt.Errorf("VAPBinding should not be created before the timestamp")
+			}
+			if ct.GetAnnotations()[constraint.VAPBGenerationAnnotation] == constraint.VAPBGenerationUnblocked {
+				return fmt.Errorf("expected %s annotations on CT to be unblocked", constraint.VAPBGenerationAnnotation)
 			}
 			if err := c.Delete(ctx, cstr); err != nil {
 				return err

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -735,6 +735,8 @@ func TestReconcile(t *testing.T) {
 			// check if vapbinding resource exists now
 			vapBinding := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
 			if err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gatekeeper-%s", cstr.GetName())}, vapBinding); err != nil {
+				// Since tests retries 3000 times at 100 retries per second, adding sleep makes sure that this test gets covarage time > 30s to cover the default wait.
+				time.Sleep(10 * time.Millisecond)
 				return err
 			}
 			blockTime, err := time.Parse(time.RFC3339, timestamp)
@@ -873,6 +875,8 @@ func TestReconcile(t *testing.T) {
 			// check if vapbinding resource exists now
 			vapBinding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
 			if err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gatekeeper-%s", cstr.GetName())}, vapBinding); err != nil {
+				// Since tests retries 3000 times at 100 retries per second, adding sleep makes sure that this test gets covarage time > 30s to cover the default wait.
+				time.Sleep(10 * time.Millisecond)
 				return err
 			}
 			vapBindingCreationTime := vapBinding.GetCreationTimestamp().Time

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -745,7 +745,7 @@ func TestReconcile(t *testing.T) {
 			if vapBindingCreationTime.Before(blockTime) {
 				return fmt.Errorf("VAPBinding should be created after default wait")
 			}
-			if ct.GetAnnotations()[constraint.VAPBGenerationAnnotation] == constraint.VAPBGenerationUnblocked {
+			if ct.GetAnnotations()[constraint.VAPBGenerationAnnotation] != constraint.VAPBGenerationUnblocked {
 				return fmt.Errorf("expected %s annotations on CT to be unblocked", constraint.VAPBGenerationAnnotation)
 			}
 			return nil
@@ -879,7 +879,7 @@ func TestReconcile(t *testing.T) {
 			if vapBindingCreationTime.Before(blockTime) {
 				return fmt.Errorf("VAPBinding should not be created before the timestamp")
 			}
-			if ct.GetAnnotations()[constraint.VAPBGenerationAnnotation] == constraint.VAPBGenerationUnblocked {
+			if ct.GetAnnotations()[constraint.VAPBGenerationAnnotation] != constraint.VAPBGenerationUnblocked {
 				return fmt.Errorf("expected %s annotations on CT to be unblocked", constraint.VAPBGenerationAnnotation)
 			}
 			if err := c.Delete(ctx, cstr); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #3683 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
