### PR TITLE
chore: removing gator test alpha note.

### DIFF
--- a/cmd/gator/test/test.go
+++ b/cmd/gator/test/test.go
@@ -32,9 +32,6 @@ cat manifest.yaml | gator test
 # Output structured violations data
 gator test --filename="manifest.yaml" --output=json
 
-Note: The alpha "gator test" has been renamed to "gator verify".  "gator
-verify" verifies individual Constraint Templates against suites of tests, where "gator
-test" evaluates sets of resources against sets of Constraints and Templates.`
 )
 
 var Cmd = &cobra.Command{


### PR DESCRIPTION
**What this PR does / why we need it**: I'm creating this PR to get rid of a note that is displayed when a user runs `gator test --help`. It is believed that this note is no longer needed since there are no plans of merge or deprecate `gator verify` or `gator test`.

**Special notes for your reviewer**: Let met know your thoughts if this Not is still needed. Thanks!
