### PR TITLE
chore: update kustomize version from 3.8.9 to 5.6.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ KIND_VERSION ?= 0.29.0
 KIND_CLUSTER_FILE ?= ""
 # note: k8s version pinned since KIND image availability lags k8s releases
 KUBERNETES_VERSION ?= 1.33.0
-KUSTOMIZE_VERSION ?= 3.8.9
+KUSTOMIZE_VERSION ?= 5.6.0
 BATS_VERSION ?= 1.13.0
 ORAS_VERSION ?= 1.3.1
 BATS_TESTS_FILE ?= test/bats/test.bats
@@ -400,7 +400,7 @@ manifests: __controller-gen
 		/gatekeeper/config/default -o /gatekeeper/manifest_staging/deploy/gatekeeper.yaml
 	docker run --rm -v $(shell pwd):/gatekeeper \
 		registry.k8s.io/kustomize/kustomize:v${KUSTOMIZE_VERSION} build \
-		--load_restrictor LoadRestrictionsNone /gatekeeper/cmd/build/helmify | go run cmd/build/helmify/*.go
+		--load-restrictor LoadRestrictionsNone /gatekeeper/cmd/build/helmify | go run cmd/build/helmify/*.go
 
 # lint runs a dockerized golangci-lint, and should give consistent results
 # across systems.

--- a/cmd/build/helmify/delete-ports.yaml
+++ b/cmd/build/helmify/delete-ports.yaml
@@ -10,10 +10,13 @@ spec:
         - name: manager
           ports:
             - containerPort: 8888
+              protocol: TCP
               $patch: delete
             - containerPort: 8443
+              protocol: TCP
               $patch: delete
             - containerPort: 9090
+              protocol: TCP
               $patch: delete
 ---
 kind: Deployment
@@ -28,6 +31,8 @@ spec:
         - name: manager
           ports:
             - containerPort: 8888
+              protocol: TCP
               $patch: delete
             - containerPort: 9090
+              protocol: TCP
               $patch: delete

--- a/cmd/build/helmify/kustomization.yaml
+++ b/cmd/build/helmify/kustomization.yaml
@@ -4,7 +4,7 @@ commonLabels:
   chart: '{{ template "gatekeeper.name" . }}'
   release: "{{ .Release.Name }}"
   heritage: "{{ .Release.Service }}"
-bases:
+resources:
   - "../../../config/default"
 patchesStrategicMerge:
   - kustomize-for-helm.yaml

--- a/cmd/build/helmify/kustomize-for-helm.yaml
+++ b/cmd/build/helmify/kustomize-for-helm.yaml
@@ -276,7 +276,8 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  annotations: HELMSUBST_SECRET_ANNOTATIONS
+  annotations:
+    HELMSUBST_SECRET_ANNOTATIONS: ""
   name: gatekeeper-webhook-server-cert
   namespace: gatekeeper-system
 ---
@@ -286,7 +287,8 @@ metadata:
   labels:
     gatekeeper.sh/system: "yes"
   name: gatekeeper-mutating-webhook-configuration
-  annotations: HELMSUBST_MUTATING_WEBHOOK_ANNOTATIONS
+  annotations:
+    HELMSUBST_MUTATING_WEBHOOK_ANNOTATIONS: ""
 webhooks:
 - clientConfig:
     service:
@@ -315,7 +317,8 @@ metadata:
   labels:
     gatekeeper.sh/system: "yes"
   name: gatekeeper-validating-webhook-configuration
-  annotations: HELMSUBST_VALIDATING_WEBHOOK_ANNOTATIONS
+  annotations:
+    HELMSUBST_VALIDATING_WEBHOOK_ANNOTATIONS: ""
 webhooks:
 - clientConfig:
     service:

--- a/cmd/build/helmify/replacements.go
+++ b/cmd/build/helmify/replacements.go
@@ -110,7 +110,7 @@ var replacements = map[string]string{
 
 	"- HELMSUBST_DEPLOYMENT_AUDIT_LOG_STATS_ADMISSION": `{{ if hasKey .Values "logStatsAudit" }}- --log-stats-audit={{ .Values.logStatsAudit }}{{- end }}`,
 
-	"HELMSUBST_SECRET_ANNOTATIONS": `{{- toYaml .Values.secretAnnotations | trim | nindent 4 }}`,
+	`HELMSUBST_SECRET_ANNOTATIONS: ""`: `{{- toYaml .Values.secretAnnotations | trim | nindent 4 }}`,
 
 	"- HELMSUBST_TLS_HEALTHCHECK_ENABLED_ARG": `{{ if .Values.enableTLSHealthcheck}}- --enable-tls-healthcheck{{- end }}`,
 
@@ -159,7 +159,7 @@ var replacements = map[string]string{
 
 	"HELMSUBST_MUTATING_WEBHOOK_REINVOCATION_POLICY": `{{ .Values.mutatingWebhookReinvocationPolicy }}`,
 
-	"HELMSUBST_MUTATING_WEBHOOK_ANNOTATIONS": `{{- toYaml .Values.mutatingWebhookAnnotations | trim | nindent 4 }}`,
+	`HELMSUBST_MUTATING_WEBHOOK_ANNOTATIONS: ""`: `{{- toYaml .Values.mutatingWebhookAnnotations | trim | nindent 4 }}`,
 
 	"- HELMSUBST_MUTATING_WEBHOOK_EXEMPT_NAMESPACE_LABELS": `
     {{- /* 1. Get mandatory exemption from helper */ -}}
@@ -216,7 +216,7 @@ var replacements = map[string]string{
 
 	"HELMSUBST_VALIDATING_WEBHOOK_FAILURE_POLICY": `{{ .Values.validatingWebhookFailurePolicy }}`,
 
-	"HELMSUBST_VALIDATING_WEBHOOK_ANNOTATIONS": `{{- toYaml .Values.validatingWebhookAnnotations | trim | nindent 4 }}`,
+	`HELMSUBST_VALIDATING_WEBHOOK_ANNOTATIONS: ""`: `{{- toYaml .Values.validatingWebhookAnnotations | trim | nindent 4 }}`,
 
 	"HELMSUBST_VALIDATING_WEBHOOK_MATCHEXPRESSION_METADATANAME": `key: kubernetes.io/metadata.name
       operator: NotIn

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,7 +12,7 @@ namePrefix: gatekeeper-
 commonLabels:
   gatekeeper.sh/system: "yes"
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager

--- a/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
@@ -70,7 +70,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main]`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main]`.'
                 type: string
               match:
                 description: |-
@@ -126,14 +127,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -179,14 +182,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -258,7 +263,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -285,20 +291,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   pathTests:
@@ -316,7 +327,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -332,13 +344,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -424,7 +438,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main]`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main]`.'
                 type: string
               match:
                 description: |-
@@ -480,14 +495,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -533,14 +550,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -612,7 +631,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -639,20 +659,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   pathTests:
@@ -670,7 +695,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -686,13 +712,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -778,7 +806,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main]`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main]`.'
                 type: string
               match:
                 description: |-
@@ -834,14 +863,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -887,14 +918,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -966,7 +999,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -993,20 +1027,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   pathTests:
@@ -1024,7 +1063,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -1040,13 +1080,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string

--- a/manifest_staging/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
@@ -70,7 +70,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].image`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main].image`.'
                 type: string
               match:
                 description: |-
@@ -126,14 +127,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -179,14 +182,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -260,7 +265,8 @@ spec:
                       slash should not be included.
                     type: string
                   assignPath:
-                    description: AssignPath sets the domain component on an image string.
+                    description: AssignPath sets the domain component on an image
+                      string.
                     type: string
                   assignTag:
                     description: |-
@@ -282,7 +288,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -298,13 +305,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string

--- a/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
@@ -98,14 +98,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -151,14 +153,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -229,7 +233,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -256,20 +261,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
@@ -282,13 +292,15 @@ spec:
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -402,14 +414,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -455,14 +469,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -533,7 +549,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -560,20 +577,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
@@ -586,13 +608,15 @@ spec:
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -706,14 +730,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -759,14 +785,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -837,7 +865,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -864,20 +893,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
@@ -890,13 +924,15 @@ spec:
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string

--- a/manifest_staging/charts/gatekeeper/crds/config-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/config-customresourcedefinition.yaml
@@ -70,7 +70,8 @@ spec:
                 description: Configuration for syncing k8s objects
                 properties:
                   syncOnly:
-                    description: If non-empty, only entries on this list will be replicated into OPA
+                    description: If non-empty, only entries on this list will be replicated
+                      into OPA
                     items:
                       properties:
                         group:
@@ -86,11 +87,13 @@ spec:
                 description: Configuration for validation
                 properties:
                   traces:
-                    description: List of requests to trace. Both "user" and "kinds" must be specified
+                    description: List of requests to trace. Both "user" and "kinds"
+                      must be specified
                     items:
                       properties:
                         dump:
-                          description: Also dump the state of OPA with the trace. Set to `All` to dump everything.
+                          description: Also dump the state of OPA with the trace.
+                            Set to `All` to dump everything.
                           type: string
                         kind:
                           description: Only trace requests of the following GroupVersionKind

--- a/manifest_staging/charts/gatekeeper/crds/connection-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/connection-customresourcedefinition.yaml
@@ -44,7 +44,8 @@ spec:
               config:
                 x-kubernetes-preserve-unknown-fields: true
               driver:
-                description: Driver is the name of one of the expected drivers i.e. dapr, disk
+                description: Driver is the name of one of the expected drivers i.e.
+                  dapr, disk
                 type: string
             required:
             - config
@@ -55,10 +56,12 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ConnectionPodStatusStatus defines the observed state of ConnectionPodStatus.
+                  description: ConnectionPodStatusStatus defines the observed state
+                    of ConnectionPodStatus.
                   properties:
                     active:
-                      description: Indicator for alive connection with at least one successful publish
+                      description: Indicator for alive connection with at least one
+                        successful publish
                       type: boolean
                     connectionUID:
                       description: |-
@@ -79,7 +82,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: ID is the unique identifier for the pod that wrote the status
+                      description: ID is the unique identifier for the pod that wrote
+                        the status
                       type: string
                     observedGeneration:
                       format: int64

--- a/manifest_staging/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
@@ -19,7 +19,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ConnectionPodStatus is the Schema for the connectionpodstatuses API.
+        description: ConnectionPodStatus is the Schema for the connectionpodstatuses
+          API.
         properties:
           apiVersion:
             description: |-
@@ -42,7 +43,8 @@ spec:
             description: No spec field is defined here, as this is a status-only resource.
             properties:
               active:
-                description: Indicator for alive connection with at least one successful publish
+                description: Indicator for alive connection with at least one successful
+                  publish
                 type: boolean
               connectionUID:
                 description: |-
@@ -63,7 +65,8 @@ spec:
                   type: object
                 type: array
               id:
-                description: ID is the unique identifier for the pod that wrote the status
+                description: ID is the unique identifier for the pod that wrote the
+                  status
                 type: string
               observedGeneration:
                 format: int64

--- a/manifest_staging/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
@@ -19,7 +19,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ConstraintPodStatus is the Schema for the constraintpodstatuses API.
+        description: ConstraintPodStatus is the Schema for the constraintpodstatuses
+          API.
         properties:
           apiVersion:
             description: |-
@@ -51,7 +52,8 @@ spec:
                 type: boolean
               enforcementPointsStatus:
                 items:
-                  description: EnforcementPointStatus represents the status of a single enforcement point.
+                  description: EnforcementPointStatus represents the status of a single
+                    enforcement point.
                   properties:
                     enforcementPoint:
                       type: string
@@ -69,7 +71,8 @@ spec:
                 type: array
               errors:
                 items:
-                  description: Error represents a single error caught while adding a constraint to engine.
+                  description: Error represents a single error caught while adding
+                    a constraint to engine.
                   properties:
                     code:
                       type: string

--- a/manifest_staging/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
@@ -19,7 +19,8 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates API
+        description: ConstraintTemplate is the Schema for the constrainttemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -42,13 +43,15 @@ spec:
             description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
             properties:
               crd:
-                description: CRD defines the custom resource definition specification for the constraint.
+                description: CRD defines the custom resource definition specification
+                  for the constraint.
                 properties:
                   spec:
                     description: CRDSpec defines the spec for the CRD.
                     properties:
                       names:
-                        description: Names defines the naming conventions for the constraint kind.
+                        description: Names defines the naming conventions for the
+                          constraint kind.
                         properties:
                           kind:
                             type: string
@@ -60,7 +63,8 @@ spec:
                       validation:
                         default:
                           legacySchema: false
-                        description: Validation defines the schema for constraint parameters.
+                        description: Validation defines the schema for constraint
+                          parameters.
                         properties:
                           legacySchema:
                             default: false
@@ -73,17 +77,20 @@ spec:
                 type: object
               targets:
                 items:
-                  description: Target defines the target handler and policy for the constraint template.
+                  description: Target defines the target handler and policy for the
+                    constraint template.
                   properties:
                     code:
                       description: |-
                         The source code options for the constraint template. "Rego" can only
                         be specified in one place (either here or in the "rego" field)
                       items:
-                        description: Code defines the policy source code for a specific engine.
+                        description: Code defines the policy source code for a specific
+                          engine.
                         properties:
                           engine:
-                            description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                            description: 'The engine used to evaluate the code. Example:
+                              "Rego". Required.'
                             type: string
                           source:
                             description: The source code for the template. Required.
@@ -129,7 +136,8 @@ spec:
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught
+                          during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -143,7 +151,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the status
+                      description: a unique identifier for the pod that wrote the
+                        status
                       type: string
                     observedGeneration:
                       format: int64
@@ -162,7 +171,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates API
+        description: ConstraintTemplate is the Schema for the constrainttemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -185,13 +195,15 @@ spec:
             description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
             properties:
               crd:
-                description: CRD defines the custom resource definition specification for the constraint.
+                description: CRD defines the custom resource definition specification
+                  for the constraint.
                 properties:
                   spec:
                     description: CRDSpec defines the spec for the CRD.
                     properties:
                       names:
-                        description: Names defines the naming conventions for the constraint kind.
+                        description: Names defines the naming conventions for the
+                          constraint kind.
                         properties:
                           kind:
                             type: string
@@ -203,7 +215,8 @@ spec:
                       validation:
                         default:
                           legacySchema: true
-                        description: Validation defines the schema for constraint parameters.
+                        description: Validation defines the schema for constraint
+                          parameters.
                         properties:
                           legacySchema:
                             default: true
@@ -216,17 +229,20 @@ spec:
                 type: object
               targets:
                 items:
-                  description: Target defines the target handler and policy for the constraint template.
+                  description: Target defines the target handler and policy for the
+                    constraint template.
                   properties:
                     code:
                       description: |-
                         The source code options for the constraint template. "Rego" can only
                         be specified in one place (either here or in the "rego" field)
                       items:
-                        description: Code defines the policy source code for a specific engine.
+                        description: Code defines the policy source code for a specific
+                          engine.
                         properties:
                           engine:
-                            description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                            description: 'The engine used to evaluate the code. Example:
+                              "Rego". Required.'
                             type: string
                           source:
                             description: The source code for the template. Required.
@@ -272,7 +288,8 @@ spec:
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught
+                          during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -286,7 +303,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the status
+                      description: a unique identifier for the pod that wrote the
+                        status
                       type: string
                     observedGeneration:
                       format: int64
@@ -305,7 +323,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates API
+        description: ConstraintTemplate is the Schema for the constrainttemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -328,13 +347,15 @@ spec:
             description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
             properties:
               crd:
-                description: CRD defines the custom resource definition specification for the constraint.
+                description: CRD defines the custom resource definition specification
+                  for the constraint.
                 properties:
                   spec:
                     description: CRDSpec defines the spec for the CRD.
                     properties:
                       names:
-                        description: Names defines the naming conventions for the constraint kind.
+                        description: Names defines the naming conventions for the
+                          constraint kind.
                         properties:
                           kind:
                             type: string
@@ -346,7 +367,8 @@ spec:
                       validation:
                         default:
                           legacySchema: true
-                        description: Validation defines the schema for constraint parameters.
+                        description: Validation defines the schema for constraint
+                          parameters.
                         properties:
                           legacySchema:
                             default: true
@@ -359,17 +381,20 @@ spec:
                 type: object
               targets:
                 items:
-                  description: Target defines the target handler and policy for the constraint template.
+                  description: Target defines the target handler and policy for the
+                    constraint template.
                   properties:
                     code:
                       description: |-
                         The source code options for the constraint template. "Rego" can only
                         be specified in one place (either here or in the "rego" field)
                       items:
-                        description: Code defines the policy source code for a specific engine.
+                        description: Code defines the policy source code for a specific
+                          engine.
                         properties:
                           engine:
-                            description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                            description: 'The engine used to evaluate the code. Example:
+                              "Rego". Required.'
                             type: string
                           source:
                             description: The source code for the template. Required.
@@ -415,7 +440,8 @@ spec:
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught
+                          during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -429,7 +455,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the status
+                      description: a unique identifier for the pod that wrote the
+                        status
                       type: string
                     observedGeneration:
                       format: int64

--- a/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -19,7 +19,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses API.
+        description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses
+          API.
         properties:
           apiVersion:
             description: |-
@@ -39,11 +40,13 @@ spec:
           metadata:
             type: object
           status:
-            description: ConstraintTemplatePodStatusStatus defines the observed state of ConstraintTemplatePodStatus.
+            description: ConstraintTemplatePodStatusStatus defines the observed state
+              of ConstraintTemplatePodStatus.
             properties:
               errors:
                 items:
-                  description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                  description: CreateCRDError represents a single error caught during
+                    parsing, compiling, etc.
                   properties:
                     code:
                       type: string
@@ -57,7 +60,8 @@ spec:
                   type: object
                 type: array
               id:
-                description: 'Important: Run "make" to regenerate code after modifying this file'
+                description: 'Important: Run "make" to regenerate code after modifying
+                  this file'
                 type: string
               observedGeneration:
                 format: int64

--- a/manifest_staging/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
@@ -98,7 +98,8 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ExpansionTemplatePodStatusStatus defines the observed state of ExpansionTemplatePodStatus.
+                  description: ExpansionTemplatePodStatusStatus defines the observed
+                    state of ExpansionTemplatePodStatus.
                   properties:
                     errors:
                       items:
@@ -112,7 +113,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: 'Important: Run "make" to regenerate code after modifying this file'
+                      description: 'Important: Run "make" to regenerate code after
+                        modifying this file'
                       type: string
                     observedGeneration:
                       format: int64
@@ -213,7 +215,8 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ExpansionTemplatePodStatusStatus defines the observed state of ExpansionTemplatePodStatus.
+                  description: ExpansionTemplatePodStatusStatus defines the observed
+                    state of ExpansionTemplatePodStatus.
                   properties:
                     errors:
                       items:
@@ -227,7 +230,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: 'Important: Run "make" to regenerate code after modifying this file'
+                      description: 'Important: Run "make" to regenerate code after
+                        modifying this file'
                       type: string
                     observedGeneration:
                       format: int64

--- a/manifest_staging/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
@@ -19,7 +19,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ExpansionTemplatePodStatus is the Schema for the expansiontemplatepodstatuses API.
+        description: ExpansionTemplatePodStatus is the Schema for the expansiontemplatepodstatuses
+          API.
         properties:
           apiVersion:
             description: |-
@@ -39,7 +40,8 @@ spec:
           metadata:
             type: object
           status:
-            description: ExpansionTemplatePodStatusStatus defines the observed state of ExpansionTemplatePodStatus.
+            description: ExpansionTemplatePodStatusStatus defines the observed state
+              of ExpansionTemplatePodStatus.
             properties:
               errors:
                 items:
@@ -53,7 +55,8 @@ spec:
                   type: object
                 type: array
               id:
-                description: 'Important: Run "make" to regenerate code after modifying this file'
+                description: 'Important: Run "make" to regenerate code after modifying
+                  this file'
                 type: string
               observedGeneration:
                 format: int64

--- a/manifest_staging/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
@@ -72,7 +72,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].args`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main].args`.'
                 type: string
               match:
                 description: |-
@@ -128,14 +129,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -181,14 +184,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -258,7 +263,8 @@ spec:
                 properties:
                   operation:
                     default: merge
-                    description: Operation describes whether values should be merged in ("merge"), or pruned ("prune"). Default value is "merge"
+                    description: Operation describes whether values should be merged
+                      in ("merge"), or pruned ("prune"). Default value is "merge"
                     enum:
                     - merge
                     - prune
@@ -281,7 +287,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -291,7 +298,8 @@ spec:
                       type: object
                     type: array
                   values:
-                    description: Values describes the values provided to the operation as `values.fromList`.
+                    description: Values describes the values provided to the operation
+                      as `values.fromList`.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
@@ -301,13 +309,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -395,7 +405,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].args`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main].args`.'
                 type: string
               match:
                 description: |-
@@ -451,14 +462,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -504,14 +517,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -581,7 +596,8 @@ spec:
                 properties:
                   operation:
                     default: merge
-                    description: Operation describes whether values should be merged in ("merge"), or pruned ("prune"). Default value is "merge"
+                    description: Operation describes whether values should be merged
+                      in ("merge"), or pruned ("prune"). Default value is "merge"
                     enum:
                     - merge
                     - prune
@@ -604,7 +620,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -614,7 +631,8 @@ spec:
                       type: object
                     type: array
                   values:
-                    description: Values describes the values provided to the operation as `values.fromList`.
+                    description: Values describes the values provided to the operation
+                      as `values.fromList`.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
@@ -624,13 +642,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -718,7 +738,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].args`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main].args`.'
                 type: string
               match:
                 description: |-
@@ -774,14 +795,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -827,14 +850,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -904,7 +929,8 @@ spec:
                 properties:
                   operation:
                     default: merge
-                    description: Operation describes whether values should be merged in ("merge"), or pruned ("prune"). Default value is "merge"
+                    description: Operation describes whether values should be merged
+                      in ("merge"), or pruned ("prune"). Default value is "merge"
                     enum:
                     - merge
                     - prune
@@ -927,7 +953,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -937,7 +964,8 @@ spec:
                       type: object
                     type: array
                   values:
-                    description: Values describes the values provided to the operation as `values.fromList`.
+                    description: Values describes the values provided to the operation
+                      as `values.fromList`.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
@@ -947,13 +975,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string

--- a/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
@@ -45,7 +45,8 @@ spec:
                 type: boolean
               errors:
                 items:
-                  description: MutatorError represents a single error caught while adding a mutator to a system.
+                  description: MutatorError represents a single error caught while
+                    adding a mutator to a system.
                   properties:
                     message:
                       type: string

--- a/manifest_staging/charts/gatekeeper/crds/provider-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/provider-customresourcedefinition.yaml
@@ -17,7 +17,8 @@ spec:
   scope: Cluster
   versions:
   - deprecated: true
-    deprecationWarning: externaldata.gatekeeper.sh/v1alpha1 is deprecated. Use externaldata.gatekeeper.sh/v1beta1 instead.
+    deprecationWarning: externaldata.gatekeeper.sh/v1alpha1 is deprecated. Use externaldata.gatekeeper.sh/v1beta1
+      instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -52,7 +53,8 @@ spec:
                 description: Timeout is the timeout when querying the provider.
                 type: integer
               url:
-                description: URL is the url for the provider. URL is prefixed with https://.
+                description: URL is the url for the provider. URL is prefixed with
+                  https://.
                 type: string
             type: object
           status:
@@ -61,13 +63,15 @@ spec:
               byPod:
                 description: ByPod is the status of the provider by pod
                 items:
-                  description: ProviderPodStatusStatus defines the observed state of ProviderPodStatus.
+                  description: ProviderPodStatusStatus defines the observed state
+                    of ProviderPodStatus.
                   properties:
                     active:
                       type: boolean
                     errors:
                       items:
-                        description: ProviderError represents a single error caught while managing providers.
+                        description: ProviderError represents a single error caught
+                          while managing providers.
                         properties:
                           errorTimestamp:
                             format: date-time
@@ -148,7 +152,8 @@ spec:
                 description: Timeout is the timeout when querying the provider.
                 type: integer
               url:
-                description: URL is the url for the provider. URL is prefixed with https://.
+                description: URL is the url for the provider. URL is prefixed with
+                  https://.
                 type: string
             type: object
           status:
@@ -157,13 +162,15 @@ spec:
               byPod:
                 description: ByPod is the status of the provider by pod
                 items:
-                  description: ProviderPodStatusStatus defines the observed state of ProviderPodStatus.
+                  description: ProviderPodStatusStatus defines the observed state
+                    of ProviderPodStatus.
                   properties:
                     active:
                       type: boolean
                     errors:
                       items:
-                        description: ProviderError represents a single error caught while managing providers.
+                        description: ProviderError represents a single error caught
+                          while managing providers.
                         properties:
                           errorTimestamp:
                             format: date-time

--- a/manifest_staging/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
@@ -45,7 +45,8 @@ spec:
                 type: boolean
               errors:
                 items:
-                  description: ProviderError represents a single error caught while managing providers.
+                  description: ProviderError represents a single error caught while
+                    managing providers.
                   properties:
                     errorTimestamp:
                       format: date-time

--- a/manifest_staging/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
@@ -19,7 +19,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: SyncSet defines which resources Gatekeeper will cache. The union of all SyncSets plus the syncOnly field of Gatekeeper's Config resource defines the sets of resources that will be synced.
+        description: SyncSet defines which resources Gatekeeper will cache. The union
+          of all SyncSets plus the syncOnly field of Gatekeeper's Config resource
+          defines the sets of resources that will be synced.
         properties:
           apiVersion:
             description: |-

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -60,16 +60,19 @@ spec:
         {{- end }}
         args:
         - --audit-interval={{ .Values.auditInterval }}
-        - --log-level={{ (.Values.audit.logLevel | empty | not) | ternary .Values.audit.logLevel .Values.logLevel }}
+        - --log-level={{ (.Values.audit.logLevel | empty | not) | ternary .Values.audit.logLevel
+          .Values.logLevel }}
         - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
-        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName }}
+        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName
+          }}
         - --mutating-webhook-configuration-name={{ .Values.mutatingWebhookName }}
         - --audit-from-cache={{ .Values.auditFromCache }}
         {{ if hasKey .Values "auditChunkSize" }}- --audit-chunk-size={{ .Values.auditChunkSize }}{{- end }}
         - --audit-match-kind-only={{ .Values.auditMatchKindOnly }}
         {{ if hasKey .Values "emitAuditEvents" }}- --emit-audit-events={{ .Values.emitAuditEvents }}{{- end }}
         {{ if hasKey .Values "logStatsAudit" }}- --log-stats-audit={{ .Values.logStatsAudit }}{{- end }}
-        - --audit-events-involved-namespace={{ .Values.auditEventsInvolvedNamespace }}
+        - --audit-events-involved-namespace={{ .Values.auditEventsInvolvedNamespace
+          }}
         
         {{- if not .Values.audit.disableGenerateOperation }}
         - --operation=generate
@@ -95,7 +98,8 @@ spec:
         - --health-addr=:{{ .Values.audit.healthPort }}
         - --prometheus-port={{ .Values.audit.metricsPort }}
         - --enable-external-data={{ .Values.enableExternalData }}
-        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion }}
+        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion
+          }}
         
         {{- range .Values.metricsBackends}}
         - --metrics-backend={{ . }}
@@ -117,8 +121,10 @@ spec:
         {{- if .Values.audit.logFile}}
         - --log-file={{ .Values.audit.logFile }}
         {{- end }}
-        - --disable-cert-rotation={{ or .Values.audit.disableCertRotation .Values.externalCertInjection.enabled }}
-        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL }}
+        - --disable-cert-rotation={{ or .Values.audit.disableCertRotation .Values.externalCertInjection.enabled
+          }}
+        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL
+          }}
         - --enable-k8s-native-validation={{ .Values.enableK8sNativeValidation }}
         
         {{- if hasKey .Values "defaultCreateVAPForTemplates"}}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -68,8 +68,10 @@ spec:
         - --log-denies={{ .Values.logDenies }}
         {{ if hasKey .Values "emitAdmissionEvents" }}- --emit-admission-events={{ .Values.emitAdmissionEvents }}{{- end }}
         {{ if hasKey .Values "logStatsAdmission" }}- --log-stats-admission={{ .Values.logStatsAdmission }}{{- end }}
-        - --admission-events-involved-namespace={{ .Values.admissionEventsInvolvedNamespace }}
-        - --log-level={{ (.Values.controllerManager.logLevel | empty | not) | ternary .Values.controllerManager.logLevel .Values.logLevel }}
+        - --admission-events-involved-namespace={{ .Values.admissionEventsInvolvedNamespace
+          }}
+        - --log-level={{ (.Values.controllerManager.logLevel | empty | not) | ternary
+          .Values.controllerManager.logLevel .Values.logLevel }}
         {{ if hasKey .Values "logLevelKey" }}- --log-level-key={{ .Values.logLevelKey }}{{- end }}
         {{ if hasKey .Values "logLevelEncoder" }}- --log-level-encoder={{ .Values.logLevelEncoder }}{{- end }}
         - --exempt-namespace={{ .Release.Namespace }}
@@ -81,17 +83,21 @@ spec:
         - --operation=generate
         {{- end }}
         - --enable-external-data={{ .Values.enableExternalData }}
-        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion }}
+        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion
+          }}
         - --log-mutations={{ .Values.logMutations }}
         - --mutation-annotations={{ .Values.mutationAnnotations }}
-        - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation }}
+        - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation
+          }}
         - --max-serving-threads={{ .Values.maxServingThreads }}
         - --tls-min-version={{ .Values.controllerManager.tlsMinVersion }}
-        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName }}
+        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName
+          }}
         {{ if .Values.additionalValidatingWebhookConfigsToRotateCerts | empty | not }}- --additional-validating-webhook-configs-to-rotate-certs={{ .Values.additionalValidatingWebhookConfigsToRotateCerts | join "," }}{{- end }}
         - --mutating-webhook-configuration-name={{ .Values.mutatingWebhookName }}
         {{ if .Values.additionalMutatingWebhookConfigsToRotateCerts | empty | not }}- --additional-mutating-webhook-configs-to-rotate-certs={{ .Values.additionalMutatingWebhookConfigsToRotateCerts | join "," }}{{- end }}
-        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL }}
+        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL
+          }}
         - --enable-k8s-native-validation={{ .Values.enableK8sNativeValidation }}
         {{ if ne .Values.controllerManager.clientCertName "" }}- --client-cert-name={{ .Values.controllerManager.clientCertName }}{{- end }}
         

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -3,7 +3,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations: {{- toYaml .Values.mutatingWebhookAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -3,6 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
+  annotations: {{- toYaml .Values.mutatingWebhookAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -3,7 +3,8 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations: {{- toYaml .Values.mutatingWebhookAnnotations | trim | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.mutatingWebhookAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -3,7 +3,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations: {{- toYaml .Values.validatingWebhookAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -3,6 +3,7 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
+  annotations: {{- toYaml .Values.validatingWebhookAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -3,7 +3,8 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations: {{- toYaml .Values.validatingWebhookAnnotations | trim | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.validatingWebhookAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
@@ -3,7 +3,6 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  annotations: {{- toYaml .Values.secretAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
@@ -3,6 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
+  annotations: {{- toYaml .Values.secretAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-webhook-server-cert-secret.yaml
@@ -3,7 +3,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  annotations: {{- toYaml .Values.secretAnnotations | trim | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.secretAnnotations | trim | nindent 4 }}
   labels:
     app: '{{ template "gatekeeper.name" . }}'
     chart: '{{ template "gatekeeper.name" . }}'

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -101,7 +101,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main]`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main]`.'
                 type: string
               match:
                 description: |-
@@ -157,14 +158,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -210,14 +213,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -289,7 +294,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -316,20 +322,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   pathTests:
@@ -347,7 +358,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -363,13 +375,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -455,7 +469,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main]`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main]`.'
                 type: string
               match:
                 description: |-
@@ -511,14 +526,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -564,14 +581,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -643,7 +662,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -670,20 +690,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   pathTests:
@@ -701,7 +726,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -717,13 +743,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -809,7 +837,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main]`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main]`.'
                 type: string
               match:
                 description: |-
@@ -865,14 +894,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -918,14 +949,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -997,7 +1030,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -1024,20 +1058,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                   pathTests:
@@ -1055,7 +1094,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -1071,13 +1111,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -1185,7 +1227,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].image`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main].image`.'
                 type: string
               match:
                 description: |-
@@ -1241,14 +1284,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -1294,14 +1339,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -1375,7 +1422,8 @@ spec:
                       slash should not be included.
                     type: string
                   assignPath:
-                    description: AssignPath sets the domain component on an image string.
+                    description: AssignPath sets the domain component on an image
+                      string.
                     type: string
                   assignTag:
                     description: |-
@@ -1397,7 +1445,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -1413,13 +1462,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -1555,14 +1606,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -1608,14 +1661,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -1686,7 +1741,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -1713,20 +1769,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
@@ -1739,13 +1800,15 @@ spec:
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -1859,14 +1922,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -1912,14 +1977,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -1990,7 +2057,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -2017,20 +2085,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
@@ -2043,13 +2116,15 @@ spec:
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -2163,14 +2238,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -2216,14 +2293,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -2294,7 +2373,8 @@ spec:
                     description: Assign.value holds the value to be assigned
                     properties:
                       externalData:
-                        description: ExternalData describes the external data provider to be used for mutation.
+                        description: ExternalData describes the external data provider
+                          to be used for mutation.
                         properties:
                           dataSource:
                             default: ValueAtLocation
@@ -2321,20 +2401,25 @@ spec:
                             - Fail
                             type: string
                           provider:
-                            description: Provider is the name of the external data provider.
+                            description: Provider is the name of the external data
+                              provider.
                             type: string
                         required:
                         - provider
                         type: object
                       fromMetadata:
-                        description: FromMetadata assigns a value from the specified metadata field.
+                        description: FromMetadata assigns a value from the specified
+                          metadata field.
                         properties:
                           field:
-                            description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                            description: Field specifies which metadata field provides
+                              the assigned value. Valid fields are `namespace` and
+                              `name`.
                             type: string
                         type: object
                       value:
-                        description: Value is a constant value that will be assigned to `location`
+                        description: Value is a constant value that will be assigned
+                          to `location`
                         x-kubernetes-preserve-unknown-fields: true
                     type: object
                 type: object
@@ -2347,13 +2432,15 @@ spec:
                   INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
                   Important: Run "make" to regenerate code after modifying this file
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -2532,7 +2619,8 @@ spec:
                 description: Configuration for syncing k8s objects
                 properties:
                   syncOnly:
-                    description: If non-empty, only entries on this list will be replicated into OPA
+                    description: If non-empty, only entries on this list will be replicated
+                      into OPA
                     items:
                       properties:
                         group:
@@ -2548,11 +2636,13 @@ spec:
                 description: Configuration for validation
                 properties:
                   traces:
-                    description: List of requests to trace. Both "user" and "kinds" must be specified
+                    description: List of requests to trace. Both "user" and "kinds"
+                      must be specified
                     items:
                       properties:
                         dump:
-                          description: Also dump the state of OPA with the trace. Set to `All` to dump everything.
+                          description: Also dump the state of OPA with the trace.
+                            Set to `All` to dump everything.
                           type: string
                         kind:
                           description: Only trace requests of the following GroupVersionKind
@@ -2632,7 +2722,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ConnectionPodStatus is the Schema for the connectionpodstatuses API.
+        description: ConnectionPodStatus is the Schema for the connectionpodstatuses
+          API.
         properties:
           apiVersion:
             description: |-
@@ -2655,7 +2746,8 @@ spec:
             description: No spec field is defined here, as this is a status-only resource.
             properties:
               active:
-                description: Indicator for alive connection with at least one successful publish
+                description: Indicator for alive connection with at least one successful
+                  publish
                 type: boolean
               connectionUID:
                 description: |-
@@ -2676,7 +2768,8 @@ spec:
                   type: object
                 type: array
               id:
-                description: ID is the unique identifier for the pod that wrote the status
+                description: ID is the unique identifier for the pod that wrote the
+                  status
                 type: string
               observedGeneration:
                 format: int64
@@ -2735,7 +2828,8 @@ spec:
               config:
                 x-kubernetes-preserve-unknown-fields: true
               driver:
-                description: Driver is the name of one of the expected drivers i.e. dapr, disk
+                description: Driver is the name of one of the expected drivers i.e.
+                  dapr, disk
                 type: string
             required:
             - config
@@ -2746,10 +2840,12 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ConnectionPodStatusStatus defines the observed state of ConnectionPodStatus.
+                  description: ConnectionPodStatusStatus defines the observed state
+                    of ConnectionPodStatus.
                   properties:
                     active:
-                      description: Indicator for alive connection with at least one successful publish
+                      description: Indicator for alive connection with at least one
+                        successful publish
                       type: boolean
                     connectionUID:
                       description: |-
@@ -2770,7 +2866,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: ID is the unique identifier for the pod that wrote the status
+                      description: ID is the unique identifier for the pod that wrote
+                        the status
                       type: string
                     observedGeneration:
                       format: int64
@@ -2808,7 +2905,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ConstraintPodStatus is the Schema for the constraintpodstatuses API.
+        description: ConstraintPodStatus is the Schema for the constraintpodstatuses
+          API.
         properties:
           apiVersion:
             description: |-
@@ -2840,7 +2938,8 @@ spec:
                 type: boolean
               enforcementPointsStatus:
                 items:
-                  description: EnforcementPointStatus represents the status of a single enforcement point.
+                  description: EnforcementPointStatus represents the status of a single
+                    enforcement point.
                   properties:
                     enforcementPoint:
                       type: string
@@ -2858,7 +2957,8 @@ spec:
                 type: array
               errors:
                 items:
-                  description: Error represents a single error caught while adding a constraint to engine.
+                  description: Error represents a single error caught while adding
+                    a constraint to engine.
                   properties:
                     code:
                       type: string
@@ -2905,7 +3005,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses API.
+        description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses
+          API.
         properties:
           apiVersion:
             description: |-
@@ -2925,11 +3026,13 @@ spec:
           metadata:
             type: object
           status:
-            description: ConstraintTemplatePodStatusStatus defines the observed state of ConstraintTemplatePodStatus.
+            description: ConstraintTemplatePodStatusStatus defines the observed state
+              of ConstraintTemplatePodStatus.
             properties:
               errors:
                 items:
-                  description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                  description: CreateCRDError represents a single error caught during
+                    parsing, compiling, etc.
                   properties:
                     code:
                       type: string
@@ -2943,7 +3046,8 @@ spec:
                   type: object
                 type: array
               id:
-                description: 'Important: Run "make" to regenerate code after modifying this file'
+                description: 'Important: Run "make" to regenerate code after modifying
+                  this file'
                 type: string
               observedGeneration:
                 format: int64
@@ -2994,7 +3098,8 @@ spec:
   - name: v1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates API
+        description: ConstraintTemplate is the Schema for the constrainttemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -3017,13 +3122,15 @@ spec:
             description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
             properties:
               crd:
-                description: CRD defines the custom resource definition specification for the constraint.
+                description: CRD defines the custom resource definition specification
+                  for the constraint.
                 properties:
                   spec:
                     description: CRDSpec defines the spec for the CRD.
                     properties:
                       names:
-                        description: Names defines the naming conventions for the constraint kind.
+                        description: Names defines the naming conventions for the
+                          constraint kind.
                         properties:
                           kind:
                             type: string
@@ -3035,7 +3142,8 @@ spec:
                       validation:
                         default:
                           legacySchema: false
-                        description: Validation defines the schema for constraint parameters.
+                        description: Validation defines the schema for constraint
+                          parameters.
                         properties:
                           legacySchema:
                             default: false
@@ -3048,17 +3156,20 @@ spec:
                 type: object
               targets:
                 items:
-                  description: Target defines the target handler and policy for the constraint template.
+                  description: Target defines the target handler and policy for the
+                    constraint template.
                   properties:
                     code:
                       description: |-
                         The source code options for the constraint template. "Rego" can only
                         be specified in one place (either here or in the "rego" field)
                       items:
-                        description: Code defines the policy source code for a specific engine.
+                        description: Code defines the policy source code for a specific
+                          engine.
                         properties:
                           engine:
-                            description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                            description: 'The engine used to evaluate the code. Example:
+                              "Rego". Required.'
                             type: string
                           source:
                             description: The source code for the template. Required.
@@ -3104,7 +3215,8 @@ spec:
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught
+                          during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -3118,7 +3230,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the status
+                      description: a unique identifier for the pod that wrote the
+                        status
                       type: string
                     observedGeneration:
                       format: int64
@@ -3137,7 +3250,8 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates API
+        description: ConstraintTemplate is the Schema for the constrainttemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -3160,13 +3274,15 @@ spec:
             description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
             properties:
               crd:
-                description: CRD defines the custom resource definition specification for the constraint.
+                description: CRD defines the custom resource definition specification
+                  for the constraint.
                 properties:
                   spec:
                     description: CRDSpec defines the spec for the CRD.
                     properties:
                       names:
-                        description: Names defines the naming conventions for the constraint kind.
+                        description: Names defines the naming conventions for the
+                          constraint kind.
                         properties:
                           kind:
                             type: string
@@ -3178,7 +3294,8 @@ spec:
                       validation:
                         default:
                           legacySchema: true
-                        description: Validation defines the schema for constraint parameters.
+                        description: Validation defines the schema for constraint
+                          parameters.
                         properties:
                           legacySchema:
                             default: true
@@ -3191,17 +3308,20 @@ spec:
                 type: object
               targets:
                 items:
-                  description: Target defines the target handler and policy for the constraint template.
+                  description: Target defines the target handler and policy for the
+                    constraint template.
                   properties:
                     code:
                       description: |-
                         The source code options for the constraint template. "Rego" can only
                         be specified in one place (either here or in the "rego" field)
                       items:
-                        description: Code defines the policy source code for a specific engine.
+                        description: Code defines the policy source code for a specific
+                          engine.
                         properties:
                           engine:
-                            description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                            description: 'The engine used to evaluate the code. Example:
+                              "Rego". Required.'
                             type: string
                           source:
                             description: The source code for the template. Required.
@@ -3247,7 +3367,8 @@ spec:
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught
+                          during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -3261,7 +3382,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the status
+                      description: a unique identifier for the pod that wrote the
+                        status
                       type: string
                     observedGeneration:
                       format: int64
@@ -3280,7 +3402,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ConstraintTemplate is the Schema for the constrainttemplates API
+        description: ConstraintTemplate is the Schema for the constrainttemplates
+          API
         properties:
           apiVersion:
             description: |-
@@ -3303,13 +3426,15 @@ spec:
             description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
             properties:
               crd:
-                description: CRD defines the custom resource definition specification for the constraint.
+                description: CRD defines the custom resource definition specification
+                  for the constraint.
                 properties:
                   spec:
                     description: CRDSpec defines the spec for the CRD.
                     properties:
                       names:
-                        description: Names defines the naming conventions for the constraint kind.
+                        description: Names defines the naming conventions for the
+                          constraint kind.
                         properties:
                           kind:
                             type: string
@@ -3321,7 +3446,8 @@ spec:
                       validation:
                         default:
                           legacySchema: true
-                        description: Validation defines the schema for constraint parameters.
+                        description: Validation defines the schema for constraint
+                          parameters.
                         properties:
                           legacySchema:
                             default: true
@@ -3334,17 +3460,20 @@ spec:
                 type: object
               targets:
                 items:
-                  description: Target defines the target handler and policy for the constraint template.
+                  description: Target defines the target handler and policy for the
+                    constraint template.
                   properties:
                     code:
                       description: |-
                         The source code options for the constraint template. "Rego" can only
                         be specified in one place (either here or in the "rego" field)
                       items:
-                        description: Code defines the policy source code for a specific engine.
+                        description: Code defines the policy source code for a specific
+                          engine.
                         properties:
                           engine:
-                            description: 'The engine used to evaluate the code. Example: "Rego". Required.'
+                            description: 'The engine used to evaluate the code. Example:
+                              "Rego". Required.'
                             type: string
                           source:
                             description: The source code for the template. Required.
@@ -3390,7 +3519,8 @@ spec:
                   properties:
                     errors:
                       items:
-                        description: CreateCRDError represents a single error caught during parsing, compiling, etc.
+                        description: CreateCRDError represents a single error caught
+                          during parsing, compiling, etc.
                         properties:
                           code:
                             type: string
@@ -3404,7 +3534,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: a unique identifier for the pod that wrote the status
+                      description: a unique identifier for the pod that wrote the
+                        status
                       type: string
                     observedGeneration:
                       format: int64
@@ -3520,7 +3651,8 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ExpansionTemplatePodStatusStatus defines the observed state of ExpansionTemplatePodStatus.
+                  description: ExpansionTemplatePodStatusStatus defines the observed
+                    state of ExpansionTemplatePodStatus.
                   properties:
                     errors:
                       items:
@@ -3534,7 +3666,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: 'Important: Run "make" to regenerate code after modifying this file'
+                      description: 'Important: Run "make" to regenerate code after
+                        modifying this file'
                       type: string
                     observedGeneration:
                       format: int64
@@ -3635,7 +3768,8 @@ spec:
             properties:
               byPod:
                 items:
-                  description: ExpansionTemplatePodStatusStatus defines the observed state of ExpansionTemplatePodStatus.
+                  description: ExpansionTemplatePodStatusStatus defines the observed
+                    state of ExpansionTemplatePodStatus.
                   properties:
                     errors:
                       items:
@@ -3649,7 +3783,8 @@ spec:
                         type: object
                       type: array
                     id:
-                      description: 'Important: Run "make" to regenerate code after modifying this file'
+                      description: 'Important: Run "make" to regenerate code after
+                        modifying this file'
                       type: string
                     observedGeneration:
                       format: int64
@@ -3693,7 +3828,8 @@ spec:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: ExpansionTemplatePodStatus is the Schema for the expansiontemplatepodstatuses API.
+        description: ExpansionTemplatePodStatus is the Schema for the expansiontemplatepodstatuses
+          API.
         properties:
           apiVersion:
             description: |-
@@ -3713,7 +3849,8 @@ spec:
           metadata:
             type: object
           status:
-            description: ExpansionTemplatePodStatusStatus defines the observed state of ExpansionTemplatePodStatus.
+            description: ExpansionTemplatePodStatusStatus defines the observed state
+              of ExpansionTemplatePodStatus.
             properties:
               errors:
                 items:
@@ -3727,7 +3864,8 @@ spec:
                   type: object
                 type: array
               id:
-                description: 'Important: Run "make" to regenerate code after modifying this file'
+                description: 'Important: Run "make" to regenerate code after modifying
+                  this file'
                 type: string
               observedGeneration:
                 format: int64
@@ -3820,7 +3958,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].args`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main].args`.'
                 type: string
               match:
                 description: |-
@@ -3876,14 +4015,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -3929,14 +4070,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -4006,7 +4149,8 @@ spec:
                 properties:
                   operation:
                     default: merge
-                    description: Operation describes whether values should be merged in ("merge"), or pruned ("prune"). Default value is "merge"
+                    description: Operation describes whether values should be merged
+                      in ("merge"), or pruned ("prune"). Default value is "merge"
                     enum:
                     - merge
                     - prune
@@ -4029,7 +4173,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -4039,7 +4184,8 @@ spec:
                       type: object
                     type: array
                   values:
-                    description: Values describes the values provided to the operation as `values.fromList`.
+                    description: Values describes the values provided to the operation
+                      as `values.fromList`.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
@@ -4049,13 +4195,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -4143,7 +4291,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].args`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main].args`.'
                 type: string
               match:
                 description: |-
@@ -4199,14 +4348,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -4252,14 +4403,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -4329,7 +4482,8 @@ spec:
                 properties:
                   operation:
                     default: merge
-                    description: Operation describes whether values should be merged in ("merge"), or pruned ("prune"). Default value is "merge"
+                    description: Operation describes whether values should be merged
+                      in ("merge"), or pruned ("prune"). Default value is "merge"
                     enum:
                     - merge
                     - prune
@@ -4352,7 +4506,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -4362,7 +4517,8 @@ spec:
                       type: object
                     type: array
                   values:
-                    description: Values describes the values provided to the operation as `values.fromList`.
+                    description: Values describes the values provided to the operation
+                      as `values.fromList`.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
@@ -4372,13 +4528,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -4466,7 +4624,8 @@ spec:
                   type: object
                 type: array
               location:
-                description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].args`.'
+                description: 'Location describes the path to be mutated, for example:
+                  `spec.containers[name: main].args`.'
                 type: string
               match:
                 description: |-
@@ -4522,14 +4681,16 @@ spec:
                       requirements of the selector.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -4575,14 +4736,16 @@ spec:
                       namespace or the object itself, if the object is a namespace.
                     properties:
                       matchExpressions:
-                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
                         items:
                           description: |-
                             A label selector requirement is a selector that contains values, a key, and an operator that
                             relates the key and values.
                           properties:
                             key:
-                              description: key is the label key that the selector applies to.
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
                             operator:
                               description: |-
@@ -4652,7 +4815,8 @@ spec:
                 properties:
                   operation:
                     default: merge
-                    description: Operation describes whether values should be merged in ("merge"), or pruned ("prune"). Default value is "merge"
+                    description: Operation describes whether values should be merged
+                      in ("merge"), or pruned ("prune"). Default value is "merge"
                     enum:
                     - merge
                     - prune
@@ -4675,7 +4839,8 @@ spec:
                         * MustNotExist - the path must not exist or do not mutate.
                       properties:
                         condition:
-                          description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                          description: Condition describes whether the path either
+                            MustExist or MustNotExist in the original object
                           enum:
                           - MustExist
                           - MustNotExist
@@ -4685,7 +4850,8 @@ spec:
                       type: object
                     type: array
                   values:
-                    description: Values describes the values provided to the operation as `values.fromList`.
+                    description: Values describes the values provided to the operation
+                      as `values.fromList`.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                 type: object
@@ -4695,13 +4861,15 @@ spec:
             properties:
               byPod:
                 items:
-                  description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                  description: MutatorPodStatusStatus defines the observed state of
+                    MutatorPodStatus.
                   properties:
                     enforced:
                       type: boolean
                     errors:
                       items:
-                        description: MutatorError represents a single error caught while adding a mutator to a system.
+                        description: MutatorError represents a single error caught
+                          while adding a mutator to a system.
                         properties:
                           message:
                             type: string
@@ -4784,7 +4952,8 @@ spec:
                 type: boolean
               errors:
                 items:
-                  description: MutatorError represents a single error caught while adding a mutator to a system.
+                  description: MutatorError represents a single error caught while
+                    adding a mutator to a system.
                   properties:
                     message:
                       type: string
@@ -4863,7 +5032,8 @@ spec:
                 type: boolean
               errors:
                 items:
-                  description: ProviderError represents a single error caught while managing providers.
+                  description: ProviderError represents a single error caught while
+                    managing providers.
                   properties:
                     errorTimestamp:
                       format: date-time
@@ -4928,7 +5098,8 @@ spec:
   scope: Cluster
   versions:
   - deprecated: true
-    deprecationWarning: externaldata.gatekeeper.sh/v1alpha1 is deprecated. Use externaldata.gatekeeper.sh/v1beta1 instead.
+    deprecationWarning: externaldata.gatekeeper.sh/v1alpha1 is deprecated. Use externaldata.gatekeeper.sh/v1beta1
+      instead.
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -4963,7 +5134,8 @@ spec:
                 description: Timeout is the timeout when querying the provider.
                 type: integer
               url:
-                description: URL is the url for the provider. URL is prefixed with https://.
+                description: URL is the url for the provider. URL is prefixed with
+                  https://.
                 type: string
             type: object
           status:
@@ -4972,13 +5144,15 @@ spec:
               byPod:
                 description: ByPod is the status of the provider by pod
                 items:
-                  description: ProviderPodStatusStatus defines the observed state of ProviderPodStatus.
+                  description: ProviderPodStatusStatus defines the observed state
+                    of ProviderPodStatus.
                   properties:
                     active:
                       type: boolean
                     errors:
                       items:
-                        description: ProviderError represents a single error caught while managing providers.
+                        description: ProviderError represents a single error caught
+                          while managing providers.
                         properties:
                           errorTimestamp:
                             format: date-time
@@ -5059,7 +5233,8 @@ spec:
                 description: Timeout is the timeout when querying the provider.
                 type: integer
               url:
-                description: URL is the url for the provider. URL is prefixed with https://.
+                description: URL is the url for the provider. URL is prefixed with
+                  https://.
                 type: string
             type: object
           status:
@@ -5068,13 +5243,15 @@ spec:
               byPod:
                 description: ByPod is the status of the provider by pod
                 items:
-                  description: ProviderPodStatusStatus defines the observed state of ProviderPodStatus.
+                  description: ProviderPodStatusStatus defines the observed state
+                    of ProviderPodStatus.
                   properties:
                     active:
                       type: boolean
                     errors:
                       items:
-                        description: ProviderError represents a single error caught while managing providers.
+                        description: ProviderError represents a single error caught
+                          while managing providers.
                         properties:
                           errorTimestamp:
                             format: date-time
@@ -5142,7 +5319,9 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: SyncSet defines which resources Gatekeeper will cache. The union of all SyncSets plus the syncOnly field of Gatekeeper's Config resource defines the sets of resources that will be synced.
+        description: SyncSet defines which resources Gatekeeper will cache. The union
+          of all SyncSets plus the syncOnly field of Gatekeeper's Config resource
+          defines the sets of resources that will be synced.
         properties:
           apiVersion:
             description: |-


### PR DESCRIPTION
## Summary

Update kustomize from 3.8.9 to 5.6.0, addressing the kustomize portion of #4082.

## Changes

- **Makefile**: Bump `KUSTOMIZE_VERSION` from 3.8.9 to 5.6.0
- **Makefile**: Fix `--load_restrictor` flag to `--load-restrictor` (hyphenated, required since kustomize 4.x)
- **config/default/kustomization.yaml**: Migrate deprecated `bases` field to `resources`
- **cmd/build/helmify/kustomization.yaml**: Same `bases` → `resources` migration

## Verification

Tested locally with kustomize 5.6.0:
- `kustomize build config/default` — builds successfully
- `kustomize build --load-restrictor LoadRestrictionsNone cmd/build/helmify` — builds successfully

Both produce deprecation warnings for `commonLabels`, `patchesStrategicMerge`, and `patchesJson6902` — these still work in 5.x and can be migrated in a follow-up PR to keep this change minimal.

## Notes

- Follows the iterative approach discussed in #4082 (one tool per PR)
- Previous tooling updates (YQ, BATS, ORAS) were merged in #4449