### PR TITLE
chore: auto-tagging once the PR is merged

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,28 @@
+name: create_tag
+on: 
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  create_tag:
+    name: "Create tag"
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release-pr') && startsWith(github.event.pull_request.title, format('chore{0} Prepare', ':'))
+    runs-on: ubuntu-22.04
+    steps:
+    - name: "Set release tag"
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github.event.pull_request.labels.*.name) }}
+      run: |
+        RELEASE_TAG=$(echo "$GITHUB_CONTEXT" | jq '.[1]' | tr -d '"')
+        echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_ENV
+    
+    - name: Check out code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 #v1.7.2
+      with:
+        tag: ${{ env.RELEASE_TAG }}
+        tag_exists_error: false


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
