### PR TITLE
Add global validating webhook rule

### DIFF
--- a/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -119,12 +119,12 @@ webhooks:
     - namespaces
   sideEffects: None
   timeoutSeconds: {{ .Values.validatingWebhookTimeoutSeconds }}
-{{- if not .Values.disableGlobalValidatingWebhook }}
+{{- if not .Values.disableValidatingGlobalWebhook }}
 - admissionReviewVersions:
   - v1
   - v1beta1
   clientConfig:
-    {{- if .Values.validatingGlobalWebhookURL }}
+    {{- if .Values.validatingWebhookURL }}
     url: https://{{ .Values.validatingWebhookURL }}/v1/admit
     {{- else }}
     service:

--- a/charts/gatekeeper/values.yaml
+++ b/charts/gatekeeper/values.yaml
@@ -18,6 +18,10 @@ validatingWebhookMatchConditions: []
 validatingWebhookCheckIgnoreFailurePolicy: Fail
 validatingWebhookCustomRules: {}
 validatingWebhookURL: null
+disableValidatingGlobalWebhook: true
+validatingGlobalWebhookTimeoutSeconds: 3
+validatingGlobalWebhookFailurePolicy: Ignore
+validatingGlobalWebhookCustomRules: {}
 enableDeleteOperations: false
 enableConnectOperations: false
 enableExternalData: true
@@ -67,23 +71,26 @@ postUpgrade:
       pullPolicy: IfNotPresent
       pullSecrets: []
     extraNamespaces: []
-    podSecurity: ["pod-security.kubernetes.io/audit=restricted",
-      "pod-security.kubernetes.io/audit-version=latest",
-      "pod-security.kubernetes.io/warn=restricted",
-      "pod-security.kubernetes.io/warn-version=latest",
-      "pod-security.kubernetes.io/enforce=restricted",
-      "pod-security.kubernetes.io/enforce-version=v1.24"]
+    podSecurity:
+      [
+        "pod-security.kubernetes.io/audit=restricted",
+        "pod-security.kubernetes.io/audit-version=latest",
+        "pod-security.kubernetes.io/warn=restricted",
+        "pod-security.kubernetes.io/warn-version=latest",
+        "pod-security.kubernetes.io/enforce=restricted",
+        "pod-security.kubernetes.io/enforce-version=v1.24",
+      ]
     extraAnnotations: {}
     priorityClassName: ""
   affinity: {}
   tolerations: []
-  nodeSelector: {kubernetes.io/os: linux}
+  nodeSelector: { kubernetes.io/os: linux }
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -101,12 +108,15 @@ postInstall:
       pullPolicy: IfNotPresent
       pullSecrets: []
     extraNamespaces: []
-    podSecurity: ["pod-security.kubernetes.io/audit=restricted",
-      "pod-security.kubernetes.io/audit-version=latest",
-      "pod-security.kubernetes.io/warn=restricted",
-      "pod-security.kubernetes.io/warn-version=latest",
-      "pod-security.kubernetes.io/enforce=restricted",
-      "pod-security.kubernetes.io/enforce-version=v1.24"]
+    podSecurity:
+      [
+        "pod-security.kubernetes.io/audit=restricted",
+        "pod-security.kubernetes.io/audit-version=latest",
+        "pod-security.kubernetes.io/warn=restricted",
+        "pod-security.kubernetes.io/warn-version=latest",
+        "pod-security.kubernetes.io/enforce=restricted",
+        "pod-security.kubernetes.io/enforce-version=v1.24",
+      ]
     extraAnnotations: {}
     priorityClassName: ""
   probeWebhook:
@@ -122,12 +132,12 @@ postInstall:
     priorityClassName: ""
   affinity: {}
   tolerations: []
-  nodeSelector: {kubernetes.io/os: linux}
+  nodeSelector: { kubernetes.io/os: linux }
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -147,13 +157,13 @@ preUninstall:
     priorityClassName: ""
   affinity: {}
   tolerations: []
-  nodeSelector: {kubernetes.io/os: linux}
+  nodeSelector: { kubernetes.io/os: linux }
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -198,7 +208,7 @@ controllerManager:
           weight: 100
   topologySpreadConstraints: []
   tolerations: []
-  nodeSelector: {kubernetes.io/os: linux}
+  nodeSelector: { kubernetes.io/os: linux }
   resources:
     limits:
       memory: 512Mi
@@ -209,7 +219,7 @@ controllerManager:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -221,7 +231,8 @@ controllerManager:
   extraRules: []
   networkPolicy:
     enabled: false
-    ingress: []
+    ingress:
+      []
       # - from:
       #   - ipBlock:
       #       cidr: 0.0.0.0/0
@@ -240,7 +251,7 @@ audit:
   podLabels: {}
   affinity: {}
   tolerations: []
-  nodeSelector: {kubernetes.io/os: linux}
+  nodeSelector: { kubernetes.io/os: linux }
   resources:
     limits:
       memory: 512Mi
@@ -251,7 +262,7 @@ audit:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 999
     runAsNonRoot: true
@@ -265,13 +276,13 @@ audit:
 crds:
   affinity: {}
   tolerations: []
-  nodeSelector: {kubernetes.io/os: linux}
+  nodeSelector: { kubernetes.io/os: linux }
   resources: {}
   securityContext:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
     readOnlyRootFilesystem: true
     runAsGroup: 65532
     runAsNonRoot: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an optional global validating webhook endpoint admissionreview entry in the validatingwebhookconfiguration.
The use case is to allow end users to specify some resources that should be watched globally (like namespaces) for custom admission policies.

Current webhook configuration allows some namespaces to be excluded which helps in configuring gatekeeper to not prevent and eks full worker node cycle.
However, it prevents the users from specifying some resources that should always be admission reviewed.
Like for example only admin users should be able to patch certain resources.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #4042 
<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->
**Are you making changes to Gatekeeper Helm chart?**
If this example chart config is acceptable I would be willing to move it's creation into the custom logic under the cmd folder.

**Special notes for your reviewer**:
