### PR TITLE
fix: remove preserveUnknownFields to avoid OutOfSync in ArgoCD

### DIFF
--- a/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: AssignList
     plural: assign
     singular: assign
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: AssignImageList
     plural: assignimage
     singular: assignimage
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: AssignMetadataList
     plural: assignmetadata
     singular: assignmetadata
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/charts/gatekeeper/crds/config-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/config-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/charts/gatekeeper/crds/configpodstatus-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/configpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConfigPodStatusList
     plural: configpodstatuses
     singular: configpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/charts/gatekeeper/crds/connection-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/connection-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConnectionList
     plural: connections
     singular: connection
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConnectionPodStatusList
     plural: connectionpodstatuses
     singular: connectionpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConstraintPodStatusList
     plural: constraintpodstatuses
     singular: constraintpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConstraintTemplateList
     plural: constrainttemplates
     singular: constrainttemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConstraintTemplatePodStatusList
     plural: constrainttemplatepodstatuses
     singular: constrainttemplatepodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ExpansionTemplateList
     plural: expansiontemplate
     singular: expansiontemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ExpansionTemplatePodStatusList
     plural: expansiontemplatepodstatuses
     singular: expansiontemplatepodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ModifySetList
     plural: modifyset
     singular: modifyset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: MutatorPodStatusList
     plural: mutatorpodstatuses
     singular: mutatorpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/charts/gatekeeper/crds/provider-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/provider-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ProviderList
     plural: providers
     singular: provider
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - deprecated: true

--- a/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ProviderPodStatusList
     plural: providerpodstatuses
     singular: providerpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
+++ b/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: SyncSetList
     plural: syncsets
     singular: syncset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/config/crd/patches/preserve_unknown_fields_false.yaml
+++ b/config/crd/patches/preserve_unknown_fields_false.yaml
@@ -1,6 +1,0 @@
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: foobar
-spec:
-  preserveUnknownFields: false

--- a/deploy/gatekeeper.yaml
+++ b/deploy/gatekeeper.yaml
@@ -45,7 +45,6 @@ spec:
     listKind: AssignList
     plural: assign
     singular: assign
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -1130,7 +1129,6 @@ spec:
     listKind: AssignImageList
     plural: assignimage
     singular: assignimage
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
@@ -1473,7 +1471,6 @@ spec:
     listKind: AssignMetadataList
     plural: assignmetadata
     singular: assignmetadata
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -2408,7 +2405,6 @@ spec:
     listKind: ConfigPodStatusList
     plural: configpodstatuses
     singular: configpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -2480,7 +2476,6 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -2632,7 +2627,6 @@ spec:
     listKind: ConnectionPodStatusList
     plural: connectionpodstatuses
     singular: connectionpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -2711,7 +2705,6 @@ spec:
     listKind: ConnectionList
     plural: connections
     singular: connection
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -2810,7 +2803,6 @@ spec:
     listKind: ConstraintPodStatusList
     plural: constraintpodstatuses
     singular: constraintpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -2908,7 +2900,6 @@ spec:
     listKind: ConstraintTemplatePodStatusList
     plural: constrainttemplatepodstatuses
     singular: constrainttemplatepodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -2998,7 +2989,6 @@ spec:
     listKind: ConstraintTemplateList
     plural: constrainttemplates
     singular: constrainttemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -3428,7 +3418,6 @@ spec:
     listKind: ExpansionTemplateList
     plural: expansiontemplate
     singular: expansiontemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
@@ -3681,7 +3670,6 @@ spec:
     listKind: ExpansionTemplatePodStatusList
     plural: expansiontemplatepodstatuses
     singular: expansiontemplatepodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -3756,7 +3744,6 @@ spec:
     listKind: ModifySetList
     plural: modifyset
     singular: modifyset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4748,7 +4735,6 @@ spec:
     listKind: MutatorPodStatusList
     plural: mutatorpodstatuses
     singular: mutatorpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -4828,7 +4814,6 @@ spec:
     listKind: ProviderPodStatusList
     plural: providerpodstatuses
     singular: providerpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -4922,7 +4907,6 @@ spec:
     listKind: ProviderList
     plural: providers
     singular: provider
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - deprecated: true
@@ -5135,7 +5119,6 @@ spec:
     listKind: SyncSetList
     plural: syncsets
     singular: syncset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: AssignList
     plural: assign
     singular: assign
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/manifest_staging/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: AssignImageList
     plural: assignimage
     singular: assignimage
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: AssignMetadataList
     plural: assignmetadata
     singular: assignmetadata
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/manifest_staging/charts/gatekeeper/crds/config-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/config-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/manifest_staging/charts/gatekeeper/crds/configpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/configpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConfigPodStatusList
     plural: configpodstatuses
     singular: configpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/manifest_staging/charts/gatekeeper/crds/connection-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/connection-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConnectionList
     plural: connections
     singular: connection
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/manifest_staging/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConnectionPodStatusList
     plural: connectionpodstatuses
     singular: connectionpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1

--- a/manifest_staging/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConstraintPodStatusList
     plural: constraintpodstatuses
     singular: constraintpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/manifest_staging/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConstraintTemplateList
     plural: constrainttemplates
     singular: constrainttemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ConstraintTemplatePodStatusList
     plural: constrainttemplatepodstatuses
     singular: constrainttemplatepodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/manifest_staging/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ExpansionTemplateList
     plural: expansiontemplate
     singular: expansiontemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/manifest_staging/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ExpansionTemplatePodStatusList
     plural: expansiontemplatepodstatuses
     singular: expansiontemplatepodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/manifest_staging/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ModifySetList
     plural: modifyset
     singular: modifyset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: MutatorPodStatusList
     plural: mutatorpodstatuses
     singular: mutatorpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/manifest_staging/charts/gatekeeper/crds/provider-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/provider-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ProviderList
     plural: providers
     singular: provider
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - deprecated: true

--- a/manifest_staging/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ProviderPodStatusList
     plural: providerpodstatuses
     singular: providerpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/manifest_staging/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: SyncSetList
     plural: syncsets
     singular: syncset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -45,7 +45,6 @@ spec:
     listKind: AssignList
     plural: assign
     singular: assign
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -1130,7 +1129,6 @@ spec:
     listKind: AssignImageList
     plural: assignimage
     singular: assignimage
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
@@ -1473,7 +1471,6 @@ spec:
     listKind: AssignMetadataList
     plural: assignmetadata
     singular: assignmetadata
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -2408,7 +2405,6 @@ spec:
     listKind: ConfigPodStatusList
     plural: configpodstatuses
     singular: configpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -2480,7 +2476,6 @@ spec:
     listKind: ConfigList
     plural: configs
     singular: config
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -2632,7 +2627,6 @@ spec:
     listKind: ConnectionPodStatusList
     plural: connectionpodstatuses
     singular: connectionpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -2711,7 +2705,6 @@ spec:
     listKind: ConnectionList
     plural: connections
     singular: connection
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -2810,7 +2803,6 @@ spec:
     listKind: ConstraintPodStatusList
     plural: constraintpodstatuses
     singular: constraintpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -2908,7 +2900,6 @@ spec:
     listKind: ConstraintTemplatePodStatusList
     plural: constrainttemplatepodstatuses
     singular: constrainttemplatepodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -2998,7 +2989,6 @@ spec:
     listKind: ConstraintTemplateList
     plural: constrainttemplates
     singular: constrainttemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -3428,7 +3418,6 @@ spec:
     listKind: ExpansionTemplateList
     plural: expansiontemplate
     singular: expansiontemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1
@@ -3681,7 +3670,6 @@ spec:
     listKind: ExpansionTemplatePodStatusList
     plural: expansiontemplatepodstatuses
     singular: expansiontemplatepodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -3756,7 +3744,6 @@ spec:
     listKind: ModifySetList
     plural: modifyset
     singular: modifyset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1
@@ -4748,7 +4735,6 @@ spec:
     listKind: MutatorPodStatusList
     plural: mutatorpodstatuses
     singular: mutatorpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -4828,7 +4814,6 @@ spec:
     listKind: ProviderPodStatusList
     plural: providerpodstatuses
     singular: providerpodstatus
-  preserveUnknownFields: false
   scope: Namespaced
   versions:
   - name: v1beta1
@@ -4922,7 +4907,6 @@ spec:
     listKind: ProviderList
     plural: providers
     singular: provider
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - deprecated: true
@@ -5135,7 +5119,6 @@ spec:
     listKind: SyncSetList
     plural: syncsets
     singular: syncset
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1alpha1

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/deploy/crds.yaml
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/deploy/crds.yaml
@@ -11,7 +11,6 @@ spec:
     listKind: ConstraintTemplateList
     plural: constrainttemplates
     singular: constrainttemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1

--- a/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/schema/yaml_constant.go
+++ b/vendor/github.com/open-policy-agent/frameworks/constraint/pkg/schema/yaml_constant.go
@@ -16,7 +16,6 @@ spec:
     listKind: ConstraintTemplateList
     plural: constrainttemplates
     singular: constrainttemplate
-  preserveUnknownFields: false
   scope: Cluster
   versions:
   - name: v1


### PR DESCRIPTION
**What this PR does / why we need it**:

The spec.preserveUnknownFields has been deprecated in favor of `x-kubernetes-preserve-unknown-fields: true` in the CRD v1.

This means that CRD deployed with Argo CD containing spec.preserveUnknownFields: false will be out of sync. To address this problem, the preserveUnknownFields field can be removed from the CRD spec.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
[Issue Number 4101](https://github.com/open-policy-agent/gatekeeper/issues/4101)

**Fixes #**
Removing `preserveUnknownFields: false` from manifests

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
