### PR TITLE
chore: update YQ version from 4.35.2 to 4.52.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ORAS_VERSION ?= 1.2.3
 BATS_TESTS_FILE ?= test/bats/test.bats
 HELM_VERSION ?= 3.17.4
 NODE_VERSION ?= 24-bullseye-slim
-YQ_VERSION ?= 4.35.2
+YQ_VERSION ?= 4.52.4
 
 HELM_ARGS ?=
 HELM_DAPR_EXPORT_ARGS := --set-string auditPodAnnotations.dapr\\.io/enabled=true \


### PR DESCRIPTION
## What this PR does / why we need it

Updates the YQ YAML processing tool from version 4.35.2 to 4.52.4 (latest stable). This is a test-only dependency used in e2e tests and the test image — it does not affect the Gatekeeper build or runtime.

Part of #4082 — isolating each tool version change into a separate PR as requested.

### Changes
- `Makefile`: `YQ_VERSION` from `4.35.2` to `4.52.4`

This version flows to:
- `e2e-dependencies` target (binary download)
- `test/image/Dockerfile` (Docker build arg)

### Testing
- CI e2e tests will validate the new version since all YAML manipulation in tests uses yq.

Fixes #4082 (partial)