### PR TITLE
ci: cleaning up disk in release workflow to avoid running out of space

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,7 @@ jobs:
         run: |
             # Filter out local helm-gh-pages image so we don't delete it
             docker system prune -a -f --filter "label!=org.opencontainers.image.source=https://github.com/stefanprodan/alpine-base"
+            # Cleaning up unused tools as per the suggested workaround - https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
             sudo rm -rf /usr/share/dotnet
             sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,8 @@ jobs:
         run: |
             # Filter out local helm-gh-pages image so we don't delete it
             docker system prune -a -f --filter "label!=org.opencontainers.image.source=https://github.com/stefanprodan/alpine-base"
+            sudo rm -rf /usr/share/dotnet
+            sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,7 @@ jobs:
             # Filter out local helm-gh-pages image so we don't delete it
             docker system prune -a -f --filter "label!=org.opencontainers.image.source=https://github.com/stefanprodan/alpine-base"
             # Cleaning up unused tools as per the suggested workaround - https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
+            # Partially cleaning up the tools directory, if we are still running out of space, we can remove everything suggested in the workaround
             sudo rm -rf /usr/share/dotnet
             sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
             # Filter out local helm-gh-pages image so we don't delete it
             docker system prune -a -f --filter "label!=org.opencontainers.image.source=https://github.com/stefanprodan/alpine-base"
             # Cleaning up unused tools as per the suggested workaround - https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-            # Partially cleaning up the tools directory, if we are still running out of space, we can remove everything suggested in the workaround
+            # Partially cleaning up from suggested workaround. If we are still running out of space, we can remove everything suggested in the workaround
             sudo rm -rf /usr/share/dotnet
             sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
To avoid running out of space while building and releasing artifacts - https://github.com/open-policy-agent/gatekeeper/actions/runs/14099177360/attempts/2.
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
