### PR TITLE
feat: support GVK and namespace selector in config match exclusions

### DIFF
--- a/apis/config/v1alpha1/config_types.go
+++ b/apis/config/v1alpha1/config_types.go
@@ -73,8 +73,12 @@ func (e *SyncOnlyEntry) ToGroupVersionKind() schema.GroupVersionKind {
 }
 
 type MatchEntry struct {
-	Processes          []string            `json:"processes,omitempty"`
-	ExcludedNamespaces []wildcard.Wildcard `json:"excludedNamespaces,omitempty"`
+	Processes          []string              `json:"processes,omitempty"`
+	ExcludedNamespaces []wildcard.Wildcard   `json:"excludedNamespaces,omitempty"`
+	APIGroups          []string              `json:"apiGroups,omitempty"`
+	APIVersions        []string              `json:"apiVersions,omitempty"`
+	Kinds              []string              `json:"kinds,omitempty"`
+	NamespaceSelector  *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 }
 
 type ReadinessSpec struct {

--- a/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 import (
 	"github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -158,6 +159,26 @@ func (in *MatchEntry) DeepCopyInto(out *MatchEntry) {
 		in, out := &in.ExcludedNamespaces, &out.ExcludedNamespaces
 		*out = make([]wildcard.Wildcard, len(*in))
 		copy(*out, *in)
+	}
+	if in.APIGroups != nil {
+		in, out := &in.APIGroups, &out.APIGroups
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.APIVersions != nil {
+		in, out := &in.APIVersions, &out.APIVersions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Kinds != nil {
+		in, out := &in.Kinds, &out.Kinds
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.NamespaceSelector != nil {
+		in, out := &in.NamespaceSelector, &out.NamespaceSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/config/crd/bases/config.gatekeeper.sh_configs.yaml
+++ b/config/crd/bases/config.gatekeeper.sh_configs.yaml
@@ -43,6 +43,14 @@ spec:
                 description: Configuration for namespace exclusion
                 items:
                   properties:
+                    apiGroups:
+                      items:
+                        type: string
+                      type: array
+                    apiVersions:
+                      items:
+                        type: string
+                      type: array
                     excludedNamespaces:
                       items:
                         description: |-
@@ -52,6 +60,59 @@ spec:
                         pattern: ^\*?[-:a-z0-9]*\*?$
                         type: string
                       type: array
+                    kinds:
+                      items:
+                        type: string
+                      type: array
+                    namespaceSelector:
+                      description: |-
+                        A label selector is a label query over a set of resources. The result of matchLabels and
+                        matchExpressions are ANDed. An empty label selector matches all objects. A null
+                        label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
                     processes:
                       items:
                         type: string

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -289,7 +289,9 @@ func (r *ReconcileConfig) Reconcile(ctx context.Context, request reconcile.Reque
 			gvksToSync = append(gvksToSync, entry.ToGroupVersionKind())
 		}
 
-		newExcluder.Add(instance.Spec.Match)
+		if err := newExcluder.Add(instance.Spec.Match); err != nil {
+			return reconcile.Result{}, fmt.Errorf("error adding match entries to excluder: %w", err)
+		}
 		statsEnabled = instance.Spec.Readiness.StatsEnabled
 	}
 

--- a/pkg/controller/config/process/excluder.go
+++ b/pkg/controller/config/process/excluder.go
@@ -1,11 +1,14 @@
 package process
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 
 	configv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/config/v1alpha1"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -21,9 +24,19 @@ const (
 	Star     = Process("*")
 )
 
+// excluderEntry is a processed form of a MatchEntry, scoped to a single process.
+type excluderEntry struct {
+	excludedNamespaces []wildcard.Wildcard
+	apiGroups          map[string]bool       // nil means match all groups
+	apiVersions        map[string]bool       // nil means match all versions
+	kinds              map[string]bool       // nil means match all kinds
+	namespaceSelector  *metav1.LabelSelector // original selector spec, used for equality comparison
+	compiledSelector   labels.Selector       // pre-compiled selector for fast matching
+}
+
 type Excluder struct {
-	mux                sync.RWMutex
-	excludedNamespaces map[Process]map[wildcard.Wildcard]bool
+	mux     sync.RWMutex
+	entries map[Process][]excluderEntry
 }
 
 var allProcesses = []Process{
@@ -34,7 +47,7 @@ var allProcesses = []Process{
 }
 
 var processExcluder = &Excluder{
-	excludedNamespaces: make(map[Process]map[wildcard.Wildcard]bool),
+	entries: make(map[Process][]excluderEntry),
 }
 
 func Get() *Excluder {
@@ -43,85 +56,232 @@ func Get() *Excluder {
 
 func New() *Excluder {
 	return &Excluder{
-		excludedNamespaces: make(map[Process]map[wildcard.Wildcard]bool),
+		entries: make(map[Process][]excluderEntry),
 	}
 }
 
-func (s *Excluder) Add(entry []configv1alpha1.MatchEntry) {
+func (s *Excluder) Add(entry []configv1alpha1.MatchEntry) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()
 
 	for _, matchEntry := range entry {
-		for _, ns := range matchEntry.ExcludedNamespaces {
-			for _, op := range matchEntry.Processes {
-				// adding excluded namespace to all processes for "*"
-				if Process(op) == Star {
-					for _, o := range allProcesses {
-						if s.excludedNamespaces[o] == nil {
-							s.excludedNamespaces[o] = make(map[wildcard.Wildcard]bool)
-						}
-						s.excludedNamespaces[o][ns] = true
-					}
-				} else {
-					if s.excludedNamespaces[Process(op)] == nil {
-						s.excludedNamespaces[Process(op)] = make(map[wildcard.Wildcard]bool)
-					}
-					s.excludedNamespaces[Process(op)][ns] = true
+		e := excluderEntry{
+			excludedNamespaces: matchEntry.ExcludedNamespaces,
+			namespaceSelector:  matchEntry.NamespaceSelector,
+		}
+
+		if matchEntry.NamespaceSelector != nil {
+			compiled, err := metav1.LabelSelectorAsSelector(matchEntry.NamespaceSelector)
+			if err != nil {
+				return fmt.Errorf("invalid namespaceSelector: %w", err)
+			}
+			e.compiledSelector = compiled
+		}
+
+		if len(matchEntry.APIGroups) > 0 {
+			e.apiGroups = make(map[string]bool, len(matchEntry.APIGroups))
+			for _, g := range matchEntry.APIGroups {
+				e.apiGroups[g] = true
+			}
+		}
+		if len(matchEntry.APIVersions) > 0 {
+			e.apiVersions = make(map[string]bool, len(matchEntry.APIVersions))
+			for _, v := range matchEntry.APIVersions {
+				e.apiVersions[v] = true
+			}
+		}
+		if len(matchEntry.Kinds) > 0 {
+			e.kinds = make(map[string]bool, len(matchEntry.Kinds))
+			for _, k := range matchEntry.Kinds {
+				e.kinds[k] = true
+			}
+		}
+
+		for _, op := range matchEntry.Processes {
+			// adding entry to all processes for "*"
+			if Process(op) == Star {
+				for _, p := range allProcesses {
+					s.entries[p] = append(s.entries[p], e)
 				}
+			} else {
+				s.entries[Process(op)] = append(s.entries[Process(op)], e)
 			}
 		}
 	}
+
+	return nil
 }
 
 func (s *Excluder) Replace(new *Excluder) { // nolint:revive
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	s.excludedNamespaces = new.excludedNamespaces
+	s.entries = new.entries
 }
 
 func (s *Excluder) Equals(new *Excluder) bool { // nolint:revive
 	s.mux.RLock()
 	defer s.mux.RUnlock()
-	return reflect.DeepEqual(s.excludedNamespaces, new.excludedNamespaces)
+	return entriesMapEqual(s.entries, new.entries)
 }
 
-// EqualsForProcess checks if the excluded namespaces for a specific process are equal.
+// EqualsForProcess checks if the entries for a specific process are equal.
 func (s *Excluder) EqualsForProcess(process Process, new *Excluder) bool { // nolint:revive
 	s.mux.RLock()
 	defer s.mux.RUnlock()
-	return reflect.DeepEqual(s.excludedNamespaces[process], new.excludedNamespaces[process])
+	return entriesEqual(s.entries[process], new.entries[process])
 }
 
+// entriesMapEqual compares two process-to-entries maps, ignoring compiled selectors.
+func entriesMapEqual(a, b map[Process][]excluderEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for p, ae := range a {
+		be, ok := b[p]
+		if !ok {
+			return false
+		}
+		if !entriesEqual(ae, be) {
+			return false
+		}
+	}
+	return true
+}
+
+// entriesEqual compares two entry slices, ignoring compiled selectors.
+func entriesEqual(a, b []excluderEntry) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !reflect.DeepEqual(a[i].excludedNamespaces, b[i].excludedNamespaces) {
+			return false
+		}
+		if !reflect.DeepEqual(a[i].apiGroups, b[i].apiGroups) {
+			return false
+		}
+		if !reflect.DeepEqual(a[i].apiVersions, b[i].apiVersions) {
+			return false
+		}
+		if !reflect.DeepEqual(a[i].kinds, b[i].kinds) {
+			return false
+		}
+		if !reflect.DeepEqual(a[i].namespaceSelector, b[i].namespaceSelector) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsNamespaceExcluded checks if an object should be excluded based on its namespace (or name for
+// Namespace objects), GVK, and namespace labels (for Namespace objects only).
+// For full namespace selector support on non-Namespace objects, use IsObjectExcluded.
 func (s *Excluder) IsNamespaceExcluded(process Process, obj client.Object) (bool, error) {
+	isNamespace := obj.GetObjectKind().GroupVersionKind().Kind == "Namespace" &&
+		obj.GetObjectKind().GroupVersionKind().Group == ""
+
+	var nsLabels map[string]string
+	if isNamespace {
+		nsLabels = obj.GetLabels()
+	}
+
+	return s.IsObjectExcluded(process, obj, nsLabels)
+}
+
+// IsObjectExcluded checks if an object should be excluded based on all configured criteria:
+// namespace name patterns, GVK, and namespace label selectors.
+// nsLabels should be the labels of the namespace containing the object (or the object's own
+// labels if it is a Namespace).
+func (s *Excluder) IsObjectExcluded(process Process, obj client.Object, nsLabels map[string]string) (bool, error) {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 
-	if obj.GetObjectKind().GroupVersionKind().Kind == "Namespace" && obj.GetObjectKind().GroupVersionKind().Group == "" {
-		return exactOrWildcardMatch(s.excludedNamespaces[process], obj.GetName()), nil
+	for i := range s.entries[process] {
+		if s.entries[process][i].matches(obj, nsLabels) {
+			return true, nil
+		}
 	}
 
-	return exactOrWildcardMatch(s.excludedNamespaces[process], obj.GetNamespace()), nil
+	return false, nil
 }
 
-// GetExcludedNamespaces returns a list of excluded namespace patterns for the given process.
+// GetExcludedNamespaces returns a deduplicated list of excluded namespace patterns for the given
+// process. Only returns patterns from entries that apply to all resource types (no GVK filter)
+// and don't use a namespace label selector.
 func (s *Excluder) GetExcludedNamespaces(process Process) []string {
 	s.mux.RLock()
 	defer s.mux.RUnlock()
 
+	seen := make(map[string]struct{})
 	var excludedNamespaces []string
-	for ns := range s.excludedNamespaces[process] {
-		excludedNamespaces = append(excludedNamespaces, string(ns))
+	for _, e := range s.entries[process] {
+		if e.apiGroups != nil || e.apiVersions != nil || e.kinds != nil || e.namespaceSelector != nil {
+			continue
+		}
+		for _, ns := range e.excludedNamespaces {
+			nsStr := string(ns)
+			if _, exists := seen[nsStr]; exists {
+				continue
+			}
+			seen[nsStr] = struct{}{}
+			excludedNamespaces = append(excludedNamespaces, nsStr)
+		}
 	}
 
 	return excludedNamespaces
 }
 
-func exactOrWildcardMatch(boolMap map[wildcard.Wildcard]bool, ns string) bool {
-	for k := range boolMap {
-		if k.Matches(ns) {
-			return true
+// matches checks whether an object matches this entry's criteria.
+// All specified criteria (namespace patterns, GVK, namespace selector) must match (AND logic).
+// Unspecified criteria (nil/empty) match everything.
+func (e *excluderEntry) matches(obj client.Object, nsLabels map[string]string) bool {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+
+	// Check GVK filters
+	if e.apiGroups != nil && !e.apiGroups[gvk.Group] {
+		return false
+	}
+	if e.apiVersions != nil && !e.apiVersions[gvk.Version] {
+		return false
+	}
+	if e.kinds != nil && !e.kinds[gvk.Kind] {
+		return false
+	}
+
+	// Determine namespace to check
+	isNamespace := gvk.Kind == "Namespace" && gvk.Group == ""
+	namespace := obj.GetNamespace()
+	if isNamespace {
+		namespace = obj.GetName()
+	}
+
+	// Check namespace name patterns
+	if len(e.excludedNamespaces) > 0 {
+		if !wildcardMatch(e.excludedNamespaces, namespace) {
+			return false
 		}
 	}
 
+	// Check namespace label selector (pre-compiled during Add)
+	if e.compiledSelector != nil {
+		if nsLabels == nil {
+			// No namespace labels available; can't evaluate selector, so don't match
+			return false
+		}
+
+		if !e.compiledSelector.Matches(labels.Set(nsLabels)) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func wildcardMatch(patterns []wildcard.Wildcard, ns string) bool {
+	for _, p := range patterns {
+		if p.Matches(ns) {
+			return true
+		}
+	}
 	return false
 }

--- a/pkg/controller/config/process/excluder_test.go
+++ b/pkg/controller/config/process/excluder_test.go
@@ -6,59 +6,51 @@ import (
 
 	configv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/config/v1alpha1"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func TestExactOrWildcardMatch(t *testing.T) {
+func TestWildcardMatch(t *testing.T) {
 	tcs := []struct {
 		name     string
-		nsMap    map[wildcard.Wildcard]bool
+		patterns []wildcard.Wildcard
 		ns       string
-		excluded bool
+		matched  bool
 	}{
 		{
-			name: "exact text match",
-			nsMap: map[wildcard.Wildcard]bool{
-				"kube-system": true,
-				"foobar":      true,
-			},
+			name:     "exact text match",
+			patterns: []wildcard.Wildcard{"kube-system", "foobar"},
 			ns:       "kube-system",
-			excluded: true,
+			matched:  true,
 		},
 		{
-			name: "wildcard prefix match",
-			nsMap: map[wildcard.Wildcard]bool{
-				"kube-*": true,
-				"foobar": true,
-			},
+			name:     "wildcard prefix match",
+			patterns: []wildcard.Wildcard{"kube-*", "foobar"},
 			ns:       "kube-system",
-			excluded: true,
+			matched:  true,
 		},
 		{
-			name: "wildcard suffix match",
-			nsMap: map[wildcard.Wildcard]bool{
-				"*-system": true,
-				"foobar":   true,
-			},
+			name:     "wildcard suffix match",
+			patterns: []wildcard.Wildcard{"*-system", "foobar"},
 			ns:       "kube-system",
-			excluded: true,
+			matched:  true,
 		},
 		{
-			name: "lack of asterisk prevents globbing",
-			nsMap: map[wildcard.Wildcard]bool{
-				"kube-": true,
-			},
+			name:     "lack of asterisk prevents globbing",
+			patterns: []wildcard.Wildcard{"kube-"},
 			ns:       "kube-system",
-			excluded: false,
+			matched:  false,
 		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			if exactOrWildcardMatch(tc.nsMap, tc.ns) != tc.excluded {
-				if tc.excluded {
-					t.Errorf("Expected ns '%v' to match map: %v", tc.ns, tc.nsMap)
+			if wildcardMatch(tc.patterns, tc.ns) != tc.matched {
+				if tc.matched {
+					t.Errorf("Expected ns '%v' to match patterns: %v", tc.ns, tc.patterns)
 				} else {
-					t.Errorf("ns '%v' unexpectedly matched map: %v", tc.ns, tc.nsMap)
+					t.Errorf("ns '%v' unexpectedly matched patterns: %v", tc.ns, tc.patterns)
 				}
 			}
 		})
@@ -141,12 +133,47 @@ func TestGetExcludedNamespaces(t *testing.T) {
 			process:            Audit,
 			expectedNamespaces: []string{},
 		},
+		{
+			name: "entries with GVK filters are excluded from GetExcludedNamespaces",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Processes:          []string{"audit"},
+				},
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"monitoring"},
+					Kinds:              []string{"ConfigMap"},
+					Processes:          []string{"audit"},
+				},
+			},
+			process:            Audit,
+			expectedNamespaces: []string{"kube-system"},
+		},
+		{
+			name: "entries with namespace selector are excluded from GetExcludedNamespaces",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"default"},
+					Processes:          []string{"webhook"},
+				},
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"webhook"},
+				},
+			},
+			process:            Webhook,
+			expectedNamespaces: []string{"default"},
+		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			excluder := New()
-			excluder.Add(tc.matchEntries)
+			if err := excluder.Add(tc.matchEntries); err != nil {
+				t.Fatalf("unexpected error from Add: %v", err)
+			}
 
 			actualNamespaces := excluder.GetExcludedNamespaces(tc.process)
 
@@ -166,5 +193,655 @@ func TestGetExcludedNamespaces(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func makeObj(group, version, kind, name, namespace string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{Group: group, Version: version, Kind: kind})
+	obj.SetName(name)
+	obj.SetNamespace(namespace)
+	return obj
+}
+
+func makeNamespace(name string, labels map[string]string) *unstructured.Unstructured {
+	obj := makeObj("", "v1", "Namespace", name, "")
+	obj.SetLabels(labels)
+	return obj
+}
+
+func TestIsNamespaceExcluded(t *testing.T) {
+	tcs := []struct {
+		name         string
+		matchEntries []configv1alpha1.MatchEntry
+		process      Process
+		obj          *unstructured.Unstructured
+		excluded     bool
+	}{
+		{
+			name: "namespace excluded by name pattern",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Audit,
+			obj:      makeNamespace("kube-system", nil),
+			excluded: true,
+		},
+		{
+			name: "namespace not excluded",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Audit,
+			obj:      makeNamespace("default", nil),
+			excluded: false,
+		},
+		{
+			name: "pod in excluded namespace",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "kube-system"),
+			excluded: true,
+		},
+		{
+			name: "pod not in excluded namespace",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "default"),
+			excluded: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			excluder := New()
+			if err := excluder.Add(tc.matchEntries); err != nil {
+				t.Fatalf("unexpected error from Add: %v", err)
+			}
+			excluded, err := excluder.IsNamespaceExcluded(tc.process, tc.obj)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if excluded != tc.excluded {
+				t.Errorf("expected excluded=%v, got %v", tc.excluded, excluded)
+			}
+		})
+	}
+}
+
+func TestIsObjectExcludedWithGVK(t *testing.T) {
+	tcs := []struct {
+		name         string
+		matchEntries []configv1alpha1.MatchEntry
+		process      Process
+		obj          *unstructured.Unstructured
+		nsLabels     map[string]string
+		excluded     bool
+	}{
+		{
+			name: "configmap excluded by kind filter",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Kinds:              []string{"ConfigMap"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "ConfigMap", "my-cm", "kube-system"),
+			excluded: true,
+		},
+		{
+			name: "pod not excluded by configmap kind filter",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Kinds:              []string{"ConfigMap"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "kube-system"),
+			excluded: false,
+		},
+		{
+			name: "apiGroup filter matches",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"default"},
+					APIGroups:          []string{"apps"},
+					Kinds:              []string{"Deployment"},
+					Processes:          []string{"audit"},
+				},
+			},
+			process:  Audit,
+			obj:      makeObj("apps", "v1", "Deployment", "my-deploy", "default"),
+			excluded: true,
+		},
+		{
+			name: "apiGroup filter does not match",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"default"},
+					APIGroups:          []string{"apps"},
+					Kinds:              []string{"Deployment"},
+					Processes:          []string{"audit"},
+				},
+			},
+			process:  Audit,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "default"),
+			excluded: false,
+		},
+		{
+			name: "apiVersion filter matches",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"default"},
+					APIVersions:        []string{"v1"},
+					Kinds:              []string{"ConfigMap"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Sync,
+			obj:      makeObj("", "v1", "ConfigMap", "my-cm", "default"),
+			excluded: true,
+		},
+		{
+			name: "apiVersion filter does not match",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"default"},
+					APIVersions:        []string{"v1beta1"},
+					Kinds:              []string{"ConfigMap"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Sync,
+			obj:      makeObj("", "v1", "ConfigMap", "my-cm", "default"),
+			excluded: false,
+		},
+		{
+			name: "multiple kinds in filter",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"default"},
+					Kinds:              []string{"ConfigMap", "Secret"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Secret", "my-secret", "default"),
+			excluded: true,
+		},
+		{
+			name: "no GVK filter matches everything",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("apps", "v1", "Deployment", "my-deploy", "kube-system"),
+			excluded: true,
+		},
+		{
+			name: "GVK filter with wrong namespace not excluded",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+					Kinds:              []string{"ConfigMap"},
+					Processes:          []string{"*"},
+				},
+			},
+			process:  Audit,
+			obj:      makeObj("", "v1", "ConfigMap", "my-cm", "default"),
+			excluded: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			excluder := New()
+			if err := excluder.Add(tc.matchEntries); err != nil {
+				t.Fatalf("unexpected error from Add: %v", err)
+			}
+			excluded, err := excluder.IsObjectExcluded(tc.process, tc.obj, tc.nsLabels)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if excluded != tc.excluded {
+				t.Errorf("expected excluded=%v, got %v", tc.excluded, excluded)
+			}
+		})
+	}
+}
+
+func TestIsObjectExcludedWithNamespaceSelector(t *testing.T) {
+	tcs := []struct {
+		name         string
+		matchEntries []configv1alpha1.MatchEntry
+		process      Process
+		obj          *unstructured.Unstructured
+		nsLabels     map[string]string
+		excluded     bool
+	}{
+		{
+			name: "namespace selector matches namespace object labels",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeNamespace("my-ns", map[string]string{"env": "dev"}),
+			nsLabels: map[string]string{"env": "dev"},
+			excluded: true,
+		},
+		{
+			name: "namespace selector does not match namespace object labels",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeNamespace("my-ns", map[string]string{"env": "prod"}),
+			nsLabels: map[string]string{"env": "prod"},
+			excluded: false,
+		},
+		{
+			name: "namespace selector with GVK filter - configmap in labeled namespace",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Kinds:       []string{"ConfigMap"},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Audit,
+			obj:      makeObj("", "v1", "ConfigMap", "my-cm", "dev-ns"),
+			nsLabels: map[string]string{"env": "dev"},
+			excluded: true,
+		},
+		{
+			name: "namespace selector with GVK filter - wrong kind not excluded",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Kinds:       []string{"ConfigMap"},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Audit,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "dev-ns"),
+			nsLabels: map[string]string{"env": "dev"},
+			excluded: false,
+		},
+		{
+			name: "namespace selector with GVK filter - labels don't match",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Kinds:       []string{"ConfigMap"},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Audit,
+			obj:      makeObj("", "v1", "ConfigMap", "my-cm", "prod-ns"),
+			nsLabels: map[string]string{"env": "prod"},
+			excluded: false,
+		},
+		{
+			name: "namespace selector with nil nsLabels - not excluded",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "some-ns"),
+			nsLabels: nil,
+			excluded: false,
+		},
+		{
+			name: "namespace selector via IsNamespaceExcluded on Namespace object",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Audit,
+			obj:      makeNamespace("dev-ns", map[string]string{"env": "dev"}),
+			nsLabels: map[string]string{"env": "dev"},
+			excluded: true,
+		},
+		{
+			name: "combined namespace pattern and selector",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"dev-*"},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "dev-ns"),
+			nsLabels: map[string]string{"env": "dev"},
+			excluded: true,
+		},
+		{
+			name: "namespace pattern matches but selector does not",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"dev-*"},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "dev-ns"),
+			nsLabels: map[string]string{"env": "prod"},
+			excluded: false,
+		},
+		{
+			name: "selector matches but namespace pattern does not",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"dev-*"},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"env": "dev"},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "prod-ns"),
+			nsLabels: map[string]string{"env": "dev"},
+			excluded: false,
+		},
+		{
+			name: "matchExpressions selector",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "env",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"dev", "staging"},
+							},
+						},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "staging-ns"),
+			nsLabels: map[string]string{"env": "staging"},
+			excluded: true,
+		},
+		{
+			name: "matchExpressions selector does not match",
+			matchEntries: []configv1alpha1.MatchEntry{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "env",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"dev", "staging"},
+							},
+						},
+					},
+					Processes: []string{"*"},
+				},
+			},
+			process:  Webhook,
+			obj:      makeObj("", "v1", "Pod", "my-pod", "prod-ns"),
+			nsLabels: map[string]string{"env": "prod"},
+			excluded: false,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			excluder := New()
+			if err := excluder.Add(tc.matchEntries); err != nil {
+				t.Fatalf("unexpected error from Add: %v", err)
+			}
+			excluded, err := excluder.IsObjectExcluded(tc.process, tc.obj, tc.nsLabels)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if excluded != tc.excluded {
+				t.Errorf("expected excluded=%v, got %v", tc.excluded, excluded)
+			}
+		})
+	}
+}
+
+func TestIsNamespaceExcludedWithNamespaceSelector(t *testing.T) {
+	// Test that IsNamespaceExcluded automatically uses the Namespace object's labels
+	excluder := New()
+	if err := excluder.Add([]configv1alpha1.MatchEntry{
+		{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"env": "dev"},
+			},
+			Processes: []string{"*"},
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error from Add: %v", err)
+	}
+
+	// Namespace with matching labels - should be excluded
+	devNS := makeNamespace("dev-ns", map[string]string{"env": "dev"})
+	excluded, err := excluder.IsNamespaceExcluded(Webhook, devNS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !excluded {
+		t.Error("expected dev namespace to be excluded")
+	}
+
+	// Namespace without matching labels - should not be excluded
+	prodNS := makeNamespace("prod-ns", map[string]string{"env": "prod"})
+	excluded, err = excluder.IsNamespaceExcluded(Webhook, prodNS)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if excluded {
+		t.Error("expected prod namespace to not be excluded")
+	}
+
+	// Non-namespace object - IsNamespaceExcluded can't provide ns labels, so selector won't match
+	pod := makeObj("", "v1", "Pod", "my-pod", "dev-ns")
+	excluded, err = excluder.IsNamespaceExcluded(Webhook, pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if excluded {
+		t.Error("expected pod to not be excluded via IsNamespaceExcluded (no ns labels available)")
+	}
+}
+
+func TestMultipleEntriesOR(t *testing.T) {
+	// Multiple entries should be OR-ed: if any entry matches, the object is excluded
+	excluder := New()
+	if err := excluder.Add([]configv1alpha1.MatchEntry{
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+			Processes:          []string{"*"},
+		},
+		{
+			Kinds:     []string{"Secret"},
+			Processes: []string{"*"},
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"sensitive": "true"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error from Add: %v", err)
+	}
+
+	// Matches first entry (namespace pattern)
+	pod := makeObj("", "v1", "Pod", "my-pod", "kube-system")
+	excluded, err := excluder.IsObjectExcluded(Webhook, pod, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !excluded {
+		t.Error("expected pod in kube-system to be excluded by first entry")
+	}
+
+	// Matches second entry (kind + namespace selector)
+	secret := makeObj("", "v1", "Secret", "my-secret", "app-ns")
+	excluded, err = excluder.IsObjectExcluded(Webhook, secret, map[string]string{"sensitive": "true"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !excluded {
+		t.Error("expected secret in sensitive namespace to be excluded by second entry")
+	}
+
+	// Doesn't match either entry
+	cm := makeObj("", "v1", "ConfigMap", "my-cm", "default")
+	excluded, err = excluder.IsObjectExcluded(Webhook, cm, map[string]string{"sensitive": "false"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if excluded {
+		t.Error("expected configmap in default to not be excluded")
+	}
+}
+
+func TestEqualsAndReplace(t *testing.T) {
+	e1 := New()
+	if err := e1.Add([]configv1alpha1.MatchEntry{
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+			Kinds:              []string{"ConfigMap"},
+			Processes:          []string{"*"},
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error from Add: %v", err)
+	}
+
+	e2 := New()
+	if err := e2.Add([]configv1alpha1.MatchEntry{
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+			Kinds:              []string{"ConfigMap"},
+			Processes:          []string{"*"},
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error from Add: %v", err)
+	}
+
+	if !e1.Equals(e2) {
+		t.Error("expected equal excluders to be equal")
+	}
+
+	e3 := New()
+	if err := e3.Add([]configv1alpha1.MatchEntry{
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"default"},
+			Processes:          []string{"*"},
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error from Add: %v", err)
+	}
+
+	if e1.Equals(e3) {
+		t.Error("expected different excluders to not be equal")
+	}
+
+	// Test Replace
+	e1.Replace(e3)
+	if !e1.Equals(e3) {
+		t.Error("expected excluder to equal replacement after Replace")
+	}
+}
+
+func TestEqualsForProcess(t *testing.T) {
+	e1 := New()
+	if err := e1.Add([]configv1alpha1.MatchEntry{
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+			Processes:          []string{"audit"},
+		},
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"default"},
+			Processes:          []string{"webhook"},
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error from Add: %v", err)
+	}
+
+	e2 := New()
+	if err := e2.Add([]configv1alpha1.MatchEntry{
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"kube-system"},
+			Processes:          []string{"audit"},
+		},
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"monitoring"},
+			Processes:          []string{"webhook"},
+		},
+	}); err != nil {
+		t.Fatalf("unexpected error from Add: %v", err)
+	}
+
+	if !e1.EqualsForProcess(Audit, e2) {
+		t.Error("expected audit process entries to be equal")
+	}
+
+	if e1.EqualsForProcess(Webhook, e2) {
+		t.Error("expected webhook process entries to not be equal")
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `apiGroups`, `apiVersions`, `kinds`, and `namespaceSelector` fields to the Config `MatchEntry` type, enabling fine-grained resource-level exclusion filtering.

Currently, Config match exclusions can only filter by namespace name patterns (`excludedNamespaces`). This PR extends `MatchEntry` to support:

- **GVK filtering** (`apiGroups`, `apiVersions`, `kinds`) — exclude only specific resource types
- **Namespace label selectors** (`namespaceSelector`) — exclude resources in namespaces matching a label selector

All criteria within a single entry are AND-ed (all must match). Multiple entries are OR-ed (any match triggers exclusion). Unspecified fields match everything, preserving full backward compatibility.

Example:
```yaml
spec:
  match:
    - apiGroups: [""]
      apiVersions: ["v1"]
      kinds: ["ConfigMap"]
      namespaceSelector:
        matchLabels:
          env: dev
      processes: ["*"]
```

A new `IsObjectExcluded(process, obj, nsLabels)` method is added for callers that can provide namespace labels. The existing `IsNamespaceExcluded` method continues to work unchanged and automatically supports namespace selector matching for Namespace objects.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

- `GetExcludedNamespaces` intentionally skips entries with GVK or selector filters, since those entries don't unconditionally exclude a namespace (used by VAP generation).
- Callers of `IsNamespaceExcluded` (webhook, audit, cachemanager) are unchanged. Wiring `IsObjectExcluded` with namespace label lookups at call sites can be done as a follow-up.
- The `zz_generated.deepcopy.go` was updated manually to match the new fields. A `make generate` run should produce equivalent output.