### PR TITLE
feat: mark semantic log lines with structured field

### DIFF
--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -329,16 +329,16 @@ func (am *Manager) audit(ctx context.Context) error {
 
 	if *auditFromCache {
 		var res []Result
-		am.log.Info("Auditing from cache")
+		am.log.WithValues(logging.Semantic, true).Info("Auditing from cache")
 		res, errs := am.auditFromCache(ctx)
-		am.log.Info("Audit from cache results", "violations", len(res))
+		am.log.WithValues(logging.Semantic, true).Info("Audit from cache results", "violations", len(res))
 		for _, err := range errs {
 			am.log.Error(err, "Auditing")
 		}
 
 		am.addAuditResponsesToUpdateLists(updateLists, res, totalViolationsPerConstraint, totalViolationsPerEnforcementAction, timestamp, &auditExportPublishingState)
 	} else {
-		am.log.Info("Auditing via discovery client")
+		am.log.WithValues(logging.Semantic, true).Info("Auditing via discovery client")
 		err := am.auditResources(ctx, constraintsGVKs, updateLists, totalViolationsPerConstraint, totalViolationsPerEnforcementAction, timestamp, &auditExportPublishingState)
 		if err != nil {
 			return err
@@ -628,7 +628,7 @@ func (am *Manager) auditFromCache(ctx context.Context) ([]Result, []error) {
 		if *logStatsAudit {
 			logging.LogStatsEntries(
 				am.opa,
-				am.log.WithValues(logging.EventType, "audit_cache_stats"),
+				am.log.WithValues(logging.EventType, "audit_cache_stats", logging.Semantic, true),
 				resp.StatsEntries,
 				"audit from cache review request stats",
 			)
@@ -761,7 +761,7 @@ func (am *Manager) reviewObjects(ctx context.Context, kind string, folderCount i
 			if *logStatsAudit {
 				logging.LogStatsEntries(
 					am.opa,
-					am.log.WithValues(logging.EventType, "audit_stats"),
+					am.log.WithValues(logging.EventType, "audit_stats", logging.Semantic, true),
 					resp.StatsEntries,
 					"audit review request stats",
 				)
@@ -1160,6 +1160,7 @@ func logStart(l logr.Logger) {
 	l.Info(
 		"auditing constraints and violations",
 		logging.EventType, "audit_started",
+		logging.Semantic, true,
 	)
 }
 
@@ -1167,6 +1168,7 @@ func logFinish(l logr.Logger, t time.Duration) {
 	l.Info(
 		"auditing is complete",
 		logging.EventType, "audit_finished",
+		logging.Semantic, true,
 		"duration", t.String(),
 	)
 }
@@ -1175,6 +1177,7 @@ func logConstraint(l logr.Logger, gvknn *util.KindVersionName, enforcementAction
 	l.Info(
 		"audit results for constraint",
 		logging.EventType, "constraint_audited",
+		logging.Semantic, true,
 		logging.ConstraintGroup, gvknn.Group,
 		logging.ConstraintAPIVersion, gvknn.Version,
 		logging.ConstraintKind, gvknn.Kind,
@@ -1223,6 +1226,7 @@ func logViolation(l logr.Logger,
 		message,
 		logging.Details, details,
 		logging.EventType, "violation_audited",
+		logging.Semantic, true,
 		logging.ConstraintGroup, constraint.GroupVersionKind().Group,
 		logging.ConstraintAPIVersion, constraint.GroupVersionKind().Version,
 		logging.ConstraintKind, constraint.GetKind(),

--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -484,6 +484,7 @@ func logAddition(l logr.Logger, constraint *unstructured.Unstructured, enforceme
 	l.Info(
 		"constraint added to OPA",
 		logging.EventType, "constraint_added",
+		logging.Semantic, true,
 		logging.ConstraintGroup, constraint.GroupVersionKind().Group,
 		logging.ConstraintAPIVersion, constraint.GroupVersionKind().Version,
 		logging.ConstraintKind, constraint.GetKind(),
@@ -497,6 +498,7 @@ func logRemoval(l logr.Logger, constraint *unstructured.Unstructured, enforcemen
 	l.Info(
 		"constraint removed from OPA",
 		logging.EventType, "constraint_removed",
+		logging.Semantic, true,
 		logging.ConstraintGroup, constraint.GroupVersionKind().Group,
 		logging.ConstraintAPIVersion, constraint.GroupVersionKind().Version,
 		logging.ConstraintKind, constraint.GetKind(),

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -678,6 +678,7 @@ func logAction(template namedObj, a action) {
 	logger.Info(
 		fmt.Sprintf("template was %s", string(a)),
 		logging.EventType, fmt.Sprintf("template_%s", string(a)),
+		logging.Semantic, true,
 		logging.TemplateName, template.GetName(),
 	)
 }
@@ -686,6 +687,7 @@ func logError(name string) {
 	logger.Info(
 		"unable to ingest template",
 		logging.EventType, "template_ingest_error",
+		logging.Semantic, true,
 		logging.TemplateName, name,
 	)
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -36,6 +36,11 @@ const (
 	Mutator                      = "mutator"
 	DebugLevel                   = 1 // r.log.Debug(foo) == r.log.V(logging.DebugLevel).Info(foo)
 	ExecutionStats               = "execution_stats"
+
+	// Semantic marks a log line as machine-readable and subject to
+	// backward-compatibility requirements. Consumers can filter on
+	// this field to find stable, parseable log entries.
+	Semantic = "semantic"
 )
 
 func LogStatsEntries(client *constraintclient.Client, logger logr.Logger, entries []*instrumentation.StatsEntry, msg string) {

--- a/pkg/mutation/logging.go
+++ b/pkg/mutation/logging.go
@@ -27,6 +27,7 @@ func logAppliedMutations(message string, mutationUUID uuid.UUID, obj *unstructur
 
 	if len(iterations) > 0 {
 		logDetails := []interface{}{
+			logging.Semantic, true,
 			"Mutation Id", mutationUUID,
 			logging.EventType, logging.MutationApplied,
 			logging.ResourceGroup, obj.GroupVersionKind().Group,

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -188,6 +188,7 @@ func (h *validationHandler) Handle(ctx context.Context, req admission.Request) a
 		logging.LogStatsEntries(
 			h.opa,
 			h.log.WithValues(
+				logging.Semantic, true,
 				logging.Process, "admission",
 				logging.EventType, "review_response_stats",
 				logging.ResourceGroup, req.Kind.Group,
@@ -274,6 +275,7 @@ func (h *validationHandler) getValidationMessages(res []*rtypes.Result, req *adm
 		}
 		if *logDenies {
 			h.log.WithValues(
+				logging.Semantic, true,
 				logging.Process, "admission",
 				logging.Details, r.Metadata["details"],
 				logging.EventType, "violation",


### PR DESCRIPTION
## What this PR does

Add a `Semantic` constant to `pkg/logging` and tag machine-readable log lines with `"semantic": true` so they can be identified in code and filtered in log output.

## Which log lines are marked

| Log line | File | Why semantic |
|----------|------|-------------|
| Admission violation denied | `pkg/webhook/policy.go` | Users build alerts on these |
| Mutation applied | `pkg/mutation/logging.go` | Audit trail for mutations |
| Audit cache results | `pkg/audit/manager.go` | Compliance reporting |

## Design

Following the approach discussed with @JaydipGabani: a simple boolean field (`"semantic": true`) added to existing structured log calls via `WithValues(logging.Semantic, true)`. This is backward compatible, no existing log formats change.

Starting with the three highest-value log lines. More can be tagged in follow-up PRs.

Ref: [design doc](https://docs.google.com/document/d/1jPl8sqZU2AEE-lxEQ-8Q2kKFS5OD93CuMm9y-htzUf8/edit)

Fixes #1644