### PR TITLE
fix: require ignore label for VAP exempt namespace matching

### DIFF
--- a/pkg/drivers/k8scel/transform/cel_snippets.go
+++ b/pkg/drivers/k8scel/transform/cel_snippets.go
@@ -120,7 +120,9 @@ const (
 				// cluster-scoped objects (non-namespace) always match
 				!has(obj.metadata.namespace) || obj.metadata.namespace == "" ? true : (
 					![%s].exists(nsMatcher,
-						(string(obj.metadata.namespace).matches("^" + string(nsMatcher).replace("*", ".*") + "$"))
+						(string(obj.metadata.namespace).matches("^" + string(nsMatcher).replace("*", ".*") + "$")) &&
+						has(namespaceObject.metadata.labels) &&
+						("admission.gatekeeper.sh/ignore" in namespaceObject.metadata.labels)
 					)
 				)
 			)

--- a/pkg/drivers/k8scel/transform/cel_snippets_test.go
+++ b/pkg/drivers/k8scel/transform/cel_snippets_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -830,6 +831,21 @@ func TestMatchExcludedNamespacesGlob(t *testing.T) {
 					t.Error(err)
 				}
 			})
+		}
+	}
+}
+
+func TestMatchGlobalExemptedNamespacesGlobRequiresIgnoreLabel(t *testing.T) {
+	mc := MatchGlobalExemptedNamespacesGlobV1Beta1(`"team-*"`)
+
+	expectedChecks := []string{
+		"has(namespaceObject.metadata.labels)",
+		`("admission.gatekeeper.sh/ignore" in namespaceObject.metadata.labels)`,
+	}
+
+	for _, check := range expectedChecks {
+		if !strings.Contains(mc.Expression, check) {
+			t.Fatalf("expected expression to contain %q, got: %s", check, mc.Expression)
 		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent VAP-based policy bypass when `--sync-vap-enforcement-scope` is enabled by aligning VAP exemption logic with the label webhook semantics that require the `admission.gatekeeper.sh/ignore` label on a namespace before its resources are exempted.

### Description
- Tighten the CEL snippet `matchGlobalExemptedNamespacesGlob` in `pkg/drivers/k8scel/transform/cel_snippets.go` so namespaced resources are exempted only when the namespace both matches the exempt pattern and `namespaceObject.metadata.labels` contains `admission.gatekeeper.sh/ignore` while preserving existing behavior for cluster-scoped objects.
- Add a regression test `TestMatchGlobalExemptedNamespacesGlobRequiresIgnoreLabel` in `pkg/drivers/k8scel/transform/cel_snippets_test.go` that asserts the generated match condition includes the namespace label checks.
- Preserve existing VAP match construction in `buildMatchConditions` and keep all other behavior unchanged.

### Testing
- Ran `go test ./pkg/drivers/k8scel/transform -run 'TestMatchGlobalExemptedNamespacesGlobRequiresIgnoreLabel|TestBuildMatchConditions' -count=1` and the tests passed (ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ba244ea4832a995f8281b7951725)