### PR TITLE
chore: cherry-pick trivy bump to 0.69.3 for release-3.22

### DIFF
--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -62,7 +62,7 @@ jobs:
           tar zxvf trivy_${{ env.TRIVY_VERSION }}_Linux-64bit.tar.gz
           echo "$(pwd)" >> $GITHUB_PATH
         env:
-          TRIVY_VERSION: "0.64.1"
+          TRIVY_VERSION: "0.69.3"
 
       - name: Download trivy db
         run: |


### PR DESCRIPTION
Cherry-pick of #4424 to release-3.22 branch.

Bumps trivy from the older version to 0.69.3 to fix CI scan failures on the release branch.