### PR TITLE
chore: bumping on sha that pins deps to full commit

### DIFF
--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -40,7 +40,7 @@ jobs:
         with:
           go-version: "1.25"
           check-latest: true
-      - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd
+      - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # unreleased, includes fix for golang/go#75908
 
   scan_vulnerabilities:
     name: "[Trivy] Scan for vulnerabilities"


### PR DESCRIPTION
**What this PR does / why we need it**:

Pin golang/govulncheck-action to 31f7c5463448f83528bd771c2d978d940080c9fd
which includes a fix for pinning internal action dependencies to full
commit SHAs (https://github.com/golang/go/issues/75908). This is required for repositories that
enforce the GitHub Actions SHA-pinning policy. The fix has not yet been
included in a release (latest is v1.0.4).

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
