### PR TITLE
fix: allow mutation-webhook only operation without constraint client …

### DIFF
--- a/main.go
+++ b/main.go
@@ -428,42 +428,47 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 
 	cfArgs := []constraintclient.Opt{constraintclient.Targets(&target.K8sValidationTarget{})}
 
-	if *enableK8sCel {
-		k8sDriver, err := k8scel.New()
+	var client *constraintclient.Client
+
+	if operations.HasValidationOperations() {
+		if *enableK8sCel {
+			k8sDriver, err := k8scel.New()
+			if err != nil {
+				setupLog.Error(err, "unable to set up K8s native driver")
+				return err
+			}
+			cfArgs = append(cfArgs, constraintclient.Driver(k8sDriver))
+		}
+
+		externs := rego.Externs()
+		if *enableReferential {
+			externs = rego.Externs("inventory")
+		}
+		args = append(args, externs)
+
+		driver, err := rego.New(args...)
 		if err != nil {
-			setupLog.Error(err, "unable to set up K8s native driver")
+			setupLog.Error(err, "unable to set up Driver")
 			return err
 		}
-		cfArgs = append(cfArgs, constraintclient.Driver(k8sDriver))
-	}
+		cfArgs = append(cfArgs, constraintclient.Driver(driver))
 
-	externs := rego.Externs()
-	if *enableReferential {
-		externs = rego.Externs("inventory")
-	}
-	args = append(args, externs)
+		eps := []string{}
+		if operations.IsAssigned(operations.Audit) {
+			eps = append(eps, util.AuditEnforcementPoint)
+		}
+		if operations.IsAssigned(operations.Webhook) {
+			eps = append(eps, util.WebhookEnforcementPoint)
+		}
 
-	driver, err := rego.New(args...)
-	if err != nil {
-		setupLog.Error(err, "unable to set up Driver")
-		return err
-	}
-	cfArgs = append(cfArgs, constraintclient.Driver(driver))
+		cfArgs = append(cfArgs, constraintclient.EnforcementPoints(eps...))
 
-	eps := []string{}
-	if operations.IsAssigned(operations.Audit) {
-		eps = append(eps, util.AuditEnforcementPoint)
-	}
-	if operations.IsAssigned(operations.Webhook) {
-		eps = append(eps, util.WebhookEnforcementPoint)
-	}
-
-	cfArgs = append(cfArgs, constraintclient.EnforcementPoints(eps...))
-
-	client, err := constraintclient.NewClient(cfArgs...)
-	if err != nil {
-		setupLog.Error(err, "unable to set up OPA client")
-		return err
+		var clientErr error
+		client, clientErr = constraintclient.NewClient(cfArgs...)
+		if clientErr != nil {
+			setupLog.Error(clientErr, "unable to set up OPA client")
+			return clientErr
+		}
 	}
 
 	mutationSystem := mutation.NewSystem(mutationOpts)
@@ -512,14 +517,20 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 	}
 
 	syncMetricsCache := syncutil.NewMetricsCache()
-	cm, err := cachemanager.NewCacheManager(&cachemanager.Config{
-		CfClient:         client,
+
+	cmConfig := &cachemanager.Config{
 		SyncMetricsCache: syncMetricsCache,
 		Tracker:          tracker,
 		ProcessExcluder:  processExcluder,
 		Registrar:        reg,
 		Reader:           mgr.GetCache(),
-	})
+	}
+
+	if client != nil {
+		cmConfig.CfClient = client
+	}
+
+	cm, err := cachemanager.NewCacheManager(cmConfig)
 	if err != nil {
 		setupLog.Error(err, "unable to create cache manager")
 		return err

--- a/pkg/cachemanager/cachemanager.go
+++ b/pkg/cachemanager/cachemanager.go
@@ -71,6 +71,18 @@ type CFDataClient interface {
 	RemoveData(ctx context.Context, data interface{}) (*types.Responses, error)
 }
 
+// noopCFDataClient is a no-op implementation of CFDataClient used when no
+// real client is provided.
+type noopCFDataClient struct{}
+
+func (*noopCFDataClient) AddData(_ context.Context, _ interface{}) (*types.Responses, error) {
+	return &types.Responses{}, nil
+}
+
+func (*noopCFDataClient) RemoveData(_ context.Context, _ interface{}) (*types.Responses, error) {
+	return &types.Responses{}, nil
+}
+
 type registrarReplacer interface {
 	ReplaceWatch(ctx context.Context, gvks []schema.GroupVersionKind) error
 }
@@ -93,8 +105,13 @@ func NewCacheManager(config *Config) (*CacheManager, error) {
 		config.GVKAggregator = aggregator.NewGVKAggregator()
 	}
 
+	cfClient := config.CfClient
+	if cfClient == nil {
+		cfClient = &noopCFDataClient{}
+	}
+
 	cm := &CacheManager{
-		cfClient:                   config.CfClient,
+		cfClient:                   cfClient,
 		syncMetricsCache:           config.SyncMetricsCache,
 		tracker:                    config.Tracker,
 		processExcluder:            config.ProcessExcluder,

--- a/pkg/cachemanager/cachemanager_test.go
+++ b/pkg/cachemanager/cachemanager_test.go
@@ -133,15 +133,26 @@ func TestCacheManager_wipeCacheIfNeeded(t *testing.T) {
 			},
 			expectedData: map[fakes.CfDataKey]interface{}{{Gvk: configMapGVK, Key: "default/config-test-1"}: nil},
 		},
+		{
+			name: "handle noop cfClient gracefully",
+			cm: &CacheManager{
+				cfClient:         &noopCFDataClient{},
+				syncMetricsCache: syncutil.NewMetricsCache(),
+				gvksToDeleteFromCache: func() *watch.Set {
+					gvksToDelete := watch.NewSet()
+					gvksToDelete.Add(configMapGVK)
+					return gvksToDelete
+				}(),
+			},
+		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			cfClient, ok := tc.cm.cfClient.(*fakes.FakeCfClient)
-			require.True(t, ok)
-
 			tc.cm.wipeCacheIfNeeded(context.Background())
-			require.True(t, cfClient.Contains(tc.expectedData))
+			if cfClient, ok := tc.cm.cfClient.(*fakes.FakeCfClient); ok {
+				require.True(t, cfClient.Contains(tc.expectedData))
+			}
 		})
 	}
 }
@@ -242,6 +253,23 @@ func TestCacheManager_AddObject(t *testing.T) {
 			expectSyncMetric:     true,
 			expectedMetricStatus: metrics.ErrorStatus,
 		},
+		{
+			name: "AddObject is a no-op with noop cfClient",
+			cm: &CacheManager{
+				cfClient: &noopCFDataClient{},
+				watchedSet: func() *watch.Set {
+					ws := watch.NewSet()
+					ws.Add(pod.GroupVersionKind())
+
+					return ws
+				}(),
+				tracker:          readiness.NewTracker(mgr.GetAPIReader(), false, false, false),
+				syncMetricsCache: syncutil.NewMetricsCache(),
+				processExcluder:  process.Get(),
+			},
+			expectSyncMetric:     true,
+			expectedMetricStatus: metrics.ActiveStatus,
+		},
 	}
 
 	for _, tc := range tcs {
@@ -251,18 +279,17 @@ func TestCacheManager_AddObject(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			assertExpecations(t, tc.cm, &unstructured.Unstructured{Object: unstructuredPod}, tc.expectedData, tc.expectSyncMetric, &tc.expectedMetricStatus)
+			assertExpectations(t, tc.cm, &unstructured.Unstructured{Object: unstructuredPod}, tc.expectedData, tc.expectSyncMetric, &tc.expectedMetricStatus)
 		})
 	}
 }
 
-func assertExpecations(t *testing.T, cm *CacheManager, instance *unstructured.Unstructured, expectedData map[fakes.CfDataKey]interface{}, expectSyncMetric bool, expectedMetricStatus *metrics.Status) {
+func assertExpectations(t *testing.T, cm *CacheManager, instance *unstructured.Unstructured, expectedData map[fakes.CfDataKey]interface{}, expectSyncMetric bool, expectedMetricStatus *metrics.Status) {
 	t.Helper()
 
-	cfClient, ok := cm.cfClient.(*fakes.FakeCfClient)
-	require.True(t, ok)
-
-	require.True(t, cfClient.Contains(expectedData))
+	if cfClient, ok := cm.cfClient.(*fakes.FakeCfClient); ok {
+		require.True(t, cfClient.Contains(expectedData))
+	}
 
 	syncKey := syncutil.GetKeyForSyncMetrics(instance.GetNamespace(), instance.GetName())
 
@@ -353,13 +380,29 @@ func TestCacheManager_RemoveObject(t *testing.T) {
 			expectedData:     map[fakes.CfDataKey]interface{}{},
 			expectSyncMetric: false,
 		},
+		{
+			name: "RemoveObject is a no-op with noop cfClient",
+			cm: &CacheManager{
+				cfClient: &noopCFDataClient{},
+				watchedSet: func() *watch.Set {
+					ws := watch.NewSet()
+					ws.Add(pod.GroupVersionKind())
+
+					return ws
+				}(),
+				tracker:          tracker,
+				syncMetricsCache: syncutil.NewMetricsCache(),
+				processExcluder:  process.Get(),
+			},
+			expectSyncMetric: false,
+		},
 	}
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NoError(t, tc.cm.RemoveObject(context.Background(), &unstructured.Unstructured{Object: unstructuredPod}))
 
-			assertExpecations(t, tc.cm, &unstructured.Unstructured{Object: unstructuredPod}, tc.expectedData, tc.expectSyncMetric, nil)
+			assertExpectations(t, tc.cm, &unstructured.Unstructured{Object: unstructuredPod}, tc.expectedData, tc.expectSyncMetric, nil)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: cherry-pick #4423 fix: allow mutation-webhook only operation without constraint client for release-3.22

**Which issue(s) this PR fixes**:
Fixes #3928

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->
