### PR TITLE
fix: Refactor retries for disk driver failed connection removal to be exponential.

### DIFF
--- a/pkg/export/disk/disk.go
+++ b/pkg/export/disk/disk.go
@@ -426,11 +426,11 @@ func (r *Writer) retryFailedConnections() {
 		} else {
 			log.Info("Failed to close connection on retry", "connection", name, "error", err, "attempt", failedConn.RetryCount+1)
 
+			failedConn.RetryCount++
 			delay := time.Duration(float64(baseRetryDelay) * math.Pow(retryBackoffFactor, float64(failedConn.RetryCount)))
 			if maxRetryDelay > 0 && delay > maxRetryDelay {
 				delay = maxRetryDelay
 			}
-			failedConn.RetryCount++
 			// Apply jitter to the retry delay
 			delay = wait.Jitter(delay, Jitter)
 			failedConn.NextRetryAt = now.Add(delay)


### PR DESCRIPTION

**What this PR does / why we need it**:
The existing retry logic for failed connection removals, which used a linearly increasing delay between attempts, has been updated to use an exponential backoff strategy with a jitter factor, aligning it with the Kubernetes implementation.
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #
Fixes https://github.com/open-policy-agent/gatekeeper/issues/4023