### PR TITLE
fix: clean up gator version output and CLI descriptions

### DIFF
--- a/cmd/gator/gator.go
+++ b/cmd/gator/gator.go
@@ -17,7 +17,7 @@ var commands = []*cobra.Command{
 	test.Cmd,
 	expand.Cmd,
 	sync.Cmd,
-	k8sVersion.WithFont("alligator2"),
+	k8sVersion.WithFont("dotmatrix"),
 }
 
 func init() {
@@ -28,6 +28,15 @@ func init() {
 var rootCmd = &cobra.Command{
 	Use:   "gator subcommand",
 	Short: "gator is a suite of authorship tools for Gatekeeper",
+	Long: `
+Gator is a suite of authorship tools designed to improve the developer experience when working with Gatekeeper.
+It supports:
+  - Validating Kubernetes manifests against constraints
+  - Expanding Rego-based constraints for debugging
+  - Running policy tests locally
+  - Verifying ConstraintTemplates and Constraints before deploying
+
+Use it to catch issues early, test policies offline, and ensure compliance.`,
 }
 
 func main() {

--- a/vendor/sigs.k8s.io/release-utils/version/command.go
+++ b/vendor/sigs.k8s.io/release-utils/version/command.go
@@ -46,7 +46,12 @@ func version(fontName string) *cobra.Command {
 	var outputJSON bool
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Prints the version",
+		Short: "Show detailed build info (commit, Go version, platform). Use -v for summary.",
+		Long: `
+Displays internal build metadata about this gator binary, including:
+	- Git commit, tree state, and build date
+	- Go compiler and platform info
+	- Git tag version if available (shows 'devel' for development builds)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := GetVersionInfo()
 			v.Name = cmd.Root().Name()
@@ -66,6 +71,8 @@ func version(fontName string) *cobra.Command {
 				cmd.Println(out)
 			} else {
 				cmd.Println(v.String())
+				cmd.Println("\nTip: Use 'gator -v' for a concise version summary.")
+				cmd.Println("     Use 'gator version --json' for JSON format output.")
 			}
 			return nil
 		},

--- a/vendor/sigs.k8s.io/release-utils/version/version.go
+++ b/vendor/sigs.k8s.io/release-utils/version/version.go
@@ -192,14 +192,14 @@ func (i *Info) String() string {
 		}
 		_, _ = fmt.Fprint(w, "\n\n")
 	}
-
-	_, _ = fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
-	_, _ = fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
-	_, _ = fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
-	_, _ = fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
-	_, _ = fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
-	_, _ = fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
-	_, _ = fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+	_, _ = fmt.Fprint(w, "Version Summary:\t\n", "")
+	_, _ = fmt.Fprintf(w, "   GitVersion:\t%s\n", i.GitVersion)
+	_, _ = fmt.Fprintf(w, "   GitCommit:\t%s\n", i.GitCommit)
+	_, _ = fmt.Fprintf(w, "   GitTreeState:\t%s\n", i.GitTreeState)
+	_, _ = fmt.Fprintf(w, "   BuildDate:\t%s\n", i.BuildDate)
+	_, _ = fmt.Fprintf(w, "   GoVersion:\t%s\n", i.GoVersion)
+	_, _ = fmt.Fprintf(w, "   Compiler:\t%s\n", i.Compiler)
+	_, _ = fmt.Fprintf(w, "   Platform:\t%s\n", i.Platform)
 
 	_ = w.Flush()
 	return b.String()


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the gator version and --help command outputs to make them more user-friendly and informative. Adds helpful descriptions for new users and clarifies what each version field means. Also updates the root command with a long description to better explain what Gator does.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #
https://github.com/open-policy-agent/gatekeeper/issues/4015


**Special notes for your reviewer**:

Hey @JaydipGabani @sidewinder12s,
I’ve made some changes to improve clarity and make it easier for users to understand. 

`gator version`
![Image](https://github.com/user-attachments/assets/f1b79011-871e-46e0-bb4c-198a680350e2)

`gator version --help`
![Image](https://github.com/user-attachments/assets/54468fe7-0166-4bd8-93c9-88d8f7e36d7f)

Add long description in root command
`gator`
![Image](https://github.com/user-attachments/assets/4e0fc6f6-f6c0-4c9d-a1bc-cd8835688756)

Please let me know if you like these changes or if you’d like me to make any further updates.
