### PR TITLE
ci: update govulncheck-action to commit with pinned SHA dependencies

### DIFF
--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           go-version: "1.25"
           check-latest: true
-      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+      - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # master (post-v1.0.4, pinned SHA deps)
 
   scan_vulnerabilities:
     name: "[Trivy] Scan for vulnerabilities"


### PR DESCRIPTION
## What this PR does / why we need it

The `govulncheck` CI job is failing on both this PR and `master` ([run 23570708451](https://github.com/open-policy-agent/gatekeeper/actions/runs/23570708451)) with:

> The actions actions/checkout@v4.1.1 and actions/setup-go@v5.0.0 are not allowed in open-policy-agent/gatekeeper because all actions must be pinned to a full-length commit SHA.

These unpinned references (`actions/checkout@v4.1.1`, `actions/setup-go@v5.0.0`) are not in our workflow file — they are inside the **composite action** `golang/govulncheck-action`'s own [`action.yml`](https://github.com/golang/govulncheck-action/blob/b625fbe08f3bccbe446d94fbf87fcc875a4f50ee/action.yml#L42-L43). The repo's action pinning policy rejects them.

## Fix

Update `golang/govulncheck-action` SHA from `b625fbe` to [`31f7c54`](https://github.com/golang/govulncheck-action/commit/31f7c5463448f83528bd771c2d978d940080c9fd) ("action.yml: pin action dependencies to full commit SHAs"), which pins the internal dependencies:

| Internal action | Old (`b625fbe`) | New (`31f7c54`) |
|---|---|---|
| `actions/checkout` | `@v4.1.1` (tag) | `@de0fac2e...` (SHA) |
| `actions/setup-go` | `@v5.0.0` (tag) | `@7a3fe6cf...` (SHA) |

## Changes
- `.github/workflows/scan-vulns.yaml`: Update `govulncheck-action` SHA