### PR TITLE
fix: fixing disk test in CI

### DIFF
--- a/pkg/export/disk/disk_test.go
+++ b/pkg/export/disk/disk_test.go
@@ -826,7 +826,7 @@ func TestGetFilesSortedByModTimeAsc(t *testing.T) {
 		{
 			name: "Error walking directory",
 			setup: func(dir string) error {
-				return os.Chmod(dir, 0o000)
+				return os.RemoveAll(dir)
 			},
 			expectedFile:  "",
 			expectedFiles: 0,


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes CI tests in frameworks - https://github.com/open-policy-agent/frameworks/actions/runs/15057381210/job/42325988959#step:8:31941.

Currently framework changes are failing due to it running with root permissions and be able to walk into dir, so updating test to remove directory and force an error regardless of the user permissions during filewalk.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
