### PR TITLE
Update version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ KIND_VERSION ?= 0.27.0
 KIND_CLUSTER_FILE ?= ""
 # note: k8s version pinned since KIND image availability lags k8s releases
 KUBERNETES_VERSION ?= 1.30.0
-KUSTOMIZE_VERSION ?= 3.8.9
+KUSTOMIZE_VERSION ?= 5.6.0
 BATS_VERSION ?= 1.8.2
 ORAS_VERSION ?= 0.16.0
 BATS_TESTS_FILE ?= test/bats/test.bats

--- a/cmd/gator/gator.go
+++ b/cmd/gator/gator.go
@@ -17,7 +17,7 @@ var commands = []*cobra.Command{
 	test.Cmd,
 	expand.Cmd,
 	sync.Cmd,
-	k8sVersion.WithFont("alligator2"),
+	k8sVersion.WithFont("dotmatrix"),
 }
 
 func init() {
@@ -28,6 +28,15 @@ func init() {
 var rootCmd = &cobra.Command{
 	Use:   "gator subcommand",
 	Short: "gator is a suite of authorship tools for Gatekeeper",
+	Long: `
+Gator is a suite of authorship tools designed to improve the developer experience when working with Gatekeeper.
+It supports:
+  - Validating Kubernetes manifests against constraints
+  - Expanding Rego-based constraints for debugging
+  - Running policy tests locally
+  - Verifying ConstraintTemplates and Constraints before deploying
+
+Use it to catch issues early, test policies offline, and ensure compliance.`,
 }
 
 func main() {

--- a/vendor/sigs.k8s.io/release-utils/version/command.go
+++ b/vendor/sigs.k8s.io/release-utils/version/command.go
@@ -46,7 +46,12 @@ func version(fontName string) *cobra.Command {
 	var outputJSON bool
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Prints the version",
+		Short: "Show detailed build info (commit, Go version, platform). Use -v for summary.",
+		Long: `
+Displays internal build metadata about this gator binary, including:
+	- Git commit, tree state, and build date
+	- Go compiler and platform info
+	- Git tag version if available (shows 'devel' for development builds)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			v := GetVersionInfo()
 			v.Name = cmd.Root().Name()
@@ -66,6 +71,8 @@ func version(fontName string) *cobra.Command {
 				cmd.Println(out)
 			} else {
 				cmd.Println(v.String())
+				cmd.Println("\nTip: Use 'gator -v' for a concise version summary.")
+				cmd.Println("     Use 'gator version --json' for JSON format output.")
 			}
 			return nil
 		},

--- a/vendor/sigs.k8s.io/release-utils/version/version.go
+++ b/vendor/sigs.k8s.io/release-utils/version/version.go
@@ -192,14 +192,14 @@ func (i *Info) String() string {
 		}
 		_, _ = fmt.Fprint(w, "\n\n")
 	}
-
-	_, _ = fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
-	_, _ = fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
-	_, _ = fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
-	_, _ = fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
-	_, _ = fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
-	_, _ = fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
-	_, _ = fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+	_, _ = fmt.Fprint(w, "Version Summary:\t\n", "")
+	_, _ = fmt.Fprintf(w, "   GitVersion:\t%s\n", i.GitVersion)
+	_, _ = fmt.Fprintf(w, "   GitCommit:\t%s\n", i.GitCommit)
+	_, _ = fmt.Fprintf(w, "   GitTreeState:\t%s\n", i.GitTreeState)
+	_, _ = fmt.Fprintf(w, "   BuildDate:\t%s\n", i.BuildDate)
+	_, _ = fmt.Fprintf(w, "   GoVersion:\t%s\n", i.GoVersion)
+	_, _ = fmt.Fprintf(w, "   Compiler:\t%s\n", i.Compiler)
+	_, _ = fmt.Fprintf(w, "   Platform:\t%s\n", i.Platform)
 
 	_ = w.Flush()
 	return b.String()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the Kustomize version used in the Gatekeeper Makefile from v3.8.9 to v5.6.0.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #
https://github.com/open-policy-agent/gatekeeper/issues/4033

**Special notes for your reviewer**:
@JaydipGabani @grosser please review it.  
![Screenshot from 2025-07-02 23-27-39](https://github.com/user-attachments/assets/5640ef26-b1cc-49b2-b02f-a8080a49f3c0)


