### PR TITLE
fix: share StatsReporter across mutator controllers CP (#4465)

### DIFF
--- a/pkg/controller/mutators/cache_test.go
+++ b/pkg/controller/mutators/cache_test.go
@@ -1,12 +1,54 @@
 package mutators
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
 
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
 )
+
+func TestSharedCache_TallyStatusAcrossKinds(t *testing.T) {
+	cache := NewMutationCache()
+
+	for i := 0; i < 4; i++ {
+		cache.Upsert(types.ID{
+			Group: "mutations.gatekeeper.sh",
+			Kind:  "Assign",
+			Name:  fmt.Sprintf("assign-%d", i),
+		}, MutatorStatusActive, false)
+	}
+
+	for i := 0; i < 2; i++ {
+		cache.Upsert(types.ID{
+			Group: "mutations.gatekeeper.sh",
+			Kind:  "ModifySet",
+			Name:  fmt.Sprintf("modifyset-%d", i),
+		}, MutatorStatusActive, false)
+	}
+
+	cache.Upsert(types.ID{
+		Group: "mutations.gatekeeper.sh",
+		Kind:  "AssignMetadata",
+		Name:  "assignmeta-0",
+	}, MutatorStatusActive, false)
+
+	cache.Upsert(types.ID{
+		Group: "mutations.gatekeeper.sh",
+		Kind:  "AssignImage",
+		Name:  "assignimage-0",
+	}, MutatorStatusActive, false)
+
+	got := cache.TallyStatus()
+
+	if got[MutatorStatusActive] != 8 {
+		t.Errorf("shared Cache.TallyStatus()[active] = %d, want 8", got[MutatorStatusActive])
+	}
+	if got[MutatorStatusError] != 0 {
+		t.Errorf("shared Cache.TallyStatus()[error] = %d, want 0", got[MutatorStatusError])
+	}
+}
 
 func TestCache_TallyStatus(t *testing.T) {
 	type fields struct {

--- a/pkg/controller/mutators/core/adder.go
+++ b/pkg/controller/mutators/core/adder.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	statusv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
+	ctrlmutators "github.com/open-policy-agent/gatekeeper/v3/pkg/controller/mutators"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/mutatorstatus"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
@@ -44,12 +45,13 @@ type Adder struct {
 	// If multiple controllers listen to EventsSource, then
 	// each controller gets a copy of each event.
 	EventsSource source.Source
+	Reporter     ctrlmutators.StatsReporter
 }
 
 // Add creates a new Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (a *Adder) Add(mgr manager.Manager) error {
-	r := newReconciler(mgr, a.MutationSystem, a.Tracker, a.GetPod, a.Kind, a.NewMutationObj, a.MutatorFor, a.Events)
+	r := newReconciler(mgr, a.MutationSystem, a.Tracker, a.GetPod, a.Kind, a.NewMutationObj, a.MutatorFor, a.Events, a.Reporter)
 	return a.add(mgr, r)
 }
 

--- a/pkg/controller/mutators/core/controller_test.go
+++ b/pkg/controller/mutators/core/controller_test.go
@@ -27,6 +27,7 @@ import (
 	mutationsinternal "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/unversioned"
 	mutationsv1 "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1"
 	podstatus "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
+	ctrlmutators "github.com/open-policy-agent/gatekeeper/v3/pkg/controller/mutators"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/mutatorstatus"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
@@ -147,7 +148,7 @@ func TestReconcile(t *testing.T) {
 	}
 	events := make(chan event.GenericEvent, 1024)
 
-	rec := newReconciler(mgr, mSys, tracker, func(_ context.Context) (*corev1.Pod, error) { return pod, nil }, kind, newObj, newMutator, events)
+	rec := newReconciler(mgr, mSys, tracker, func(_ context.Context) (*corev1.Pod, error) { return pod, nil }, kind, newObj, newMutator, events, ctrlmutators.NewStatsReporter())
 	adder := Adder{Events: events}
 
 	err = adder.add(mgr, rec)

--- a/pkg/controller/mutators/core/reconciler.go
+++ b/pkg/controller/mutators/core/reconciler.go
@@ -54,15 +54,20 @@ func newReconciler(
 	newMutationObj func() client.Object,
 	mutatorFor func(client.Object) (types.Mutator, error),
 	events chan event.GenericEvent,
+	reporter ctrlmutators.StatsReporter,
 ) *Reconciler {
+	cache := ctrlmutators.NewMutationCache()
+	if reporter != nil {
+		reporter.RegisterTally(cache.TallyStatus, cache.TallyConflict)
+	}
 	r := &Reconciler{
 		system:         mutationSystem,
 		Client:         mgr.GetClient(),
 		tracker:        tracker,
 		getPod:         getPod,
 		scheme:         mgr.GetScheme(),
-		reporter:       ctrlmutators.NewStatsReporter(),
-		cache:          ctrlmutators.NewMutationCache(),
+		reporter:       reporter,
+		cache:          cache,
 		gvk:            mutationsv1.GroupVersion.WithKind(kind),
 		newMutationObj: newMutationObj,
 		mutatorFor:     mutatorFor,
@@ -232,16 +237,6 @@ func (r *Reconciler) reportMutator(_ types.ID, ingestionStatus ctrlmutators.Muta
 		if err := r.reporter.ReportMutatorIngestionRequest(ingestionStatus, time.Since(startTime)); err != nil {
 			r.log.Error(err, "failed to report mutator ingestion request")
 		}
-	}
-
-	for status, count := range r.cache.TallyStatus() {
-		if err := r.reporter.ReportMutatorsStatus(status, count); err != nil {
-			r.log.Error(err, "failed to report mutator status request")
-		}
-	}
-
-	if err := r.reporter.ReportMutatorsInConflict(r.cache.TallyConflict()); err != nil {
-		r.log.Error(err, "failed to report mutators in conflict request")
 	}
 }
 

--- a/pkg/controller/mutators/instances/mutator_controllers.go
+++ b/pkg/controller/mutators/instances/mutator_controllers.go
@@ -6,6 +6,7 @@ import (
 	mutationsunversioned "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/unversioned"
 	mutationsv1 "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1"
 	"github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1alpha1"
+	ctrlmutators "github.com/open-policy-agent/gatekeeper/v3/pkg/controller/mutators"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/mutators/core"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/mutators"
@@ -33,6 +34,8 @@ func (a *Adder) Add(mgr manager.Manager) error {
 	events := make(chan event.GenericEvent, eventQueueSize)
 	scheme := mgr.GetScheme()
 
+	reporter := ctrlmutators.NewStatsReporter()
+
 	assign := core.Adder{
 		Tracker:        a.Tracker,
 		GetPod:         a.GetPod,
@@ -50,7 +53,8 @@ func (a *Adder) Add(mgr manager.Manager) error {
 			}
 			return mutators.MutatorForAssign(unversioned)
 		},
-		Events: events,
+		Events:   events,
+		Reporter: reporter,
 	}
 	if err := assign.Add(mgr); err != nil {
 		return err
@@ -73,7 +77,8 @@ func (a *Adder) Add(mgr manager.Manager) error {
 			}
 			return mutators.MutatorForModifySet(unversioned)
 		},
-		Events: events,
+		Events:   events,
+		Reporter: reporter,
 	}
 	if err := modifySet.Add(mgr); err != nil {
 		return err
@@ -96,7 +101,8 @@ func (a *Adder) Add(mgr manager.Manager) error {
 			}
 			return mutators.MutatorForAssignImage(unversioned)
 		},
-		Events: events,
+		Events:   events,
+		Reporter: reporter,
 	}
 	if err := assignImage.Add(mgr); err != nil {
 		return err
@@ -119,6 +125,7 @@ func (a *Adder) Add(mgr manager.Manager) error {
 			}
 			return mutators.MutatorForAssignMetadata(unversioned)
 		},
+		Reporter: reporter,
 	}
 	return assignMetadata.Add(mgr)
 }

--- a/pkg/controller/mutators/stats_reporter.go
+++ b/pkg/controller/mutators/stats_reporter.go
@@ -38,15 +38,14 @@ const (
 // StatsReporter reports mutator-related controller metrics.
 type StatsReporter interface {
 	ReportMutatorIngestionRequest(ms MutatorIngestionStatus, d time.Duration) error
-	ReportMutatorsStatus(ms MutatorIngestionStatus, n int) error
-	ReportMutatorsInConflict(n int) error
+	RegisterTally(statusFn func() map[MutatorIngestionStatus]int, conflictFn func() int)
 }
 
 // reporter implements StatsReporter interface.
 type reporter struct {
-	mu                  sync.RWMutex
-	mutatorStatusReport map[MutatorIngestionStatus]int
-	mutatorsInConflict  int
+	mu          sync.RWMutex
+	statusFns   []func() map[MutatorIngestionStatus]int
+	conflictFns []func() int
 }
 
 func init() {
@@ -113,40 +112,46 @@ func (r *reporter) ReportMutatorIngestionRequest(ms MutatorIngestionStatus, d ti
 	return nil
 }
 
-// ReportMutatorsStatus reports the number of mutators of a specific status that are present in the
-// mutation System.
-func (r *reporter) ReportMutatorsStatus(ms MutatorIngestionStatus, n int) error {
+func (r *reporter) RegisterTally(statusFn func() map[MutatorIngestionStatus]int, conflictFn func() int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-
-	if r.mutatorStatusReport == nil {
-		r.mutatorStatusReport = make(map[MutatorIngestionStatus]int)
-	}
-	r.mutatorStatusReport[ms] = n
-	return nil
+	r.statusFns = append(r.statusFns, statusFn)
+	r.conflictFns = append(r.conflictFns, conflictFn)
 }
 
+// observeMutatorsStatus reports the current number of mutators by status.
+// Note: statusFns are called while r.mu is held.
+// Registered functions must not call back into this reporter.
 func (r *reporter) observeMutatorsStatus(_ context.Context, observer metric.Int64Observer) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	for status, count := range r.mutatorStatusReport {
+
+	totals := map[MutatorIngestionStatus]int{
+		MutatorStatusActive: 0,
+		MutatorStatusError:  0,
+	}
+	for _, fn := range r.statusFns {
+		for status, count := range fn() {
+			totals[status] += count
+		}
+	}
+	for status, count := range totals {
 		observer.Observe(int64(count), metric.WithAttributes(attribute.String(statusKey, string(status))))
 	}
 	return nil
 }
 
-// ReportMutatorsInConflict reports the number of mutators that have schema
-// conflicts with other mutators in the mutation system.
-func (r *reporter) ReportMutatorsInConflict(n int) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.mutatorsInConflict = n
-	return nil
-}
-
+// observeMutatorsInConflict reports the current number of conflicting mutators.
+// Note: conflictFns are called while r.mu is held.
+// Registered functions must not call back into this reporter.
 func (r *reporter) observeMutatorsInConflict(_ context.Context, observer metric.Int64Observer) error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	observer.Observe(int64(r.mutatorsInConflict))
+
+	total := 0
+	for _, fn := range r.conflictFns {
+		total += fn()
+	}
+	observer.Observe(int64(total))
 	return nil
 }

--- a/pkg/controller/mutators/stats_reporter_test.go
+++ b/pkg/controller/mutators/stats_reporter_test.go
@@ -2,6 +2,7 @@ package mutators
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -33,6 +34,33 @@ func initializeTestInstruments(t *testing.T) (rdr *sdkmetric.PeriodicReader, r S
 	assert.NoError(t, err)
 
 	return rdr, r
+}
+
+func findMetricByName(t *testing.T, rm *metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+
+	var (
+		result metricdata.Metrics
+		found  bool
+	)
+
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				if found {
+					t.Fatalf("multiple metrics found with name %q", name)
+				}
+				result = m
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		t.Fatalf("metric %q not found", name)
+	}
+
+	return result
 }
 
 func TestReportMutatorIngestionRequest(t *testing.T) {
@@ -129,16 +157,78 @@ func TestReportMutatorsStatus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rdr, r := initializeTestInstruments(t)
-			for status, count := range tt.c.TallyStatus() {
-				assert.NoError(t, r.ReportMutatorsStatus(status, count))
-			}
+			r.RegisterTally(tt.c.TallyStatus, tt.c.TallyConflict)
 
 			rm := &metricdata.ResourceMetrics{}
 			assert.Equal(t, tt.expectedErr, rdr.Collect(tt.ctx, rm))
 
-			metricdatatest.AssertEqual(t, tt.want, rm.ScopeMetrics[0].Metrics[0], metricdatatest.IgnoreTimestamp())
+			metricdatatest.AssertEqual(t, tt.want, findMetricByName(t, rm, mutatorsMetricName), metricdatatest.IgnoreTimestamp())
 		})
 	}
+}
+
+func TestReporterAggregatesAcrossRegisteredCaches(t *testing.T) {
+	rdr, r := initializeTestInstruments(t)
+
+	assignCache := NewMutationCache()
+	modifySetCache := NewMutationCache()
+	assignMetaCache := NewMutationCache()
+	assignImageCache := NewMutationCache()
+
+	r.RegisterTally(assignCache.TallyStatus, assignCache.TallyConflict)
+	r.RegisterTally(modifySetCache.TallyStatus, modifySetCache.TallyConflict)
+	r.RegisterTally(assignMetaCache.TallyStatus, assignMetaCache.TallyConflict)
+	r.RegisterTally(assignImageCache.TallyStatus, assignImageCache.TallyConflict)
+
+	for i := 0; i < 4; i++ {
+		assignCache.Upsert(types.ID{Group: "mutations.gatekeeper.sh", Kind: "Assign", Name: fmt.Sprintf("assign-%d", i)}, MutatorStatusActive, false)
+	}
+	for i := 0; i < 2; i++ {
+		modifySetCache.Upsert(types.ID{Group: "mutations.gatekeeper.sh", Kind: "ModifySet", Name: fmt.Sprintf("modifyset-%d", i)}, MutatorStatusActive, false)
+	}
+	assignMetaCache.Upsert(types.ID{Group: "mutations.gatekeeper.sh", Kind: "AssignMetadata", Name: "assignmeta-0"}, MutatorStatusActive, false)
+	assignImageCache.Upsert(types.ID{Group: "mutations.gatekeeper.sh", Kind: "AssignImage", Name: "assignimage-0"}, MutatorStatusActive, false)
+
+	want := metricdata.Metrics{
+		Name: mutatorsMetricName,
+		Data: metricdata.Gauge[int64]{
+			DataPoints: []metricdata.DataPoint[int64]{
+				{Attributes: attribute.NewSet(attribute.String(statusKey, string(MutatorStatusActive))), Value: 8},
+				{Attributes: attribute.NewSet(attribute.String(statusKey, string(MutatorStatusError))), Value: 0},
+			},
+		},
+	}
+
+	rm := &metricdata.ResourceMetrics{}
+	assert.NoError(t, rdr.Collect(context.Background(), rm))
+	metricdatatest.AssertEqual(t, want, findMetricByName(t, rm, mutatorsMetricName), metricdatatest.IgnoreTimestamp())
+}
+
+func TestReporterAggregatesConflictsAcrossCaches(t *testing.T) {
+	rdr, r := initializeTestInstruments(t)
+
+	cache1 := NewMutationCache()
+	cache2 := NewMutationCache()
+	r.RegisterTally(cache1.TallyStatus, cache1.TallyConflict)
+	r.RegisterTally(cache2.TallyStatus, cache2.TallyConflict)
+
+	// 1 conflict in cache1, 2 conflicts in cache2
+	cache1.Upsert(types.ID{Kind: "Assign", Name: "a1"}, MutatorStatusActive, true)
+	cache2.Upsert(types.ID{Kind: "ModifySet", Name: "m1"}, MutatorStatusActive, true)
+	cache2.Upsert(types.ID{Kind: "ModifySet", Name: "m2"}, MutatorStatusActive, true)
+
+	want := metricdata.Metrics{
+		Name: mutatorsConflictingCountMetricsName,
+		Data: metricdata.Gauge[int64]{
+			DataPoints: []metricdata.DataPoint[int64]{
+				{Value: 3},
+			},
+		},
+	}
+
+	rm := &metricdata.ResourceMetrics{}
+	assert.NoError(t, rdr.Collect(context.Background(), rm))
+	metricdatatest.AssertEqual(t, want, findMetricByName(t, rm, mutatorsConflictingCountMetricsName), metricdatatest.IgnoreTimestamp())
 }
 
 func TestReportMutatorsInConflict(t *testing.T) {
@@ -181,12 +271,12 @@ func TestReportMutatorsInConflict(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rdr, r := initializeTestInstruments(t)
-			assert.NoError(t, r.ReportMutatorsInConflict(tt.c.TallyConflict()))
+			r.RegisterTally(tt.c.TallyStatus, tt.c.TallyConflict)
 
 			rm := &metricdata.ResourceMetrics{}
 			assert.Equal(t, tt.expectedErr, rdr.Collect(tt.ctx, rm))
 
-			metricdatatest.AssertEqual(t, tt.want, rm.ScopeMetrics[0].Metrics[0], metricdatatest.IgnoreTimestamp())
+			metricdatatest.AssertEqual(t, tt.want, findMetricByName(t, rm, mutatorsConflictingCountMetricsName), metricdatatest.IgnoreTimestamp())
 		})
 	}
 }


### PR DESCRIPTION
Cherry-pick of #4465 (4d20af0ae069eae56e53d762347782d1ca3faef6) to release-3.22.

Original PR: https://github.com/open-policy-agent/gatekeeper/pull/4465