### PR TITLE
fix(chart): use fully qualified container image names #4288

### DIFF
--- a/cmd/build/helmify/static/templates/_helpers.tpl
+++ b/cmd/build/helmify/static/templates/_helpers.tpl
@@ -107,7 +107,7 @@ Output post install webhook probe container entry
 */}}
 {{- define "gatekeeper.postInstallWebhookProbeContainer" -}}
 - name: webhook-probe-post
-  image: "{{ .Values.postInstall.probeWebhook.image.repository }}:{{ .Values.postInstall.probeWebhook.image.tag }}"
+  image: {{ printf "%s/%s:%s" .Values.postInstall.probeWebhook.image.registry .Values.postInstall.probeWebhook.image.repository .Values.postInstall.probeWebhook.image.tag }}
   imagePullPolicy: {{ .Values.postInstall.probeWebhook.image.pullPolicy }}
   command:
     - "curl"

--- a/cmd/build/helmify/static/templates/namespace-post-install.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-install.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
         - name: kubectl-label
-          image: "{{ .Values.postInstall.labelNamespace.image.repository }}:{{ .Values.postInstall.labelNamespace.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.postInstall.labelNamespace.image.registry .Values.postInstall.labelNamespace.image.repository .Values.postInstall.labelNamespace.image.tag }}
           imagePullPolicy: {{ .Values.postInstall.labelNamespace.image.pullPolicy }}
           args:
             - label
@@ -62,7 +62,7 @@ spec:
             {{- toYaml .Values.postInstall.securityContext | nindent 12 }}
         {{- if .Values.postInstall.labelNamespace.extraNamespaces }}
         - name: kubectl-label-extra
-          image: "{{ .Values.postInstall.labelNamespace.image.repository }}:{{ .Values.postInstall.labelNamespace.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.postInstall.labelNamespace.image.registry .Values.postInstall.labelNamespace.image.repository .Values.postInstall.labelNamespace.image.tag }}
           imagePullPolicy: {{ .Values.postInstall.labelNamespace.image.pullPolicy }}
           args:
             - label

--- a/cmd/build/helmify/static/templates/namespace-post-upgrade.yaml
+++ b/cmd/build/helmify/static/templates/namespace-post-upgrade.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: kubectl-label
-          image: "{{ .Values.postUpgrade.labelNamespace.image.repository }}:{{ .Values.postUpgrade.labelNamespace.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.postUpgrade.labelNamespace.image.registry .Values.postUpgrade.labelNamespace.image.repository .Values.postUpgrade.labelNamespace.image.tag }}
           imagePullPolicy: {{ .Values.postUpgrade.labelNamespace.image.pullPolicy }}
           args:
             - label
@@ -54,7 +54,7 @@ spec:
             {{- toYaml .Values.postUpgrade.securityContext | nindent 12 }}
         {{- if .Values.postUpgrade.labelNamespace.extraNamespaces }}
         - name: kubectl-label-extra
-          image: "{{ .Values.postUpgrade.labelNamespace.image.repository }}:{{ .Values.postUpgrade.labelNamespace.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.postUpgrade.labelNamespace.image.registry .Values.postUpgrade.labelNamespace.image.repository .Values.postUpgrade.labelNamespace.image.tag }}
           imagePullPolicy: {{ .Values.postUpgrade.labelNamespace.image.pullPolicy }}
           args:
             - label

--- a/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
+++ b/cmd/build/helmify/static/templates/upgrade-crds-hook.yaml
@@ -97,15 +97,15 @@ spec:
       - name: crds-upgrade
         {{- if .Values.preInstall.crdRepository.image.repository }}
           {{- if not .Values.preInstall.crdRepository.image.tag }}
-        image: '{{ .Values.preInstall.crdRepository.image.repository }}'
+        image: {{ printf "%s/%s" .Values.preInstall.crdRepository.image.registry .Values.preInstall.crdRepository.image.repository }}
           {{- else }}
-        image: '{{ .Values.preInstall.crdRepository.image.repository }}:{{ .Values.preInstall.crdRepository.image.tag }}'
+        image: {{ printf "%s/%s:%s" .Values.preInstall.crdRepository.image.registry .Values.preInstall.crdRepository.image.repository .Values.preInstall.crdRepository.image.tag }}
           {{- end }}
         {{- else }}
           {{- if not .Values.image.release }}
-        image: '{{ .Values.image.crdRepository }}'
+        image: {{ printf "%s/%s" .Values.image.crdRegistry .Values.image.crdRepository }}
           {{- else }}
-        image: '{{ .Values.image.crdRepository }}:{{ .Values.image.release }}'
+        image: {{ printf "%s/%s:%s" .Values.image.crdRegistry .Values.image.crdRepository .Values.image.release }}
           {{- end }}
         {{- end }}
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'

--- a/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
+++ b/cmd/build/helmify/static/templates/webhook-configs-pre-delete.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
         - name: kubectl-delete
-          image: "{{ .Values.preUninstall.deleteWebhookConfigurations.image.repository }}:{{ .Values.preUninstall.deleteWebhookConfigurations.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.preUninstall.deleteWebhookConfigurations.image.registry .Values.preUninstall.deleteWebhookConfigurations.image.repository .Values.preUninstall.deleteWebhookConfigurations.image.tag }}
           imagePullPolicy: {{ .Values.preUninstall.deleteWebhookConfigurations.image.pullPolicy }}
           args:
             - delete

--- a/cmd/build/helmify/static/values.yaml
+++ b/cmd/build/helmify/static/values.yaml
@@ -87,7 +87,9 @@ commonAnnotations: {}
 extraVolumeMounts: []
 extraVolumes: []
 image:
+  registry: docker.io
   repository: openpolicyagent/gatekeeper
+  crdRegistry: docker.io
   crdRepository: openpolicyagent/gatekeeper-crds
   release: v3.22.0-beta.0
   pullPolicy: IfNotPresent
@@ -95,6 +97,7 @@ image:
 preInstall:
   crdRepository:
     image:
+      registry: null
       repository: null
       tag: v3.22.0-beta.0
 postUpgrade:
@@ -104,6 +107,7 @@ postUpgrade:
       create: true
     enabled: false
     image:
+      registry: docker.io
       repository: openpolicyagent/gatekeeper-crds
       tag: v3.22.0-beta.0
       pullPolicy: IfNotPresent
@@ -141,6 +145,7 @@ postInstall:
     enabled: true
     extraRules: []
     image:
+      registry: docker.io
       repository: openpolicyagent/gatekeeper-crds
       tag: v3.22.0-beta.0
       pullPolicy: IfNotPresent
@@ -160,6 +165,7 @@ postInstall:
   probeWebhook:
     enabled: true
     image:
+      registry: docker.io
       repository: curlimages/curl
       tag: 8.12.0
       pullPolicy: IfNotPresent
@@ -188,6 +194,7 @@ preUninstall:
     extraRules: []
     enabled: false
     image:
+      registry: docker.io
       repository: openpolicyagent/gatekeeper-crds
       tag: v3.22.0-beta.0
       pullPolicy: IfNotPresent

--- a/manifest_staging/charts/gatekeeper/templates/_helpers.tpl
+++ b/manifest_staging/charts/gatekeeper/templates/_helpers.tpl
@@ -107,7 +107,7 @@ Output post install webhook probe container entry
 */}}
 {{- define "gatekeeper.postInstallWebhookProbeContainer" -}}
 - name: webhook-probe-post
-  image: "{{ .Values.postInstall.probeWebhook.image.repository }}:{{ .Values.postInstall.probeWebhook.image.tag }}"
+  image: {{ printf "%s/%s:%s" .Values.postInstall.probeWebhook.image.registry .Values.postInstall.probeWebhook.image.repository .Values.postInstall.probeWebhook.image.tag }}
   imagePullPolicy: {{ .Values.postInstall.probeWebhook.image.pullPolicy }}
   command:
     - "curl"

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-install.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
         - name: kubectl-label
-          image: "{{ .Values.postInstall.labelNamespace.image.repository }}:{{ .Values.postInstall.labelNamespace.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.postInstall.labelNamespace.image.registry .Values.postInstall.labelNamespace.image.repository .Values.postInstall.labelNamespace.image.tag }}
           imagePullPolicy: {{ .Values.postInstall.labelNamespace.image.pullPolicy }}
           args:
             - label
@@ -62,7 +62,7 @@ spec:
             {{- toYaml .Values.postInstall.securityContext | nindent 12 }}
         {{- if .Values.postInstall.labelNamespace.extraNamespaces }}
         - name: kubectl-label-extra
-          image: "{{ .Values.postInstall.labelNamespace.image.repository }}:{{ .Values.postInstall.labelNamespace.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.postInstall.labelNamespace.image.registry .Values.postInstall.labelNamespace.image.repository .Values.postInstall.labelNamespace.image.tag }}
           imagePullPolicy: {{ .Values.postInstall.labelNamespace.image.pullPolicy }}
           args:
             - label

--- a/manifest_staging/charts/gatekeeper/templates/namespace-post-upgrade.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/namespace-post-upgrade.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
       containers:
         - name: kubectl-label
-          image: "{{ .Values.postUpgrade.labelNamespace.image.repository }}:{{ .Values.postUpgrade.labelNamespace.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.postUpgrade.labelNamespace.image.registry .Values.postUpgrade.labelNamespace.image.repository .Values.postUpgrade.labelNamespace.image.tag }}
           imagePullPolicy: {{ .Values.postUpgrade.labelNamespace.image.pullPolicy }}
           args:
             - label
@@ -54,7 +54,7 @@ spec:
             {{- toYaml .Values.postUpgrade.securityContext | nindent 12 }}
         {{- if .Values.postUpgrade.labelNamespace.extraNamespaces }}
         - name: kubectl-label-extra
-          image: "{{ .Values.postUpgrade.labelNamespace.image.repository }}:{{ .Values.postUpgrade.labelNamespace.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.postUpgrade.labelNamespace.image.registry .Values.postUpgrade.labelNamespace.image.repository .Values.postUpgrade.labelNamespace.image.tag }}
           imagePullPolicy: {{ .Values.postUpgrade.labelNamespace.image.pullPolicy }}
           args:
             - label

--- a/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/upgrade-crds-hook.yaml
@@ -97,15 +97,15 @@ spec:
       - name: crds-upgrade
         {{- if .Values.preInstall.crdRepository.image.repository }}
           {{- if not .Values.preInstall.crdRepository.image.tag }}
-        image: '{{ .Values.preInstall.crdRepository.image.repository }}'
+        image: {{ printf "%s/%s" .Values.preInstall.crdRepository.image.registry .Values.preInstall.crdRepository.image.repository }}
           {{- else }}
-        image: '{{ .Values.preInstall.crdRepository.image.repository }}:{{ .Values.preInstall.crdRepository.image.tag }}'
+        image: {{ printf "%s/%s:%s" .Values.preInstall.crdRepository.image.registry .Values.preInstall.crdRepository.image.repository .Values.preInstall.crdRepository.image.tag }}
           {{- end }}
         {{- else }}
           {{- if not .Values.image.release }}
-        image: '{{ .Values.image.crdRepository }}'
+        image: {{ printf "%s/%s" .Values.image.crdRegistry .Values.image.crdRepository }}
           {{- else }}
-        image: '{{ .Values.image.crdRepository }}:{{ .Values.image.release }}'
+        image: {{ printf "%s/%s:%s" .Values.image.crdRegistry .Values.image.crdRepository .Values.image.release }}
           {{- end }}
         {{- end }}
         imagePullPolicy: '{{ .Values.image.pullPolicy }}'

--- a/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/webhook-configs-pre-delete.yaml
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       containers:
         - name: kubectl-delete
-          image: "{{ .Values.preUninstall.deleteWebhookConfigurations.image.repository }}:{{ .Values.preUninstall.deleteWebhookConfigurations.image.tag }}"
+          image: {{ printf "%s/%s:%s" .Values.preUninstall.deleteWebhookConfigurations.image.registry .Values.preUninstall.deleteWebhookConfigurations.image.repository .Values.preUninstall.deleteWebhookConfigurations.image.tag }}
           imagePullPolicy: {{ .Values.preUninstall.deleteWebhookConfigurations.image.pullPolicy }}
           args:
             - delete

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -87,7 +87,9 @@ commonAnnotations: {}
 extraVolumeMounts: []
 extraVolumes: []
 image:
+  registry: docker.io
   repository: openpolicyagent/gatekeeper
+  crdRegistry: docker.io
   crdRepository: openpolicyagent/gatekeeper-crds
   release: v3.22.0-beta.0
   pullPolicy: IfNotPresent
@@ -95,6 +97,7 @@ image:
 preInstall:
   crdRepository:
     image:
+      registry: null
       repository: null
       tag: v3.22.0-beta.0
 postUpgrade:
@@ -104,6 +107,7 @@ postUpgrade:
       create: true
     enabled: false
     image:
+      registry: docker.io
       repository: openpolicyagent/gatekeeper-crds
       tag: v3.22.0-beta.0
       pullPolicy: IfNotPresent
@@ -141,6 +145,7 @@ postInstall:
     enabled: true
     extraRules: []
     image:
+      registry: docker.io
       repository: openpolicyagent/gatekeeper-crds
       tag: v3.22.0-beta.0
       pullPolicy: IfNotPresent
@@ -160,6 +165,7 @@ postInstall:
   probeWebhook:
     enabled: true
     image:
+      registry: docker.io
       repository: curlimages/curl
       tag: 8.12.0
       pullPolicy: IfNotPresent
@@ -188,6 +194,7 @@ preUninstall:
     extraRules: []
     enabled: false
     image:
+      registry: docker.io
       repository: openpolicyagent/gatekeeper-crds
       tag: v3.22.0-beta.0
       pullPolicy: IfNotPresent


### PR DESCRIPTION
The container runtime CRI-O changed their default behavior for unqualified container images names, also named short-names.

In privious versions of CRI-O v1.34 has unqualified container images been pulled from docker.io. Starting with CRI-O 1.34 it is necessary to define in `/etc/containers/registry.conf` the property like the example below:

```conf
unqualified-search-registries = [
  "docker.io"
]
```

Based on the fact that this configuration is not enabled by default, the deployment of OPA failes.

This patch extends the `values.yaml` file of the attribute `registry`. Other users should not be affected by this change. It should only help users with CRI-O >= v1.34 to be able to deploy OPA successfully again.


