### PR TITLE
docs: update link to install ORAS CLI

### DIFF
--- a/website/docs/gator.md
+++ b/website/docs/gator.md
@@ -641,7 +641,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.11.x/gator.md
+++ b/website/versioned_docs/version-v3.11.x/gator.md
@@ -336,7 +336,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.12.x/gator.md
+++ b/website/versioned_docs/version-v3.12.x/gator.md
@@ -336,7 +336,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.13.x/gator.md
+++ b/website/versioned_docs/version-v3.13.x/gator.md
@@ -336,7 +336,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.14.x/gator.md
+++ b/website/versioned_docs/version-v3.14.x/gator.md
@@ -507,7 +507,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.15.x/gator.md
+++ b/website/versioned_docs/version-v3.15.x/gator.md
@@ -507,7 +507,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.16.x/gator.md
+++ b/website/versioned_docs/version-v3.16.x/gator.md
@@ -511,7 +511,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.17.x/gator.md
+++ b/website/versioned_docs/version-v3.17.x/gator.md
@@ -511,7 +511,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.18.x/gator.md
+++ b/website/versioned_docs/version-v3.18.x/gator.md
@@ -626,7 +626,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.19.x/gator.md
+++ b/website/versioned_docs/version-v3.19.x/gator.md
@@ -633,7 +633,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 

--- a/website/versioned_docs/version-v3.20.x/gator.md
+++ b/website/versioned_docs/version-v3.20.x/gator.md
@@ -641,7 +641,7 @@ ignored. `gator` does not enforce any file schema in the artifacts; it only
 requires that all files of the support extensions describe valid Kubernetes
 resources.
 
-We recommend using the [Oras CLI](https://oras.land/cli/) to create OCI
+We recommend using the [Oras CLI](https://oras.land/docs/installation) to create OCI
 artifacts. For example, to push a bundle containing the 2 local directories
 `constraints` and `template_library`:
 


### PR DESCRIPTION
**What this PR does / why we need it**: inexperienced developers who are new to gatekeeper, may want to install ORAS, and having a working link helps encourage them and builds a community for gatekeeper

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
(didn't raise any issues as it's just a url update)

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
