### PR TITLE
fix: parse namespace from oldObject when processing a DELETE operation

### DIFF
--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -150,6 +150,7 @@ func (h *webhookHandler) tracingLevel(ctx context.Context, req *admission.Reques
 }
 
 func (h *webhookHandler) skipExcludedNamespace(req *admissionv1.AdmissionRequest, excludedProcess process.Process) (bool, error) {
+	var data []byte
 	if req.Operation == admissionv1.Delete {
 		// oldObject is the existing object.
 		// It is null for DELETE operations in API servers prior to v1.15.0.
@@ -163,11 +164,13 @@ func (h *webhookHandler) skipExcludedNamespace(req *admissionv1.AdmissionRequest
 		// object is the new object being admitted.
 		// It is null for DELETE operations.
 		// https://github.com/kubernetes/kubernetes/pull/76346
-		req.Object = req.OldObject
+		data = req.OldObject.Raw
+	} else {
+		data = req.Object.Raw
 	}
 
 	obj := &unstructured.Unstructured{}
-	if _, _, err := deserializer.Decode(req.Object.Raw, nil, obj); err != nil {
+	if _, _, err := deserializer.Decode(data, nil, obj); err != nil {
 		return false, err
 	}
 	obj.SetNamespace(req.Namespace)

--- a/pkg/webhook/common.go
+++ b/pkg/webhook/common.go
@@ -48,6 +48,7 @@ var (
 	runtimeScheme                      = k8sruntime.NewScheme()
 	codecs                             = serializer.NewCodecFactory(runtimeScheme)
 	deserializer                       = codecs.UniversalDeserializer()
+	errOldObjectIsNil                  = errors.New("oldObject cannot be nil for DELETE operations")
 	disableEnforcementActionValidation = flag.Bool("disable-enforcementaction-validation", false, "disable validation of the enforcementAction and scopedEnforcementActions field of a constraint")
 	logDenies                          = flag.Bool("log-denies", false, "log detailed info on each deny")
 	emitAdmissionEvents                = flag.Bool("emit-admission-events", false, "(alpha) emit Kubernetes events for each admission violation")
@@ -149,6 +150,22 @@ func (h *webhookHandler) tracingLevel(ctx context.Context, req *admission.Reques
 }
 
 func (h *webhookHandler) skipExcludedNamespace(req *admissionv1.AdmissionRequest, excludedProcess process.Process) (bool, error) {
+	if req.Operation == admissionv1.Delete {
+		// oldObject is the existing object.
+		// It is null for DELETE operations in API servers prior to v1.15.0.
+		// https://github.com/kubernetes/website/pull/14671
+		if req.OldObject.Raw == nil {
+			return false, errOldObjectIsNil
+		}
+
+		// For admission webhooks registered for DELETE operations on k8s built APIs or CRDs,
+		// the apiserver now sends the existing object as admissionRequest.Request.OldObject to the webhook
+		// object is the new object being admitted.
+		// It is null for DELETE operations.
+		// https://github.com/kubernetes/kubernetes/pull/76346
+		req.Object = req.OldObject
+	}
+
 	obj := &unstructured.Unstructured{}
 	if _, _, err := deserializer.Decode(req.Object.Raw, nil, obj); err != nil {
 		return false, err


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**

#3743 

**Special notes for your reviewer**:

I think that substituting req.Object for req.OldObject is the simplest solution, and it prevents us from modifying the logic in https://github.com/open-policy-agent/gatekeeper/blob/v3.18.0/pkg/webhook/policy.go#L172.

let me know if you want me to do it in another way.