### PR TITLE
Add "ExtraObjects" object

### DIFF
--- a/charts/gatekeeper/templates/extra-manifests.yaml
+++ b/charts/gatekeeper/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -298,3 +298,4 @@ externalCertInjection:
 serviceAccount:
   gatekeeperAdmin:
     create: true
+extraObjects: []


### PR DESCRIPTION
### Description

This PR adds support for injecting extra Kubernetes manifests into the Helm release via the `extraManifests` parameter, similar to the approach used in the [Argo CD Helm chart](https://github.com/argoproj/argo-helm/blob/main/charts/argo-cd/templates/extra-manifests.yaml).

#### Changes:
- Introduced a new Helm value: `extraManifests`, which allows users to define additional YAML manifests inline.
- Added a new template `extra-manifests.yaml` that renders user-provided manifests.
- Enables advanced customization and GitOps integration use cases without requiring chart modification or forking.

#### Example usage:
```yaml
extraManifests:
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: custom-config
    data:
      foo: bar
