### PR TITLE
feat: Added kube-api-linter to linters - 4219

### DIFF
--- a/.custom-gcl.yaml
+++ b/.custom-gcl.yaml
@@ -1,0 +1,7 @@
+version: v2.6.2
+name: golangci-lint-kube-api-linter
+destination: "./bin"
+
+plugins:
+  - module: 'sigs.k8s.io/kube-api-linter'
+    version: 'v0.0.0-20251112164541-d94382a24f06'

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
     - govet
     - importas
     - ineffassign
+    - kubeapilinter
     - misspell
     - revive # replacement for golint
     - staticcheck
@@ -42,6 +43,18 @@ linters:
       rules:
         - name: var-naming
           disabled: true
+    custom:
+      kubeapilinter:
+        type: "module"
+        description: Kube API Linter lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters: 
+            disable:
+              - "*"
+            enable:
+              - statusoptional
+              - statussubresource
+          lintersConfig: {}
   exclusions:
     generated: lax
     presets:
@@ -52,6 +65,9 @@ linters:
     rules:
       - path: (.+)\.go$
         text: 'deprecated: This package is intended for older projects transitioning from OPA v0.x and will remain for the lifetime of OPA v1.x'
+      - linters:
+          - kubeapilinter
+        path-except: api/*
     paths:
       - pkg/target/matchcrd_constant.go
       - third_party$

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -67,7 +67,7 @@ linters:
         text: 'deprecated: This package is intended for older projects transitioning from OPA v0.x and will remain for the lifetime of OPA v1.x'
       - linters:
           - kubeapilinter
-        path-except: api/*
+        path-except: apis/*
     paths:
       - pkg/target/matchcrd_constant.go
       - third_party$

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ GOLANGCI_LINT_VERSION := v2.4.0
 
 # Detects the location of the user golangci-lint cache.
 GOLANGCI_LINT_CACHE := $(shell pwd)/.tmp/golangci-lint
-CUSTOM_GOLANGCI_LINT := ./bin/golangci-lint-kube-api-linter
+
 TIMEOUT ?= 30m
 
 BENCHMARK_FILE_NAME ?= benchmarks.txt
@@ -383,11 +383,11 @@ manifests: __controller-gen
 lint:
 
 # Run using Docker
-	
+
 	docker run --rm -t -v $(shell pwd):/app \
 		-v ${GOLANGCI_LINT_CACHE}:/root/.cache/golangci-lint \
 		-w /app golangci/golangci-lint:${GOLANGCI_LINT_VERSION} \
-		sh -c "test -f /app/bin/golangci-lint-kube-api-linter || golangci-lint custom && \
+		sh -c "test -f /app/bin/golangci-lint-kube-api-linter || golangci-lint custom ; \
 			/app/bin/golangci-lint-kube-api-linter run --timeout=$(TIMEOUT) --fix --concurrency 2 "
 
 # Intentionally kept for reference during transition.

--- a/apis/config/v1alpha1/config_types.go
+++ b/apis/config/v1alpha1/config_types.go
@@ -83,6 +83,7 @@ type ReadinessSpec struct {
 
 // ConfigStatus defines the observed state of Config.
 type ConfigStatus struct { // Important: Run "make" to regenerate code after modifying this file
+	// +optional
 	ByPod []status.ConfigPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/connection/v1alpha1/connection_types.go
+++ b/apis/connection/v1alpha1/connection_types.go
@@ -28,7 +28,7 @@ import (
 type ConnectionSpec struct {
 	// +kubebuilder:validation:Required
 	// Driver is the name of one of the expected drivers i.e. dapr, disk
-	Driver string `json:"driver"`
+	Driver string `json:"driver,omitempty"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields
@@ -37,6 +37,7 @@ type ConnectionSpec struct {
 
 // ConnectionStatus defines the observed state of Connection.
 type ConnectionStatus struct {
+	// +optional
 	ByPod []statusv1alpha1.ConnectionPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/connection/v1alpha1/connection_types.go
+++ b/apis/connection/v1alpha1/connection_types.go
@@ -28,7 +28,7 @@ import (
 type ConnectionSpec struct {
 	// +kubebuilder:validation:Required
 	// Driver is the name of one of the expected drivers i.e. dapr, disk
-	Driver string `json:"driver,omitempty"`
+	Driver string `json:"driver"`
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Schemaless
 	// +kubebuilder:validation:XPreserveUnknownFields

--- a/apis/expansion/unversioned/expansiontemplate_types.go
+++ b/apis/expansion/unversioned/expansiontemplate_types.go
@@ -70,6 +70,7 @@ type ExpansionTemplate struct {
 
 // ExpansionTemplateStatus defines the observed state of ExpansionTemplate.
 type ExpansionTemplateStatus struct {
+	// +optional
 	ByPod []statusv1alpha1.ExpansionTemplatePodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/expansion/v1alpha1/expansiontemplate_types.go
+++ b/apis/expansion/v1alpha1/expansiontemplate_types.go
@@ -71,6 +71,7 @@ type ExpansionTemplate struct {
 
 // ExpansionTemplateStatus defines the observed state of ExpansionTemplate.
 type ExpansionTemplateStatus struct {
+	// +optional
 	ByPod []status.ExpansionTemplatePodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/expansion/v1beta1/expansiontemplate_types.go
+++ b/apis/expansion/v1beta1/expansiontemplate_types.go
@@ -70,6 +70,7 @@ type ExpansionTemplate struct {
 
 // ExpansionTemplateStatus defines the observed state of ExpansionTemplate.
 type ExpansionTemplateStatus struct {
+	// +optional
 	ByPod []status.ExpansionTemplatePodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/unversioned/assign_types.go
+++ b/apis/mutations/unversioned/assign_types.go
@@ -77,6 +77,7 @@ type AssignStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/unversioned/assignimage_types.go
+++ b/apis/mutations/unversioned/assignimage_types.go
@@ -66,6 +66,7 @@ type AssignImageStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/unversioned/assignmetadata_types.go
+++ b/apis/mutations/unversioned/assignmetadata_types.go
@@ -40,6 +40,7 @@ type MetadataParameters struct {
 type AssignMetadataStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/unversioned/modifyset_types.go
+++ b/apis/mutations/unversioned/modifyset_types.go
@@ -115,6 +115,7 @@ type ModifySetStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1/assign_types.go
+++ b/apis/mutations/v1/assign_types.go
@@ -77,6 +77,7 @@ type AssignStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1/assignmetadata_types.go
+++ b/apis/mutations/v1/assignmetadata_types.go
@@ -40,6 +40,7 @@ type MetadataParameters struct {
 type AssignMetadataStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1/modifyset_types.go
+++ b/apis/mutations/v1/modifyset_types.go
@@ -115,6 +115,7 @@ type ModifySetStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1alpha1/assign_types.go
+++ b/apis/mutations/v1alpha1/assign_types.go
@@ -77,6 +77,7 @@ type AssignStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1alpha1/assignimage_types.go
+++ b/apis/mutations/v1alpha1/assignimage_types.go
@@ -66,6 +66,7 @@ type AssignImageStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1alpha1/assignmetadata_types.go
+++ b/apis/mutations/v1alpha1/assignmetadata_types.go
@@ -40,6 +40,7 @@ type MetadataParameters struct {
 type AssignMetadataStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1alpha1/modifyset_types.go
+++ b/apis/mutations/v1alpha1/modifyset_types.go
@@ -115,6 +115,7 @@ type ModifySetStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1beta1/assign_types.go
+++ b/apis/mutations/v1beta1/assign_types.go
@@ -77,6 +77,7 @@ type AssignStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1beta1/assignmetadata_types.go
+++ b/apis/mutations/v1beta1/assignmetadata_types.go
@@ -40,6 +40,7 @@ type MetadataParameters struct {
 type AssignMetadataStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/mutations/v1beta1/modifyset_types.go
+++ b/apis/mutations/v1beta1/modifyset_types.go
@@ -115,6 +115,7 @@ type ModifySetStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ByPod []v1beta1.MutatorPodStatusStatus `json:"byPod,omitempty"`
 }
 

--- a/apis/status/v1alpha1/connectionpodstatus_types.go
+++ b/apis/status/v1alpha1/connectionpodstatus_types.go
@@ -32,12 +32,18 @@ import (
 // ConnectionPodStatusStatus defines the observed state of ConnectionPodStatus.
 type ConnectionPodStatusStatus struct {
 	// ID is the unique identifier for the pod that wrote the status
-	ID                 string    `json:"id,omitempty"`
-	ConnectionUID      types.UID `json:"connectionUID,omitempty"`
-	Operations         []string  `json:"operations,omitempty"`
-	ObservedGeneration int64     `json:"observedGeneration,omitempty"`
+	// +optional
+	ID string `json:"id,omitempty"`
+	// +optional
+	ConnectionUID types.UID `json:"connectionUID,omitempty"`
+	// +optional
+	Operations []string `json:"operations,omitempty"`
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 	// Indicator for alive connection with at least one successful publish
-	Active bool               `json:"active,omitempty"`
+	// +optional
+	Active bool `json:"active,omitempty"`
+	// +optional
 	Errors []*ConnectionError `json:"errors,omitempty"`
 }
 
@@ -55,6 +61,7 @@ const (
 
 // +kubebuilder:object:root=true
 // ConnectionPodStatus is the Schema for the connectionpodstatuses API.
+// +kubebuilder:subresource:status
 type ConnectionPodStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/status/v1beta1/configpodstatus_types.go
+++ b/apis/status/v1beta1/configpodstatus_types.go
@@ -15,11 +15,16 @@ import (
 // +kubebuilder:object:generate=true
 
 type ConfigPodStatusStatus struct {
-	ID                 string         `json:"id,omitempty"`
-	ConfigUID          types.UID      `json:"configUID,omitempty"`
-	Operations         []string       `json:"operations,omitempty"`
-	ObservedGeneration int64          `json:"observedGeneration,omitempty"`
-	Errors             []*ConfigError `json:"errors,omitempty"`
+	// +optional
+	ID string `json:"id,omitempty"`
+	// +optional
+	ConfigUID types.UID `json:"configUID,omitempty"`
+	// +optional
+	Operations []string `json:"operations,omitempty"`
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// +optional
+	Errors []*ConfigError `json:"errors,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/apis/status/v1beta1/constraintpodstatus_types.go
+++ b/apis/status/v1beta1/constraintpodstatus_types.go
@@ -35,15 +35,22 @@ const ConstraintsGroup = "constraints.gatekeeper.sh"
 type ConstraintPodStatusStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ID string `json:"id,omitempty"`
 	// Storing the constraint UID allows us to detect drift, such as
 	// when a constraint has been recreated after its CRD was deleted
 	// out from under it, interrupting the watch
-	ConstraintUID           types.UID                `json:"constraintUID,omitempty"`
-	Operations              []string                 `json:"operations,omitempty"`
-	Enforced                bool                     `json:"enforced,omitempty"`
-	Errors                  []Error                  `json:"errors,omitempty"`
-	ObservedGeneration      int64                    `json:"observedGeneration,omitempty"`
+	// +optional
+	ConstraintUID types.UID `json:"constraintUID,omitempty"`
+	// +optional
+	Operations []string `json:"operations,omitempty"`
+	// +optional
+	Enforced bool `json:"enforced,omitempty"`
+	// +optional
+	Errors []Error `json:"errors,omitempty"`
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// +optional
 	EnforcementPointsStatus []EnforcementPointStatus `json:"enforcementPointsStatus,omitempty"`
 }
 

--- a/apis/status/v1beta1/constrainttemplatepodstatus_types.go
+++ b/apis/status/v1beta1/constrainttemplatepodstatus_types.go
@@ -29,12 +29,18 @@ import (
 // ConstraintTemplatePodStatusStatus defines the observed state of ConstraintTemplatePodStatus.
 type ConstraintTemplatePodStatusStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
-	ID                  string                             `json:"id,omitempty"`
-	TemplateUID         types.UID                          `json:"templateUID,omitempty"`
-	Operations          []string                           `json:"operations,omitempty"`
-	ObservedGeneration  int64                              `json:"observedGeneration,omitempty"`
-	Errors              []*templatesv1beta1.CreateCRDError `json:"errors,omitempty"`
-	VAPGenerationStatus *VAPGenerationStatus               `json:"vapGenerationStatus,omitempty"`
+	// +optional
+	ID string `json:"id,omitempty"`
+	// +optional
+	TemplateUID types.UID `json:"templateUID,omitempty"`
+	// +optional
+	Operations []string `json:"operations,omitempty"`
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// +optional
+	Errors []*templatesv1beta1.CreateCRDError `json:"errors,omitempty"`
+	// +optional
+	VAPGenerationStatus *VAPGenerationStatus `json:"vapGenerationStatus,omitempty"`
 }
 
 // VAPGenerationStatus represents the status of VAP generation.

--- a/apis/status/v1beta1/expansiontemplatepodstatus_types.go
+++ b/apis/status/v1beta1/expansiontemplatepodstatus_types.go
@@ -13,11 +13,16 @@ import (
 // ExpansionTemplatePodStatusStatus defines the observed state of ExpansionTemplatePodStatus.
 type ExpansionTemplatePodStatusStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
-	ID                 string                    `json:"id,omitempty"`
-	TemplateUID        types.UID                 `json:"templateUID,omitempty"`
-	Operations         []string                  `json:"operations,omitempty"`
-	ObservedGeneration int64                     `json:"observedGeneration,omitempty"`
-	Errors             []*ExpansionTemplateError `json:"errors,omitempty"`
+	// +optional
+	ID string `json:"id,omitempty"`
+	// +optional
+	TemplateUID types.UID `json:"templateUID,omitempty"`
+	// +optional
+	Operations []string `json:"operations,omitempty"`
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// +optional
+	Errors []*ExpansionTemplateError `json:"errors,omitempty"`
 }
 
 // +kubebuilder:object:generate=true

--- a/apis/status/v1beta1/mutatorpodstatus_types.go
+++ b/apis/status/v1beta1/mutatorpodstatus_types.go
@@ -35,15 +35,21 @@ const MutationsGroup = "mutations.gatekeeper.sh"
 type MutatorPodStatusStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ID string `json:"id,omitempty"`
 	// Storing the mutator UID allows us to detect drift, such as
 	// when a mutator has been recreated after its CRD was deleted
 	// out from under it, interrupting the watch
-	MutatorUID         types.UID      `json:"mutatorUID,omitempty"`
-	Operations         []string       `json:"operations,omitempty"`
-	Enforced           bool           `json:"enforced,omitempty"`
-	Errors             []MutatorError `json:"errors,omitempty"`
-	ObservedGeneration int64          `json:"observedGeneration,omitempty"`
+	// +optional
+	MutatorUID types.UID `json:"mutatorUID,omitempty"`
+	// +optional
+	Operations []string `json:"operations,omitempty"`
+	// +optional
+	Enforced bool `json:"enforced,omitempty"`
+	// +optional
+	Errors []MutatorError `json:"errors,omitempty"`
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // MutatorError represents a single error caught while adding a mutator to a system.

--- a/apis/status/v1beta1/providerpodstatus_types.go
+++ b/apis/status/v1beta1/providerpodstatus_types.go
@@ -32,17 +32,25 @@ import (
 type ProviderPodStatusStatus struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +optional
 	ID string `json:"id,omitempty"`
 	// Storing the provider UID allows us to detect drift, such as
 	// when a provider has been recreated after its CRD was deleted
 	// out from under it, interrupting the watch
-	ProviderUID         types.UID        `json:"providerUID,omitempty"`
-	Operations          []string         `json:"operations,omitempty"`
-	Active              bool             `json:"active,omitempty"`
-	Errors              []*ProviderError `json:"errors,omitempty"`
-	ObservedGeneration  int64            `json:"observedGeneration,omitempty"`
-	LastTransitionTime  *metav1.Time     `json:"lastTransitionTime,omitempty"`
-	LastCacheUpdateTime *metav1.Time     `json:"lastCacheUpdateTime,omitempty"`
+	// +optional
+	ProviderUID types.UID `json:"providerUID,omitempty"`
+	// +optional
+	Operations []string `json:"operations,omitempty"`
+	// +optional
+	Active bool `json:"active,omitempty"`
+	// +optional
+	Errors []*ProviderError `json:"errors,omitempty"`
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+	// +optional
+	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
+	// +optional
+	LastCacheUpdateTime *metav1.Time `json:"lastCacheUpdateTime,omitempty"`
 }
 
 // ProviderError represents a single error caught while managing providers.
@@ -67,6 +75,7 @@ const (
 
 // +kubebuilder:object:root=true
 // ProviderPodStatus is the Schema for the providerpodstatuses API.
+// +kubebuilder:subresource:status
 type ProviderPodStatus struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/status.gatekeeper.sh_connectionpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_connectionpodstatuses.yaml
@@ -77,3 +77,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/config/crd/bases/status.gatekeeper.sh_providerpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_providerpodstatuses.yaml
@@ -90,3 +90,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/manifest_staging/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
@@ -77,3 +77,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/manifest_staging/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
@@ -92,3 +92,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -2695,6 +2695,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -4906,6 +4908,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
Signed-off-by: Devi Vasudevan <deviv@microsoft.com>

**What this PR does / why we need it**:

Added kube-api-linter to linters and enabled the linters statusoptional and statussubresource - 4219

This PR is a **feat**.
Adds docker-based custom golangci-lint build

Fixes # 4219 https://github.com/open-policy-agent/gatekeeper/issues/4219 
