### PR TITLE
fix: bumping kubectl and golang through cherry-picks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-bookworm@sha256:ee7ff13d239350cc9b962c1bf371a60f3c32ee00eaaf0d0f0489713a87e51a67 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm@sha256:81dc45d05a7444ead8c92a389621fafabc8e40f8fd1a19d7e5df14e61e98bc1a AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/crd.Dockerfile
+++ b/crd.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM registry.k8s.io/kubectl:v1.33.3 AS builder
+FROM --platform=$TARGETPLATFORM registry.k8s.io/kubectl:v1.34.0 AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/crd.Dockerfile
+++ b/crd.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM registry.k8s.io/kubectl:v1.33.2 AS builder
+FROM --platform=$TARGETPLATFORM registry.k8s.io/kubectl:v1.33.3 AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/gator.Dockerfile
+++ b/gator.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-bookworm@sha256:ee7ff13d239350cc9b962c1bf371a60f3c32ee00eaaf0d0f0489713a87e51a67 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-bookworm@sha256:81dc45d05a7444ead8c92a389621fafabc8e40f8fd1a19d7e5df14e61e98bc1a AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes CVEs in 3.20 image - 

<img width="994" height="328" alt="image" src="https://github.com/user-attachments/assets/16cf942d-61f5-41c4-b492-e7b2c484b033" />


**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
