### PR TITLE
chore: update BATS version from 1.12.0 to 1.13.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ KIND_CLUSTER_FILE ?= ""
 # note: k8s version pinned since KIND image availability lags k8s releases
 KUBERNETES_VERSION ?= 1.33.0
 KUSTOMIZE_VERSION ?= 3.8.9
-BATS_VERSION ?= 1.12.0
+BATS_VERSION ?= 1.13.0
 ORAS_VERSION ?= 1.2.3
 BATS_TESTS_FILE ?= test/bats/test.bats
 HELM_VERSION ?= 3.17.4


### PR DESCRIPTION
## What this PR does / why we need it

Updates the BATS test framework from 1.12.0 to 1.13.0 (latest stable). BATS is used for all e2e tests and the test image — it does not affect the Gatekeeper build or runtime.

Part of #4082 — isolating each tool version change into a separate PR as requested.

### Changes
- `Makefile`: `BATS_VERSION` from `1.12.0` to `1.13.0`

Fixes #4082 (partial)