### PR TITLE
chore: Add specification about sync annotation to docs

### DIFF
--- a/website/versioned_docs/version-v3.13.x/sync.md
+++ b/website/versioned_docs/version-v3.13.x/sync.md
@@ -35,8 +35,59 @@ You can install this config with the following command:
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/demo/basic/sync.yaml
 ```
-
-Once data is synced into OPA, rules can access the cached data under the `data.inventory` document.
+Once data is synced, ConstraintTemplates can access the cached data under the `data.inventory` document. ConstraintTemplates must specify the Group/Version/Kinds that they will need in a `metadata.gatekeeper.sh/requires-sync-data` annotation. This is specified in a format like this:
+```
+[
+  [ // Requirement 1
+    { // Clause 1
+      "groups": ["group1", group2"]
+      "versions": ["version1", "version2", "version3"]
+      "kinds": ["kind1", "kind2"]
+    },
+    { // Clause 2
+      "groups": ["group3", group4"]
+      "versions": ["version3", "version4"]
+      "kinds": ["kind3", "kind4"]
+    }
+  ],
+  [ // Requirement 2
+    { // Clause 1
+      "groups": ["group5"]
+      "versions": ["version5"]
+      "kinds": ["kind5"]
+    }
+  ]
+]
+```
+Each clause within the requirement is treated as a logical OR. So "group1/version1/kind1" OR "group2/version2/kind2" OR "group2/version1/kind1", etc.
+So, for example, if a Constraint Template required to sync PodDisruptionBudgets, Deployments, and StatefulSets, the annotation would be as follows:
+```
+metadata.gatekeeper.sh/requires-sync-data: |
+      "[
+        [
+          {
+            "groups": ["policy"],
+            "versions": ["v1"],
+            "kinds": ["PodDisruptionBudget"]
+          }
+        ],
+        [
+          {
+            "groups": ["apps"],
+            "versions": ["v1"],
+            "kinds": ["Deployment"]
+          }
+        ],
+        [
+          {
+            "groups": ["apps"],
+            "versions": ["v1"],
+            "kinds": ["StatefulSet"]
+          }
+        ]
+      ]
+      "
+```
 
 The `data.inventory` document has the following format:
 

--- a/website/versioned_docs/version-v3.14.x/sync.md
+++ b/website/versioned_docs/version-v3.14.x/sync.md
@@ -35,8 +35,59 @@ You can install this config with the following command:
 ```sh
 kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/demo/basic/sync.yaml
 ```
-
-Once data is synced into OPA, rules can access the cached data under the `data.inventory` document.
+Once data is synced, ConstraintTemplates can access the cached data under the `data.inventory` document. ConstraintTemplates must specify the Group/Version/Kinds that they will need in a `metadata.gatekeeper.sh/requires-sync-data` annotation. This is specified in a format like this:
+```
+[
+  [ // Requirement 1
+    { // Clause 1
+      "groups": ["group1", group2"]
+      "versions": ["version1", "version2", "version3"]
+      "kinds": ["kind1", "kind2"]
+    },
+    { // Clause 2
+      "groups": ["group3", group4"]
+      "versions": ["version3", "version4"]
+      "kinds": ["kind3", "kind4"]
+    }
+  ],
+  [ // Requirement 2
+    { // Clause 1
+      "groups": ["group5"]
+      "versions": ["version5"]
+      "kinds": ["kind5"]
+    }
+  ]
+]
+```
+Each clause within the requirement is treated as a logical OR. So "group1/version1/kind1" OR "group2/version2/kind2" OR "group2/version1/kind1", etc.
+So, for example, if a Constraint Template required to sync PodDisruptionBudgets, Deployments, and StatefulSets, the annotation would be as follows:
+```
+metadata.gatekeeper.sh/requires-sync-data: |
+      "[
+        [
+          {
+            "groups": ["policy"],
+            "versions": ["v1"],
+            "kinds": ["PodDisruptionBudget"]
+          }
+        ],
+        [
+          {
+            "groups": ["apps"],
+            "versions": ["v1"],
+            "kinds": ["Deployment"]
+          }
+        ],
+        [
+          {
+            "groups": ["apps"],
+            "versions": ["v1"],
+            "kinds": ["StatefulSet"]
+          }
+        ]
+      ]
+      "
+```
 
 The `data.inventory` document has the following format:
 

--- a/website/versioned_docs/version-v3.16.x/sync.md
+++ b/website/versioned_docs/version-v3.16.x/sync.md
@@ -75,8 +75,59 @@ kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/
 
 ### Accessing replicated data
 
-Once data is synced, ConstraintTemplates can access the cached data under the `data.inventory` document.
-
+Once data is synced, ConstraintTemplates can access the cached data under the `data.inventory` document. ConstraintTemplates must specify the Group/Version/Kinds that they will need in a `metadata.gatekeeper.sh/requires-sync-data` annotation. This is specified in a format like this:
+```
+[
+  [ // Requirement 1
+    { // Clause 1
+      "groups": ["group1", group2"]
+      "versions": ["version1", "version2", "version3"]
+      "kinds": ["kind1", "kind2"]
+    },
+    { // Clause 2
+      "groups": ["group3", group4"]
+      "versions": ["version3", "version4"]
+      "kinds": ["kind3", "kind4"]
+    }
+  ],
+  [ // Requirement 2
+    { // Clause 1
+      "groups": ["group5"]
+      "versions": ["version5"]
+      "kinds": ["kind5"]
+    }
+  ]
+]
+```
+Each clause within the requirement is treated as a logical OR. So "group1/version1/kind1" OR "group2/version2/kind2" OR "group2/version1/kind1", etc.
+So, for example, if a Constraint Template required to sync PodDisruptionBudgets, Deployments, and StatefulSets, the annotation would be as follows:
+```
+metadata.gatekeeper.sh/requires-sync-data: |
+      "[
+        [
+          {
+            "groups": ["policy"],
+            "versions": ["v1"],
+            "kinds": ["PodDisruptionBudget"]
+          }
+        ],
+        [
+          {
+            "groups": ["apps"],
+            "versions": ["v1"],
+            "kinds": ["Deployment"]
+          }
+        ],
+        [
+          {
+            "groups": ["apps"],
+            "versions": ["v1"],
+            "kinds": ["StatefulSet"]
+          }
+        ]
+      ]
+      "
+```
 The `data.inventory` document has the following format:
   * For cluster-scoped objects: `data.inventory.cluster[<groupVersion>][<kind>][<name>]`
      * Example referencing the Gatekeeper namespace: `data.inventory.cluster["v1"].Namespace["gatekeeper"]`


### PR DESCRIPTION
…rameter

When I was debugging a constraint template with @JaydipGabani, we found that the ConstraintTemplate also required the sync annotation, in addition to the SyncSet resource. This just updates the docs to reflect that

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
