### PR TITLE
fix: clean up stale VAPB when vap.k8s.io removed from constraint (CP #4446)

### DIFF
--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -46,10 +46,12 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -337,7 +339,8 @@ func (r *ReconcileConstraint) Reconcile(ctx context.Context, request reconcile.R
 		}
 	} else {
 		r.log.Info("handling constraint delete", "instance", instance)
-		r.reporter.DeleteVAPBStatus(types.NamespacedName{Name: getVAPBindingName(instance.GetName())})
+		r.reporter.DeleteVAPBStatus(types.NamespacedName{Name: transform.GetVAPBindingName(instance.GetKind(), instance.GetName())})
+		r.reporter.DeleteVAPBStatus(types.NamespacedName{Name: transform.LegacyVAPBindingName(instance.GetName())})
 		if _, err := r.cfClient.RemoveConstraint(ctx, instance); err != nil {
 			if errors.Is(err, constraintclient.ErrMissingConstraint) {
 				return reconcile.Result{}, err
@@ -391,16 +394,25 @@ func (r *ReconcileConstraint) Reconcile(ctx context.Context, request reconcile.R
 					return reconcile.Result{}, err
 				}
 				if hasVAP {
-					vapBindingName := getVAPBindingName(instance.GetName())
-					currentVapBinding, err := vapBindingForVersion(*groupVersion)
+					// Delete new-format VAPB (gatekeeper-<kind>-<name>).
+					vapBindingName := transform.GetVAPBindingName(instance.GetKind(), instance.GetName())
+					newVapBinding, err := vapBindingForVersion(*groupVersion)
 					if err != nil {
 						return reconcile.Result{}, err
 					}
-					currentVapBinding.SetName(vapBindingName)
-					if err := r.writer.Delete(ctx, currentVapBinding); err != nil {
+					newVapBinding.SetName(vapBindingName)
+					if err := r.reader.Get(ctx, types.NamespacedName{Name: vapBindingName}, newVapBinding); err != nil {
 						if !apierrors.IsNotFound(err) {
 							return reconcile.Result{}, err
 						}
+					} else {
+						if err := r.deleteVAPBIfOwned(ctx, newVapBinding, instance, vapBindingName); err != nil {
+							return reconcile.Result{}, err
+						}
+					}
+					// Migration: also delete legacy VAPB (gatekeeper-<name>).
+					if err := r.cleanupLegacyVAPB(ctx, instance, groupVersion); err != nil {
+						return reconcile.Result{}, err
 					}
 				}
 			}
@@ -523,9 +535,9 @@ func (r *ReconcileConstraint) reportErrorOnConstraintStatus(ctx context.Context,
 
 func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction util.EnforcementAction, instance *unstructured.Unstructured, status *constraintstatusv1beta1.ConstraintPodStatus) (time.Duration, error) {
 	noDelay := time.Duration(0)
-	vapBindingKey := types.NamespacedName{Name: getVAPBindingName(instance.GetName())}
+	vapBindingKey := types.NamespacedName{Name: transform.GetVAPBindingName(instance.GetKind(), instance.GetName())}
 	if !operations.IsAssigned(operations.Generate) {
-		log.Info("generate operation is not assigned, ValidatingAdmissionPolicyBinding resource will not be generated")
+		log.Info("generate operation is not assigned, ValidatingAdmissionPolicyBinding resource will not be generated", "constraintName", instance.GetName(), "constraintKind", instance.GetKind())
 		r.reporter.DeleteVAPBStatus(vapBindingKey)
 		return noDelay, nil
 	}
@@ -540,11 +552,10 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 		log.Error(err, "could not determine if ValidatingAdmissionPolicyBinding should be generated")
 		return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, "could not determine if ValidatingAdmissionPolicyBinding should be generated")
 	}
-	isAPIEnabled := false
-	var groupVersion *schema.GroupVersion
-	if shouldGenerateVAPB {
-		isAPIEnabled, groupVersion = transform.IsVapAPIEnabled(&log)
-	}
+	intendsVAPB := shouldGenerateVAPB
+
+	isAPIEnabled, groupVersion := transform.IsVapAPIEnabled(&log)
+	generationPathSetStatus := false
 	if shouldGenerateVAPB {
 		if !isAPIEnabled {
 			log.Error(ErrValidatingAdmissionPolicyAPIDisabled, "Cannot generate ValidatingAdmissionPolicyBinding", "constraint", instance.GetName())
@@ -562,6 +573,7 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 			case errors.Is(err, celSchema.ErrCELEngineMissing):
 				updateEnforcementPointStatus(status, util.VAPEnforcementPoint, ErrGenerateVAPBState, err.Error(), instance.GetGeneration())
 				r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
+				generationPathSetStatus = true
 				shouldGenerateVAPB = false
 			case err != nil:
 				log.Error(err, "could not determine if ConstraintTemplate is configured to generate ValidatingAdmissionPolicy", "constraint", instance.GetName(), "constraint_template", unversionedCT.GetName())
@@ -597,7 +609,7 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 		}
 	}
 
-	r.log.Info("constraint controller", "generateVAPB", shouldGenerateVAPB)
+	r.log.Info("constraint controller", "generateVAPB", shouldGenerateVAPB, "constraintName", instance.GetName(), "constraintKind", instance.GetKind())
 	// generate vapbinding resources
 	if shouldGenerateVAPB && groupVersion != nil {
 		currentVapBinding, err := vapBindingForVersion(*groupVersion)
@@ -605,7 +617,7 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 			r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
 			return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, "could not get ValidatingAdmissionPolicyBinding API version")
 		}
-		vapBindingName := getVAPBindingName(instance.GetName())
+		vapBindingName := transform.GetVAPBindingName(instance.GetKind(), instance.GetName())
 		log.Info("check if vapbinding exists", "vapBindingName", vapBindingName)
 		if err := r.reader.Get(ctx, types.NamespacedName{Name: vapBindingName}, currentVapBinding); err != nil {
 			if !apierrors.IsNotFound(err) {
@@ -632,13 +644,13 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 		}
 
 		if currentVapBinding == nil {
-			log.Info("creating vapbinding")
+			log.Info("creating vapbinding", "vapBindingName", vapBindingName, "constraintName", instance.GetName(), "constraintKind", instance.GetKind())
 			if err := r.writer.Create(ctx, newVapBinding); err != nil {
 				r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
 				return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, fmt.Sprintf("could not create ValidatingAdmissionPolicyBinding: %s", vapBindingName))
 			}
 		} else if !reflect.DeepEqual(currentVapBinding, newVapBinding) {
-			log.Info("updating vapbinding")
+			log.Info("updating vapbinding", "vapBindingName", vapBindingName, "constraintName", instance.GetName(), "constraintKind", instance.GetKind())
 			if err := r.writer.Update(ctx, newVapBinding); err != nil {
 				r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
 				return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, fmt.Sprintf("could not update ValidatingAdmissionPolicyBinding: %s", vapBindingName))
@@ -646,6 +658,10 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 		}
 		updateEnforcementPointStatus(status, util.VAPEnforcementPoint, GeneratedVAPBState, "", instance.GetGeneration())
 		r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusActive)
+
+		// Migration cleanup is best-effort during normal reconcile. Failures here
+		// should not block VAPB create or update.
+		_ = r.cleanupLegacyVAPB(ctx, instance, groupVersion)
 	}
 	// do not generate vapbinding resources
 	// remove if exists
@@ -655,7 +671,7 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 			r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
 			return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, "could not get ValidatingAdmissionPolicyBinding API version")
 		}
-		vapBindingName := getVAPBindingName(instance.GetName())
+		vapBindingName := transform.GetVAPBindingName(instance.GetKind(), instance.GetName())
 		log.Info("check if vapbinding exists", "vapBindingName", vapBindingName)
 		if err := r.reader.Get(ctx, types.NamespacedName{Name: vapBindingName}, currentVapBinding); err != nil {
 			if !apierrors.IsNotFound(err) && !errors.As(err, &discoveryErr) && !meta.IsNoMatchError(err) {
@@ -665,16 +681,44 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 			currentVapBinding = nil
 		}
 		if currentVapBinding != nil {
-			log.Info("deleting vapbinding")
-			if err := r.writer.Delete(ctx, currentVapBinding); err != nil {
+			if err := r.deleteVAPBIfOwned(ctx, currentVapBinding, instance, vapBindingName); err != nil {
 				r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
 				return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, fmt.Sprintf("could not delete ValidatingAdmissionPolicyBinding: %s", vapBindingName))
 			}
+		}
+
+		// Clean stale enforcement point status unless it was set
+		// by the generation path in this reconcile.
+		if !generationPathSetStatus {
 			cleanEnforcementPointStatus(status, util.VAPEnforcementPoint)
 		}
-		r.reporter.DeleteVAPBStatus(vapBindingKey)
+
+		// Migration cleanup is best-effort during normal reconcile. Failures here
+		// should not block VAPB delete or status cleanup.
+		_ = r.cleanupLegacyVAPB(ctx, instance, groupVersion)
+
+		if !intendsVAPB {
+			r.reporter.DeleteVAPBStatus(vapBindingKey)
+		}
 	}
 	return noDelay, r.writer.Update(ctx, status)
+}
+
+func (r *ReconcileConstraint) deleteVAPBIfOwned(ctx context.Context, vapBinding client.Object, instance *unstructured.Unstructured, vapBindingName string) error {
+	if !vapBindingControlledByConstraint(vapBinding, instance) {
+		log.Info("vapbinding exists but is not owned by this constraint, skipping delete", "vapBindingName", vapBindingName, "constraintName", instance.GetName(), "constraintKind", instance.GetKind())
+		return nil
+	}
+
+	log.Info("deleting vapbinding", "vapBindingName", vapBindingName)
+	if err := r.writer.Delete(ctx, vapBinding); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("vapbinding already deleted", "vapBindingName", vapBindingName)
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func NewConstraintsCache() *ConstraintsCache {
@@ -721,6 +765,72 @@ func (c *ConstraintsCache) reportTotalConstraints(ctx context.Context, reporter 
 			}
 		}
 	}
+}
+
+// TODO(v3.25.0): Remove this function and all call sites once users have had
+// releases to upgrade (introduced in v3.23.0).
+func (r *ReconcileConstraint) cleanupLegacyVAPB(ctx context.Context, instance *unstructured.Unstructured, groupVersion *schema.GroupVersion) error {
+	if groupVersion == nil {
+		return nil
+	}
+	oldName := transform.LegacyVAPBindingName(instance.GetName())
+	newName := transform.GetVAPBindingName(instance.GetKind(), instance.GetName())
+	if oldName == newName || len(oldName) > validation.DNS1123SubdomainMaxLength {
+		return nil
+	}
+	legacyBinding, err := vapBindingForVersion(*groupVersion)
+	if err != nil {
+		log.Error(err, "could not get legacy VAPB API version", "legacyVAPBName", oldName)
+		return err
+	}
+	if err := r.reader.Get(ctx, types.NamespacedName{Name: oldName}, legacyBinding); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.Error(err, "failed to get legacy vapbinding", "legacyVAPBName", oldName)
+			return err
+		}
+		return nil
+	}
+	if !vapBindingControlledByConstraint(legacyBinding, instance) {
+		log.Info("legacy vapbinding exists but is not owned by this constraint, skipping cleanup", "legacyVAPBName", oldName, "constraintName", instance.GetName(), "constraintKind", instance.GetKind())
+		return nil
+	}
+	log.Info("cleaning up legacy vapbinding", "legacyVAPBName", oldName, "newVAPBName", newName)
+	if err := r.writer.Delete(ctx, legacyBinding); err != nil && !apierrors.IsNotFound(err) {
+		log.Error(err, "failed to delete legacy vapbinding", "legacyVAPBName", oldName)
+		return err
+	}
+	r.reporter.DeleteVAPBStatus(types.NamespacedName{Name: oldName})
+	return nil
+}
+
+func vapBindingControlledByConstraint(binding metav1.Object, instance *unstructured.Unstructured) bool {
+	if instance.GetUID() != "" {
+		return metav1.IsControlledBy(binding, instance)
+	}
+
+	ownerRef := metav1.GetControllerOfNoCopy(binding)
+	if ownerRef == nil {
+		return false
+	}
+
+	ownerGV, err := schema.ParseGroupVersion(ownerRef.APIVersion)
+	if err != nil {
+		// This path is only a best-effort fallback for synthetic delete reconciles
+		// where the constraint UID is unavailable. If the controller ownerRef is
+		// malformed, skip cleanup rather than failing reconcile or risking deletion
+		// of a VAPB we cannot confidently attribute to this constraint.
+		log.Error(err, "failed to parse controller owner APIVersion for legacy vapbinding, skipping cleanup fallback",
+			"ownerAPIVersion", ownerRef.APIVersion,
+			"ownerKind", ownerRef.Kind,
+			"ownerName", ownerRef.Name,
+			"constraint", instance.GetName(),
+			"constraintKind", instance.GetKind(),
+		)
+		return false
+	}
+
+	gvk := instance.GroupVersionKind()
+	return ownerGV.Group == gvk.Group && ownerRef.Kind == gvk.Kind && ownerRef.Name == instance.GetName()
 }
 
 func vapBindingForVersion(gvk schema.GroupVersion) (client.Object, error) {
@@ -818,10 +928,6 @@ func cleanEnforcementPointStatus(status *constraintstatusv1beta1.ConstraintPodSt
 			return
 		}
 	}
-}
-
-func getVAPBindingName(constraintName string) string {
-	return fmt.Sprintf("gatekeeper-%s", constraintName)
 }
 
 func eventPackerMapFuncFromOwnerRefs() handler.MapFunc {

--- a/pkg/controller/constraint/constraint_controller_test.go
+++ b/pkg/controller/constraint/constraint_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	apiconstraints "github.com/open-policy-agent/frameworks/constraint/pkg/apis/constraints"
 	templatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
+	templatesv1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
 	regoSchema "github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/rego/schema"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	constraintstatusv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
@@ -21,11 +22,15 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func makeTemplateWithRegoAndCELEngine(vapGenerationVal *bool) *templates.ConstraintTemplate {
@@ -768,6 +773,643 @@ func TestEventPackerMapFuncFromOwnerRefs_IgnoredOwner(t *testing.T) {
 // ptrBool returns a pointer to the provided bool.
 func ptrBool(b bool) *bool { return &b }
 
+// fakeReader is a configurable fake client.Reader for testing.
+type fakeReader struct {
+	objects map[types.NamespacedName]client.Object
+	getErr  error
+	getErrs map[types.NamespacedName]error
+}
+
+func (f *fakeReader) Get(_ context.Context, key types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+	if err, ok := f.getErrs[key]; ok {
+		return err
+	}
+	if f.getErr != nil {
+		return f.getErr
+	}
+	stored, ok := f.objects[key]
+	if !ok {
+		return apierrors.NewNotFound(schema.GroupResource{}, key.Name)
+	}
+	// Copy stored object data into the output parameter.
+	switch dst := obj.(type) {
+	case *templatesv1beta1.ConstraintTemplate:
+		src, ok := stored.(*templatesv1beta1.ConstraintTemplate)
+		if !ok {
+			return fmt.Errorf("type mismatch: expected *templatesv1beta1.ConstraintTemplate, got %T", stored)
+		}
+		*dst = *src
+	case *admissionregistrationv1.ValidatingAdmissionPolicyBinding:
+		src, ok := stored.(*admissionregistrationv1.ValidatingAdmissionPolicyBinding)
+		if !ok {
+			return fmt.Errorf("type mismatch: expected *admissionregistrationv1.ValidatingAdmissionPolicyBinding, got %T", stored)
+		}
+		*dst = *src
+	default:
+		return fmt.Errorf("fakeReader does not support type %T", obj)
+	}
+	return nil
+}
+
+func (f *fakeReader) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return nil
+}
+
+// trackingWriter records Delete calls for assertions.
+type trackingWriter struct {
+	fakeWriter
+	deletedObjects []client.Object
+	createdObjects []client.Object
+}
+
+func (t *trackingWriter) Delete(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
+	t.deletedObjects = append(t.deletedObjects, obj)
+	return nil
+}
+
+func (t *trackingWriter) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+	t.createdObjects = append(t.createdObjects, obj)
+	return nil
+}
+
+// fakeReporter implements StatsReporter for testing.
+type fakeReporter struct {
+	vapbStatuses map[types.NamespacedName]metrics.VAPStatus
+}
+
+func (f *fakeReporter) reportConstraints(_ context.Context, _ tags, _ int64) error { return nil }
+
+func (f *fakeReporter) ReportVAPBStatus(name types.NamespacedName, status metrics.VAPStatus) {
+	if f.vapbStatuses == nil {
+		f.vapbStatuses = make(map[types.NamespacedName]metrics.VAPStatus)
+	}
+	f.vapbStatuses[name] = status
+}
+
+func (f *fakeReporter) DeleteVAPBStatus(name types.NamespacedName) {
+	delete(f.vapbStatuses, name)
+}
+
+func TestManageVAPB_CleansUpStaleVAPB(t *testing.T) {
+	// Regression test for https://github.com/open-policy-agent/gatekeeper/issues/4441
+	// When vap.k8s.io is removed from scopedEnforcementActions, the stale VAPB must be deleted.
+
+	// Set up the VAP API as enabled with v1 group version.
+	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+	transform.SetVapAPIEnabled(ptr.To(true))
+	transform.SetGroupVersion(&gv)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	// Ensure DefaultGenerateVAPB is true (default).
+	origDefault := *DefaultGenerateVAPB
+	*DefaultGenerateVAPB = true
+	t.Cleanup(func() { *DefaultGenerateVAPB = origDefault })
+
+	// Constraint with scoped enforcement — only webhook + audit, no vap.k8s.io.
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+				"uid":  "12345",
+			},
+			"spec": map[string]interface{}{
+				"enforcementAction": "scoped",
+				"scopedEnforcementActions": []interface{}{
+					map[string]interface{}{
+						"action": "deny",
+						"enforcementPoints": []interface{}{
+							map[string]interface{}{"name": util.WebhookEnforcementPoint},
+							map[string]interface{}{"name": util.AuditEnforcementPoint},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// A stale VAPB owned by this constraint — should be cleaned up.
+	staleVAPB := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatekeeper-testkind-test-constraint",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestKind",
+				Name:       "test-constraint",
+				UID:        "12345",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	// A minimal ConstraintTemplate (needed because manageVAPB does reader.Get for it).
+	ct := &templatesv1beta1.ConstraintTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testkind",
+		},
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			{Name: "testkind"}: ct,
+			{Name: "gatekeeper-testkind-test-constraint"}: staleVAPB,
+		},
+	}
+
+	writer := &trackingWriter{}
+
+	status := &constraintstatusv1beta1.ConstraintPodStatus{
+		Status: constraintstatusv1beta1.ConstraintPodStatusStatus{},
+	}
+
+	r := &ReconcileConstraint{
+		reader:   reader,
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+		scheme:   runtime.NewScheme(),
+	}
+
+	_, err := r.manageVAPB(context.Background(), util.Scoped, instance, status)
+	if err != nil {
+		t.Fatalf("manageVAPB returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 1 {
+		t.Fatalf("expected 1 VAPB to be deleted, got %d", len(writer.deletedObjects))
+	}
+
+	deletedVAPB, ok := writer.deletedObjects[0].(*admissionregistrationv1.ValidatingAdmissionPolicyBinding)
+	if !ok {
+		t.Fatalf("deleted object is not a ValidatingAdmissionPolicyBinding, got %T", writer.deletedObjects[0])
+	}
+	if deletedVAPB.Name != "gatekeeper-testkind-test-constraint" {
+		t.Errorf("expected deleted VAPB name 'gatekeeper-testkind-test-constraint', got %q", deletedVAPB.Name)
+	}
+}
+
+func TestManageVAPB_NoStaleVAPB_NoDelete(t *testing.T) {
+	// When vap.k8s.io is removed and no VAPB exists, Delete should not be called.
+
+	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+	transform.SetVapAPIEnabled(ptr.To(true))
+	transform.SetGroupVersion(&gv)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	origDefault := *DefaultGenerateVAPB
+	*DefaultGenerateVAPB = true
+	t.Cleanup(func() { *DefaultGenerateVAPB = origDefault })
+
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+				"uid":  "12345",
+			},
+			"spec": map[string]interface{}{
+				"enforcementAction": "scoped",
+				"scopedEnforcementActions": []interface{}{
+					map[string]interface{}{
+						"action": "deny",
+						"enforcementPoints": []interface{}{
+							map[string]interface{}{"name": util.WebhookEnforcementPoint},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ct := &templatesv1beta1.ConstraintTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testkind",
+		},
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			{Name: "testkind"}: ct,
+			// No stale VAPB — the reader will return NotFound for VAPB lookup.
+		},
+	}
+
+	writer := &trackingWriter{}
+
+	status := &constraintstatusv1beta1.ConstraintPodStatus{
+		Status: constraintstatusv1beta1.ConstraintPodStatusStatus{},
+	}
+
+	reporter := &fakeReporter{
+		vapbStatuses: map[types.NamespacedName]metrics.VAPStatus{
+			{Name: "gatekeeper-testkind-test-constraint"}: metrics.VAPStatusError,
+		},
+	}
+
+	r := &ReconcileConstraint{
+		reader:   reader,
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: reporter,
+		scheme:   runtime.NewScheme(),
+	}
+
+	_, err := r.manageVAPB(context.Background(), util.Scoped, instance, status)
+	if err != nil {
+		t.Fatalf("manageVAPB returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 0 {
+		t.Fatalf("expected no VAPB deletions when no stale VAPB exists, got %d", len(writer.deletedObjects))
+	}
+
+	if _, exists := reporter.vapbStatuses[types.NamespacedName{Name: "gatekeeper-testkind-test-constraint"}]; exists {
+		t.Fatal("expected VAPB metric to be deleted when constraint no longer intends to use VAP")
+	}
+}
+
+func TestManageVAPB_SkipsDeleteIfNotOwner(t *testing.T) {
+	// Regression test: a VAPB owned by a different constraint kind with the same name
+	// must NOT be deleted by this constraint's cleanup path.
+
+	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+	transform.SetVapAPIEnabled(ptr.To(true))
+	transform.SetGroupVersion(&gv)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	origDefault := *DefaultGenerateVAPB
+	*DefaultGenerateVAPB = true
+	t.Cleanup(func() { *DefaultGenerateVAPB = origDefault })
+
+	// This constraint does NOT use vap.k8s.io.
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKindB",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+				"uid":  "other-uid-67890",
+			},
+			"spec": map[string]interface{}{
+				"enforcementAction": "scoped",
+				"scopedEnforcementActions": []interface{}{
+					map[string]interface{}{
+						"action": "deny",
+						"enforcementPoints": []interface{}{
+							map[string]interface{}{"name": util.WebhookEnforcementPoint},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// VAPB with same name but owned by a DIFFERENT constraint (TestKindA/test-constraint).
+	vapbOwnedByOther := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatekeeper-testkindb-test-constraint",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestKindA",
+				Name:       "test-constraint",
+				UID:        "original-uid-12345",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	ct := &templatesv1beta1.ConstraintTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testkindb",
+		},
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			{Name: "testkindb"}:                            ct,
+			{Name: "gatekeeper-testkindb-test-constraint"}: vapbOwnedByOther,
+		},
+	}
+
+	writer := &trackingWriter{}
+
+	status := &constraintstatusv1beta1.ConstraintPodStatus{
+		Status: constraintstatusv1beta1.ConstraintPodStatusStatus{},
+	}
+
+	r := &ReconcileConstraint{
+		reader:   reader,
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+		scheme:   runtime.NewScheme(),
+	}
+
+	_, err := r.manageVAPB(context.Background(), util.Scoped, instance, status)
+	if err != nil {
+		t.Fatalf("manageVAPB returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 0 {
+		t.Fatalf("expected no VAPB deletions when VAPB is owned by a different constraint, got %d", len(writer.deletedObjects))
+	}
+}
+
+func TestDeleteVAPBIfOwned_FallsBackToOwnerCoordinatesWhenUIDMissing(t *testing.T) {
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+			},
+		},
+	}
+
+	vapBinding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatekeeper-testkind-test-constraint",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestKind",
+				Name:       "test-constraint",
+				UID:        "original-uid-12345",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	writer := &trackingWriter{}
+	r := &ReconcileConstraint{
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+	}
+
+	if err := r.deleteVAPBIfOwned(context.Background(), vapBinding, instance, vapBinding.GetName()); err != nil {
+		t.Fatalf("deleteVAPBIfOwned returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 1 {
+		t.Fatalf("expected 1 VAPB to be deleted when UID is missing but owner coordinates match, got %d", len(writer.deletedObjects))
+	}
+}
+
+func TestManageVAPB_EnforcementPointStatusCleanup(t *testing.T) {
+	tests := []struct {
+		name              string
+		useVAPEnforcement bool
+		regoOnlyTemplate  bool
+		initialEPState    string
+		expectEPCleaned   bool
+		expectEPState     string
+	}{
+		{
+			name:              "stale generated status cleaned when no VAPB exists",
+			useVAPEnforcement: false,
+			initialEPState:    GeneratedVAPBState,
+			expectEPCleaned:   true,
+		},
+		{
+			name:              "stale error status cleaned when vap.k8s.io removed",
+			useVAPEnforcement: false,
+			initialEPState:    ErrGenerateVAPBState,
+			expectEPCleaned:   true,
+		},
+		{
+			name:              "error status preserved for rego-only template with vap.k8s.io",
+			useVAPEnforcement: true,
+			regoOnlyTemplate:  true,
+			initialEPState:    "",
+			expectEPCleaned:   false,
+			expectEPState:     ErrGenerateVAPBState,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+			transform.SetVapAPIEnabled(ptr.To(true))
+			transform.SetGroupVersion(&gv)
+			t.Cleanup(func() {
+				transform.SetVapAPIEnabled(nil)
+				transform.SetGroupVersion(nil)
+			})
+
+			origDefault := *DefaultGenerateVAPB
+			*DefaultGenerateVAPB = true
+			t.Cleanup(func() { *DefaultGenerateVAPB = origDefault })
+
+			epName := util.WebhookEnforcementPoint
+			if tt.useVAPEnforcement {
+				epName = util.VAPEnforcementPoint
+			}
+
+			instance := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+					"kind":       "TestKind",
+					"metadata": map[string]interface{}{
+						"name": "test-constraint",
+						"uid":  "12345",
+					},
+					"spec": map[string]interface{}{
+						"enforcementAction": "scoped",
+						"scopedEnforcementActions": []interface{}{
+							map[string]interface{}{
+								"action": "deny",
+								"enforcementPoints": []interface{}{
+									map[string]interface{}{"name": epName},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			s := runtime.NewScheme()
+			var ct *templatesv1beta1.ConstraintTemplate
+
+			if tt.regoOnlyTemplate {
+				if err := templatesv1beta1.AddToScheme(s); err != nil {
+					t.Fatal(err)
+				}
+				regoOnlyCT := makeTemplateWithRegoEngine()
+				ct = &templatesv1beta1.ConstraintTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "testkind"},
+				}
+				if err := s.Convert(regoOnlyCT, ct, nil); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				ct = &templatesv1beta1.ConstraintTemplate{
+					ObjectMeta: metav1.ObjectMeta{Name: "testkind"},
+				}
+			}
+
+			reader := &fakeReader{
+				objects: map[types.NamespacedName]client.Object{
+					{Name: "testkind"}: ct,
+				},
+			}
+
+			status := &constraintstatusv1beta1.ConstraintPodStatus{
+				Status: constraintstatusv1beta1.ConstraintPodStatusStatus{},
+			}
+			if tt.initialEPState != "" {
+				status.Status.EnforcementPointsStatus = []constraintstatusv1beta1.EnforcementPointStatus{
+					{
+						EnforcementPoint:   util.VAPEnforcementPoint,
+						State:              tt.initialEPState,
+						ObservedGeneration: 1,
+					},
+				}
+			}
+
+			r := &ReconcileConstraint{
+				reader:   reader,
+				writer:   &trackingWriter{},
+				log:      logf.Log.WithName("test"),
+				reporter: &fakeReporter{},
+				scheme:   s,
+			}
+
+			_, err := r.manageVAPB(context.Background(), util.Scoped, instance, status)
+			if err != nil {
+				t.Fatalf("manageVAPB returned unexpected error: %v", err)
+			}
+
+			var foundEP *constraintstatusv1beta1.EnforcementPointStatus
+			for i, ep := range status.Status.EnforcementPointsStatus {
+				if ep.EnforcementPoint == util.VAPEnforcementPoint {
+					foundEP = &status.Status.EnforcementPointsStatus[i]
+					break
+				}
+			}
+
+			if tt.expectEPCleaned {
+				if foundEP != nil {
+					t.Fatalf("expected EP status to be cleaned, but found: %+v", *foundEP)
+				}
+			} else {
+				if foundEP == nil {
+					t.Fatal("expected EP status to be preserved, but it was removed")
+				}
+				if foundEP.State != tt.expectEPState {
+					t.Fatalf("expected EP state %q, got %q", tt.expectEPState, foundEP.State)
+				}
+			}
+		})
+	}
+}
+
+func TestManageVAPB_PreservesErrorMetricWhenGenerationFails(t *testing.T) {
+	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+	transform.SetVapAPIEnabled(ptr.To(true))
+	transform.SetGroupVersion(&gv)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	origDefault := *DefaultGenerateVAPB
+	*DefaultGenerateVAPB = true
+	t.Cleanup(func() { *DefaultGenerateVAPB = origDefault })
+
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+				"uid":  "12345",
+			},
+			"spec": map[string]interface{}{
+				"enforcementAction": "scoped",
+				"scopedEnforcementActions": []interface{}{
+					map[string]interface{}{
+						"action": "deny",
+						"enforcementPoints": []interface{}{
+							map[string]interface{}{"name": util.VAPEnforcementPoint},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	s := runtime.NewScheme()
+	if err := templatesv1beta1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	regoOnlyCT := makeTemplateWithRegoEngine()
+	ct := &templatesv1beta1.ConstraintTemplate{
+		ObjectMeta: metav1.ObjectMeta{Name: "testkind"},
+	}
+	if err := s.Convert(regoOnlyCT, ct, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	staleVAPB := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatekeeper-testkind-test-constraint",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestKind",
+				Name:       "test-constraint",
+				UID:        "12345",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			{Name: "testkind"}: ct,
+			{Name: "gatekeeper-testkind-test-constraint"}: staleVAPB,
+		},
+	}
+
+	writer := &trackingWriter{}
+	reporter := &fakeReporter{}
+	status := &constraintstatusv1beta1.ConstraintPodStatus{
+		Status: constraintstatusv1beta1.ConstraintPodStatusStatus{},
+	}
+
+	r := &ReconcileConstraint{
+		reader:   reader,
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: reporter,
+		scheme:   s,
+	}
+
+	_, err := r.manageVAPB(context.Background(), util.Scoped, instance, status)
+	if err != nil {
+		t.Fatalf("manageVAPB returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 1 {
+		t.Fatalf("expected stale VAPB to be deleted, got %d deletions", len(writer.deletedObjects))
+	}
+
+	vapBindingKey := types.NamespacedName{Name: "gatekeeper-testkind-test-constraint"}
+	if got := reporter.vapbStatuses[vapBindingKey]; got != metrics.VAPStatusError {
+		t.Fatalf("expected VAPB metric status %q after generation failure, got %q", metrics.VAPStatusError, got)
+	}
+}
+
 type fakeWriter struct {
 	updateErr error
 }
@@ -864,5 +1506,288 @@ func TestEventPackerMapFuncFromOwnerRefs_MultipleOwners(t *testing.T) {
 	}
 	if unpacked.Name != "foo-name" {
 		t.Fatalf("unexpected name: %s", unpacked.Name)
+	}
+}
+
+func TestCleanupLegacyVAPB(t *testing.T) {
+	// When a new-format VAPB has been created, the old-format (legacy) VAPB
+	// owned by the same constraint must be cleaned up.
+
+	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+	transform.SetVapAPIEnabled(ptr.To(true))
+	transform.SetGroupVersion(&gv)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+				"uid":  "12345",
+			},
+		},
+	}
+
+	// Legacy VAPB (old format without Kind) owned by this constraint.
+	legacyVAPB := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatekeeper-test-constraint",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestKind",
+				Name:       "test-constraint",
+				UID:        "12345",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			{Name: "gatekeeper-test-constraint"}: legacyVAPB,
+		},
+	}
+
+	writer := &trackingWriter{}
+
+	r := &ReconcileConstraint{
+		reader:   reader,
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+		scheme:   runtime.NewScheme(),
+	}
+
+	if err := r.cleanupLegacyVAPB(context.Background(), instance, &gv); err != nil {
+		t.Fatalf("cleanupLegacyVAPB returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 1 {
+		t.Fatalf("expected 1 legacy VAPB to be deleted, got %d", len(writer.deletedObjects))
+	}
+
+	deletedVAPB, ok := writer.deletedObjects[0].(*admissionregistrationv1.ValidatingAdmissionPolicyBinding)
+	if !ok {
+		t.Fatalf("deleted object is not a ValidatingAdmissionPolicyBinding, got %T", writer.deletedObjects[0])
+	}
+	if deletedVAPB.Name != "gatekeeper-test-constraint" {
+		t.Errorf("expected deleted VAPB name 'gatekeeper-test-constraint', got %q", deletedVAPB.Name)
+	}
+}
+
+func TestCleanupLegacyVAPB_SkipsIfNotOwner(t *testing.T) {
+	// Legacy VAPB owned by a different constraint must NOT be deleted.
+
+	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+	transform.SetVapAPIEnabled(ptr.To(true))
+	transform.SetGroupVersion(&gv)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKindB",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+				"uid":  "other-uid-67890",
+			},
+		},
+	}
+
+	// Legacy VAPB owned by a DIFFERENT constraint kind.
+	legacyVAPB := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatekeeper-test-constraint",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestKindA",
+				Name:       "test-constraint",
+				UID:        "original-uid-12345",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			{Name: "gatekeeper-test-constraint"}: legacyVAPB,
+		},
+	}
+
+	writer := &trackingWriter{}
+
+	r := &ReconcileConstraint{
+		reader:   reader,
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+		scheme:   runtime.NewScheme(),
+	}
+
+	if err := r.cleanupLegacyVAPB(context.Background(), instance, &gv); err != nil {
+		t.Fatalf("cleanupLegacyVAPB returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 0 {
+		t.Fatalf("expected no legacy VAPB deletions when owned by different constraint, got %d", len(writer.deletedObjects))
+	}
+}
+
+func TestCleanupLegacyVAPB_FallsBackToOwnerCoordinatesWhenUIDMissing(t *testing.T) {
+	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+	transform.SetVapAPIEnabled(ptr.To(true))
+	transform.SetGroupVersion(&gv)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+			},
+		},
+	}
+
+	legacyVAPB := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatekeeper-test-constraint",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestKind",
+				Name:       "test-constraint",
+				UID:        "original-uid-12345",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			{Name: "gatekeeper-test-constraint"}: legacyVAPB,
+		},
+	}
+
+	writer := &trackingWriter{}
+	r := &ReconcileConstraint{
+		reader:   reader,
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+		scheme:   runtime.NewScheme(),
+	}
+
+	if err := r.cleanupLegacyVAPB(context.Background(), instance, &gv); err != nil {
+		t.Fatalf("cleanupLegacyVAPB returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 1 {
+		t.Fatalf("expected 1 legacy VAPB to be deleted when UID is missing but owner coordinates match, got %d", len(writer.deletedObjects))
+	}
+}
+
+func TestCleanupLegacyVAPB_SkipsFallbackWhenOwnerCoordinatesDoNotMatch(t *testing.T) {
+	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
+	transform.SetVapAPIEnabled(ptr.To(true))
+	transform.SetGroupVersion(&gv)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"name": "test-constraint",
+			},
+		},
+	}
+
+	legacyVAPB := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "gatekeeper-test-constraint",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "OtherKind",
+				Name:       "test-constraint",
+				UID:        "original-uid-12345",
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			{Name: "gatekeeper-test-constraint"}: legacyVAPB,
+		},
+	}
+
+	writer := &trackingWriter{}
+	r := &ReconcileConstraint{
+		reader:   reader,
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+		scheme:   runtime.NewScheme(),
+	}
+
+	if err := r.cleanupLegacyVAPB(context.Background(), instance, &gv); err != nil {
+		t.Fatalf("cleanupLegacyVAPB returned unexpected error: %v", err)
+	}
+
+	if len(writer.deletedObjects) != 0 {
+		t.Fatalf("expected no legacy VAPB deletions when UID is missing and owner coordinates do not match, got %d", len(writer.deletedObjects))
+	}
+}
+
+func TestGetVAPBindingName(t *testing.T) {
+	// New format includes Kind.
+	name := transform.GetVAPBindingName("K8sRequiredLabels", "my-policy")
+	expected := "gatekeeper-k8srequiredlabels-my-policy"
+	if name != expected {
+		t.Errorf("expected %q, got %q", expected, name)
+	}
+}
+
+func TestGetVAPBindingName_Truncation(t *testing.T) {
+	// Kind and name that together exceed the 253-char K8s limit.
+	longKind := strings.Repeat("a", 63)
+	longName := strings.Repeat("b", 253)
+	name := transform.GetVAPBindingName(longKind, longName)
+	if len(name) > 253 {
+		t.Errorf("expected name length <= 253, got %d: %s", len(name), name)
+	}
+	// Verify deterministic: same input produces same output.
+	name2 := transform.GetVAPBindingName(longKind, longName)
+	if name != name2 {
+		t.Errorf("expected deterministic name, got %q and %q", name, name2)
+	}
+	// Short names should not be truncated.
+	shortName := transform.GetVAPBindingName("Kind", "my-constraint")
+	if strings.Contains(shortName, "-") && len(shortName) <= 253 {
+		expectedShort := "gatekeeper-kind-my-constraint"
+		if shortName != expectedShort {
+			t.Errorf("expected %q, got %q", expectedShort, shortName)
+		}
+	}
+}
+
+func TestLegacyVAPBindingName(t *testing.T) {
+	name := transform.LegacyVAPBindingName("my-policy")
+	expected := "gatekeeper-my-policy"
+	if name != expected {
+		t.Errorf("expected %q, got %q", expected, name)
 	}
 }

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -232,6 +232,116 @@ func getMatchEntryConfig() []configv1alpha1.MatchEntry {
 	}
 }
 
+func cloneGroupVersionPtr(value *schema.GroupVersion) *schema.GroupVersion {
+	if value == nil {
+		return nil
+	}
+	clone := *value
+	return &clone
+}
+
+func setVAPTestGlobals(t *testing.T, groupVersion *schema.GroupVersion) {
+	t.Helper()
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	transform.SetVapAPIEnabled(ptr.To[bool](true))
+	transform.SetGroupVersion(cloneGroupVersionPtr(groupVersion))
+}
+
+func setupVersionPinnedReconcileTest(t *testing.T, groupVersion *schema.GroupVersion) (context.Context, client.Client) {
+	t.Helper()
+
+	setVAPTestGlobals(t, groupVersion)
+
+	mgr, wm := testutils.SetupManager(t, cfg)
+	c := testclient.NewRetryClient(mgr.GetClient())
+
+	err := testutils.CreateGatekeeperNamespace(mgr.GetConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	driver, err := rego.New(rego.Tracing(true))
+	if err != nil {
+		t.Fatalf("unable to set up Driver: %v", err)
+	}
+	k8sDriver, err := k8scel.New()
+	if err != nil {
+		t.Fatalf("unable to set up K8s native driver: %v", err)
+	}
+
+	cfClient, err := constraintclient.NewClient(constraintclient.Targets(&target.K8sValidationTarget{}), constraintclient.Driver(driver), constraintclient.Driver(k8sDriver), constraintclient.EnforcementPoints(util.AuditEnforcementPoint))
+	if err != nil {
+		t.Fatalf("unable to set up constraint framework client: %s", err)
+	}
+
+	testutils.Setenv(t, "POD_NAME", "no-pod")
+
+	tracker, err := readiness.SetupTracker(mgr, false, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
+
+	constraintEvents := make(chan event.GenericEvent, 1024)
+	constraintTemplateEvents := make(chan event.GenericEvent, 1024)
+	processExcluder := process.New()
+	processExcluder.Add(getMatchEntryConfig())
+
+	webhookCache := webhookconfigcache.NewWebhookConfigCache()
+	const testWebhookName = "gatekeeper-validating-webhook-configuration"
+	webhookName := testWebhookName
+	originalVwhName := webhook.VwhName
+	t.Cleanup(func() { webhook.VwhName = originalVwhName })
+	webhook.VwhName = &webhookName
+
+	exactMatch := admissionregistrationv1.Exact
+	webhookCache.UpsertConfig(testWebhookName, webhookconfigcache.WebhookMatchingConfig{
+		Rules: []admissionregistrationv1.RuleWithOperations{
+			{
+				Operations: []admissionregistrationv1.OperationType{
+					admissionregistrationv1.Create,
+					admissionregistrationv1.Update,
+					admissionregistrationv1.Delete,
+					admissionregistrationv1.Connect,
+				},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{""},
+					APIVersions: []string{"v1"},
+					Resources:   []string{"*"},
+				},
+			},
+		},
+		MatchPolicy: &exactMatch,
+	})
+
+	rec, err := newReconciler(mgr, cfClient, wm, tracker, constraintEvents, constraintEvents, func(context.Context) (*corev1.Pod, error) { return pod, nil }, webhookCache, processExcluder)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = add(mgr, rec, constraintTemplateEvents)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	testutils.StartManager(ctx, t, mgr)
+
+	origWait := *constraint.DefaultWaitForVAPBGeneration
+	*constraint.DefaultWaitForVAPBGeneration = 2
+	t.Cleanup(func() { *constraint.DefaultWaitForVAPBGeneration = origWait })
+
+	return ctx, c
+}
+
 func TestReconcile(t *testing.T) {
 	// Uncommenting the below enables logging of K8s internals like watch.
 	// fs := flag.NewFlagSet("", flag.PanicOnError)
@@ -317,6 +427,7 @@ func TestReconcile(t *testing.T) {
 
 	// Make webhook cache available to tests for configuration
 	sharedWebhookCache := webhookCache
+	setVAPTestGlobals(t, &admissionregistrationv1beta1.SchemeGroupVersion)
 
 	rec, err := newReconciler(mgr, cfClient, wm, tracker, constraintEvents, constraintEvents, func(context.Context) (*corev1.Pod, error) { return pod, nil }, webhookCache, processExcluder)
 	if err != nil {
@@ -330,9 +441,6 @@ func TestReconcile(t *testing.T) {
 
 	ctx := context.Background()
 	testutils.StartManager(ctx, t, mgr)
-
-	transform.SetVapAPIEnabled(ptr.To[bool](true))
-	transform.SetGroupVersion(&admissionregistrationv1beta1.SchemeGroupVersion)
 
 	// Override the default VAPB generation wait time to speed up tests.
 	// The production default is 30s, but tests only need to verify the
@@ -637,7 +745,7 @@ func TestReconcile(t *testing.T) {
 		}, func() error {
 			// check if vapbinding resource exists now
 			vapBinding := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gatekeeper-%s", cstr.GetName())}, vapBinding); err != nil {
+			if err := c.Get(ctx, types.NamespacedName{Name: transform.GetVAPBindingName(cstr.GetKind(), cstr.GetName())}, vapBinding); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return err
 				}
@@ -672,7 +780,7 @@ func TestReconcile(t *testing.T) {
 		}, func() error {
 			// check if vapbinding resource exists now
 			vapBinding := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gatekeeper-%s", cstr.GetName())}, vapBinding); err != nil {
+			if err := c.Get(ctx, types.NamespacedName{Name: transform.GetVAPBindingName(cstr.GetKind(), cstr.GetName())}, vapBinding); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return err
 				}
@@ -757,7 +865,7 @@ func TestReconcile(t *testing.T) {
 			return true
 		}, func() error {
 			vapBinding := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gatekeeper-%s", cstr.GetName())}, vapBinding); err != nil {
+			if err := c.Get(ctx, types.NamespacedName{Name: transform.GetVAPBindingName(cstr.GetKind(), cstr.GetName())}, vapBinding); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return err
 				}
@@ -803,7 +911,7 @@ func TestReconcile(t *testing.T) {
 			}
 			// check if vapbinding resource exists now
 			vapBinding := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gatekeeper-%s", cstr.GetName())}, vapBinding); err != nil {
+			if err := c.Get(ctx, types.NamespacedName{Name: transform.GetVAPBindingName(cstr.GetKind(), cstr.GetName())}, vapBinding); err != nil {
 				// Since tests retries 3000 times at 100 retries per second, adding sleep makes sure that this test gets covarage time > 30s to cover the default wait.
 				time.Sleep(10 * time.Millisecond)
 				return err
@@ -848,7 +956,7 @@ func TestReconcile(t *testing.T) {
 		}, func() error {
 			// check if vapbinding resource exists now
 			vapBinding := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gatekeeper-%s", cstr.GetName())}, vapBinding); err != nil {
+			if err := c.Get(ctx, types.NamespacedName{Name: transform.GetVAPBindingName(cstr.GetKind(), cstr.GetName())}, vapBinding); err != nil {
 				if !apierrors.IsNotFound(err) {
 					return err
 				}
@@ -1272,7 +1380,7 @@ func TestReconcile(t *testing.T) {
 			}
 			// check if vapbinding resource exists now
 			vapBinding := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("gatekeeper-%s", cstr.GetName())}, vapBinding); err != nil {
+			if err := c.Get(ctx, types.NamespacedName{Name: transform.GetVAPBindingName(cstr.GetKind(), cstr.GetName())}, vapBinding); err != nil {
 				// Since tests retries 3000 times at 100 retries per second, adding sleep makes sure that this test gets covarage time > 30s to cover the default wait.
 				time.Sleep(10 * time.Millisecond)
 				return err
@@ -1353,264 +1461,6 @@ func TestReconcile(t *testing.T) {
 			}
 			return c.Delete(ctx, cstr)
 		})
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("VAP v1beta1 should be recreated when deleted", func(t *testing.T) {
-		suffix := "VapV1Beta1ShouldBeRecreated"
-
-		logger.Info("Running test: VAP v1beta1 should be recreated when deleted")
-		constraintTemplate := makeReconcileConstraintTemplateForVap(suffix, ptr.To[bool](true), nil)
-		t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
-		transform.SetGroupVersion(&admissionregistrationv1beta1.SchemeGroupVersion)
-		testutils.CreateThenCleanup(ctx, t, c, constraintTemplate)
-
-		vapName := fmt.Sprintf("gatekeeper-%s", denyall+strings.ToLower(suffix))
-
-		// First, wait for VAP to be created
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			vap := &admissionregistrationv1beta1.ValidatingAdmissionPolicy{}
-			if err := c.Get(ctx, types.NamespacedName{Name: vapName}, vap); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Delete the VAP resource directly to simulate external deletion
-		vapToDelete := &admissionregistrationv1beta1.ValidatingAdmissionPolicy{}
-		err = c.Get(ctx, types.NamespacedName{Name: vapName}, vapToDelete)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = c.Delete(ctx, vapToDelete)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Verify the VAP is recreated by the watch
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			vap := &admissionregistrationv1beta1.ValidatingAdmissionPolicy{}
-			if err := c.Get(ctx, types.NamespacedName{Name: vapName}, vap); err != nil {
-				return err
-			}
-			// Check that this is a new VAP instance (different UID)
-			if vap.UID == vapToDelete.UID {
-				return fmt.Errorf("VAP was not recreated, same UID found")
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("VAP v1 should be recreated when deleted", func(t *testing.T) {
-		suffix := "VapV1ShouldBeRecreated"
-
-		logger.Info("Running test: VAP v1 should be recreated when deleted")
-		constraintTemplate := makeReconcileConstraintTemplateForVap(suffix, ptr.To[bool](true), nil)
-		t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
-		transform.SetGroupVersion(&admissionregistrationv1.SchemeGroupVersion)
-		testutils.CreateThenCleanup(ctx, t, c, constraintTemplate)
-
-		vapName := fmt.Sprintf("gatekeeper-%s", denyall+strings.ToLower(suffix))
-
-		// First, wait for VAP to be created
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-			if err := c.Get(ctx, types.NamespacedName{Name: vapName}, vap); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Delete the VAP resource directly to simulate external deletion
-		vapToDelete := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-		err = c.Get(ctx, types.NamespacedName{Name: vapName}, vapToDelete)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = c.Delete(ctx, vapToDelete)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Verify the VAP is recreated by the watch
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
-			if err := c.Get(ctx, types.NamespacedName{Name: vapName}, vap); err != nil {
-				return err
-			}
-			// Check that this is a new VAP instance (different UID)
-			if vap.UID == vapToDelete.UID {
-				return fmt.Errorf("VAP was not recreated, same UID found")
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("VAPB v1beta1 should be recreated when deleted", func(t *testing.T) {
-		suffix := "VapbV1Beta1ShouldBeRecreated"
-
-		logger.Info("Running test: VAPB v1beta1 should be recreated when deleted")
-		constraintTemplate := makeReconcileConstraintTemplateForVap(suffix, ptr.To[bool](true), nil)
-		cstr := newDenyAllCstr(suffix)
-		t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
-		transform.SetGroupVersion(&admissionregistrationv1beta1.SchemeGroupVersion)
-		testutils.CreateThenCleanup(ctx, t, c, constraintTemplate)
-
-		// Create the constraint first
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			return c.Create(ctx, cstr)
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		vapbName := fmt.Sprintf("gatekeeper-%s", cstr.GetName())
-
-		// First, wait for VAPB to be created
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			vapb := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: vapbName}, vapb); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Delete the VAPB resource directly to simulate external deletion
-		vapbToDelete := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
-		err = c.Get(ctx, types.NamespacedName{Name: vapbName}, vapbToDelete)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = c.Delete(ctx, vapbToDelete)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Verify the VAPB is recreated by the watch
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			vapb := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: vapbName}, vapb); err != nil {
-				return err
-			}
-			// Check that this is a new VAPB instance (different UID)
-			if vapb.UID == vapbToDelete.UID {
-				return fmt.Errorf("VAPB was not recreated, same UID found")
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Clean up the constraint
-		err = c.Delete(ctx, cstr)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("VAPB v1 should be recreated when deleted", func(t *testing.T) {
-		suffix := "VapbV1ShouldBeRecreated"
-
-		logger.Info("Running test: VAPB v1 should be recreated when deleted")
-		constraintTemplate := makeReconcileConstraintTemplateForVap(suffix, ptr.To[bool](true), nil)
-		cstr := newDenyAllCstr(suffix)
-		t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
-		transform.SetGroupVersion(&admissionregistrationv1.SchemeGroupVersion)
-		testutils.CreateThenCleanup(ctx, t, c, constraintTemplate)
-
-		// Create the constraint first
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			return c.Create(ctx, cstr)
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		vapbName := fmt.Sprintf("gatekeeper-%s", cstr.GetName())
-
-		// First, wait for VAPB to be created
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			vapb := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: vapbName}, vapb); err != nil {
-				return err
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Delete the VAPB resource directly to simulate external deletion
-		vapbToDelete := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
-		err = c.Get(ctx, types.NamespacedName{Name: vapbName}, vapbToDelete)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		err = c.Delete(ctx, vapbToDelete)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Verify the VAPB is recreated by the watch
-		err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
-			return true
-		}, func() error {
-			vapb := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
-			if err := c.Get(ctx, types.NamespacedName{Name: vapbName}, vapb); err != nil {
-				return err
-			}
-			// Check that this is a new VAPB instance (different UID)
-			if vapb.UID == vapbToDelete.UID {
-				return fmt.Errorf("VAPB was not recreated, same UID found")
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Clean up the constraint
-		err = c.Delete(ctx, cstr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2071,6 +1921,224 @@ func TestReconcile(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+func TestReconcile_VAPV1Beta1RecreatedWhenDeleted(t *testing.T) {
+	ctx, c := setupVersionPinnedReconcileTest(t, &admissionregistrationv1beta1.SchemeGroupVersion)
+	suffix := "VapV1Beta1ShouldBeRecreated"
+
+	logger.Info("Running test: VAP v1beta1 should be recreated when deleted")
+	constraintTemplate := makeReconcileConstraintTemplateForVap(suffix, ptr.To[bool](true), nil)
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
+	testutils.CreateThenCleanup(ctx, t, c, constraintTemplate)
+
+	vapName := fmt.Sprintf("gatekeeper-%s", denyall+strings.ToLower(suffix))
+
+	err := retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		vap := &admissionregistrationv1beta1.ValidatingAdmissionPolicy{}
+		return c.Get(ctx, types.NamespacedName{Name: vapName}, vap)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vapToDelete := &admissionregistrationv1beta1.ValidatingAdmissionPolicy{}
+	err = c.Get(ctx, types.NamespacedName{Name: vapName}, vapToDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.Delete(ctx, vapToDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		vap := &admissionregistrationv1beta1.ValidatingAdmissionPolicy{}
+		if err := c.Get(ctx, types.NamespacedName{Name: vapName}, vap); err != nil {
+			return err
+		}
+		if vap.UID == vapToDelete.UID {
+			return fmt.Errorf("VAP was not recreated, same UID found")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcile_VAPV1RecreatedWhenDeleted(t *testing.T) {
+	ctx, c := setupVersionPinnedReconcileTest(t, &admissionregistrationv1.SchemeGroupVersion)
+	suffix := "VapV1ShouldBeRecreated"
+
+	logger.Info("Running test: VAP v1 should be recreated when deleted")
+	constraintTemplate := makeReconcileConstraintTemplateForVap(suffix, ptr.To[bool](true), nil)
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
+	testutils.CreateThenCleanup(ctx, t, c, constraintTemplate)
+
+	vapName := fmt.Sprintf("gatekeeper-%s", denyall+strings.ToLower(suffix))
+
+	err := retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+		return c.Get(ctx, types.NamespacedName{Name: vapName}, vap)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vapToDelete := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	err = c.Get(ctx, types.NamespacedName{Name: vapName}, vapToDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.Delete(ctx, vapToDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+		if err := c.Get(ctx, types.NamespacedName{Name: vapName}, vap); err != nil {
+			return err
+		}
+		if vap.UID == vapToDelete.UID {
+			return fmt.Errorf("VAP was not recreated, same UID found")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcile_VAPBV1Beta1RecreatedWhenDeleted(t *testing.T) {
+	ctx, c := setupVersionPinnedReconcileTest(t, &admissionregistrationv1beta1.SchemeGroupVersion)
+	suffix := "VapbV1Beta1ShouldBeRecreated"
+
+	logger.Info("Running test: VAPB v1beta1 should be recreated when deleted")
+	constraintTemplate := makeReconcileConstraintTemplateForVap(suffix, ptr.To[bool](true), nil)
+	cstr := newDenyAllCstr(suffix)
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
+	testutils.CreateThenCleanup(ctx, t, c, constraintTemplate)
+
+	err := retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		return c.Create(ctx, cstr)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, cstr))
+
+	vapbName := transform.GetVAPBindingName(cstr.GetKind(), cstr.GetName())
+
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		vapb := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
+		return c.Get(ctx, types.NamespacedName{Name: vapbName}, vapb)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vapbToDelete := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
+	err = c.Get(ctx, types.NamespacedName{Name: vapbName}, vapbToDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.Delete(ctx, vapbToDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		vapb := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{}
+		if err := c.Get(ctx, types.NamespacedName{Name: vapbName}, vapb); err != nil {
+			return err
+		}
+		if vapb.UID == vapbToDelete.UID {
+			return fmt.Errorf("VAPB was not recreated, same UID found")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcile_VAPBV1RecreatedWhenDeleted(t *testing.T) {
+	ctx, c := setupVersionPinnedReconcileTest(t, &admissionregistrationv1.SchemeGroupVersion)
+	suffix := "VapbV1ShouldBeRecreated"
+
+	logger.Info("Running test: VAPB v1 should be recreated when deleted")
+	constraintTemplate := makeReconcileConstraintTemplateForVap(suffix, ptr.To[bool](true), nil)
+	cstr := newDenyAllCstr(suffix)
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
+	testutils.CreateThenCleanup(ctx, t, c, constraintTemplate)
+
+	err := retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		return c.Create(ctx, cstr)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, cstr))
+
+	vapbName := transform.GetVAPBindingName(cstr.GetKind(), cstr.GetName())
+
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		vapb := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+		return c.Get(ctx, types.NamespacedName{Name: vapbName}, vapb)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vapbToDelete := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+	err = c.Get(ctx, types.NamespacedName{Name: vapbName}, vapbToDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = c.Delete(ctx, vapbToDelete)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool {
+		return true
+	}, func() error {
+		vapb := &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}
+		if err := c.Get(ctx, types.NamespacedName{Name: vapbName}, vapb); err != nil {
+			return err
+		}
+		if vapb.UID == vapbToDelete.UID {
+			return fmt.Errorf("VAPB was not recreated, same UID found")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 // Tests that expectations for constraints are canceled if the corresponding constraint is deleted.

--- a/pkg/drivers/k8scel/transform/make_vap_objects.go
+++ b/pkg/drivers/k8scel/transform/make_vap_objects.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"crypto/sha256"
 	"errors"
 	"flag"
 	"fmt"
@@ -18,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/utils/ptr"
 )
 
@@ -287,7 +289,7 @@ func ConstraintToBinding(constraint *unstructured.Unstructured, actions []string
 
 	binding := &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("gatekeeper-%s", constraint.GetName()),
+			Name: GetVAPBindingName(constraint.GetKind(), constraint.GetName()),
 		},
 		Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
 			PolicyName: fmt.Sprintf("gatekeeper-%s", strings.ToLower(constraint.GetKind())),
@@ -325,4 +327,24 @@ func ConstraintToBinding(constraint *unstructured.Unstructured, actions []string
 		binding.Spec.MatchResources.NamespaceSelector = namespaceSelector
 	}
 	return binding, nil
+}
+
+func GetVAPBindingName(kind, constraintName string) string {
+	name := fmt.Sprintf("gatekeeper-%s-%s", strings.ToLower(kind), constraintName)
+	if len(name) <= validation.DNS1123SubdomainMaxLength {
+		return name
+	}
+	hash := fmt.Sprintf("%x", sha256.Sum256([]byte(name)))[:8]
+	truncated := name[:validation.DNS1123SubdomainMaxLength-len(hash)-1]
+	truncated = strings.TrimRight(truncated, "-.")
+	return truncated + "-" + hash
+}
+
+// LegacyVAPBindingName returns the old-format VAPB name that did not include
+// the constraint Kind. Used during migration to clean up old VAPBs.
+//
+// TODO(v3.25.0): Remove this function once users have had two releases to
+// upgrade (introduced in v3.23.0).
+func LegacyVAPBindingName(constraintName string) string {
+	return fmt.Sprintf("gatekeeper-%s", constraintName)
 }

--- a/pkg/drivers/k8scel/transform/make_vap_objects_test.go
+++ b/pkg/drivers/k8scel/transform/make_vap_objects_test.go
@@ -1102,7 +1102,7 @@ func TestConstraintToBinding(t *testing.T) {
 			enforcementActions: []string{"deny"},
 			expected: &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gatekeeper-foo-name",
+					Name: "gatekeeper-footemplate-foo-name",
 				},
 				Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
 					PolicyName: "gatekeeper-footemplate",
@@ -1121,7 +1121,7 @@ func TestConstraintToBinding(t *testing.T) {
 			enforcementActions: []string{"deny"},
 			expected: &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gatekeeper-foo-name",
+					Name: "gatekeeper-footemplate-foo-name",
 				},
 				Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
 					PolicyName: "gatekeeper-footemplate",
@@ -1142,7 +1142,7 @@ func TestConstraintToBinding(t *testing.T) {
 			constraint:         newTestConstraint("", &metav1.LabelSelector{MatchLabels: map[string]string{"match": "yes"}}, nil, &unstructured.Unstructured{}),
 			expected: &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gatekeeper-foo-name",
+					Name: "gatekeeper-footemplate-foo-name",
 				},
 				Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
 					PolicyName: "gatekeeper-footemplate",
@@ -1163,7 +1163,7 @@ func TestConstraintToBinding(t *testing.T) {
 			constraint:         newTestConstraint("", &metav1.LabelSelector{MatchLabels: map[string]string{"matchNS": "yes"}}, &metav1.LabelSelector{MatchLabels: map[string]string{"match": "yes"}}, &unstructured.Unstructured{}),
 			expected: &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gatekeeper-foo-name",
+					Name: "gatekeeper-footemplate-foo-name",
 				},
 				Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
 					PolicyName: "gatekeeper-footemplate",
@@ -1185,7 +1185,7 @@ func TestConstraintToBinding(t *testing.T) {
 			constraint:         newTestConstraint("deny", nil, nil, &unstructured.Unstructured{}),
 			expected: &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gatekeeper-foo-name",
+					Name: "gatekeeper-footemplate-foo-name",
 				},
 				Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
 					PolicyName: "gatekeeper-footemplate",
@@ -1204,7 +1204,7 @@ func TestConstraintToBinding(t *testing.T) {
 			constraint:         newTestConstraint("warn", nil, nil, &unstructured.Unstructured{}),
 			expected: &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gatekeeper-foo-name",
+					Name: "gatekeeper-footemplate-foo-name",
 				},
 				Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
 					PolicyName: "gatekeeper-footemplate",
@@ -1223,7 +1223,7 @@ func TestConstraintToBinding(t *testing.T) {
 			constraint:         newTestConstraint("dryrun", nil, nil, &unstructured.Unstructured{}),
 			expected: &admissionregistrationv1beta1.ValidatingAdmissionPolicyBinding{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "gatekeeper-foo-name",
+					Name: "gatekeeper-footemplate-foo-name",
 				},
 				Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicyBindingSpec{
 					PolicyName: "gatekeeper-footemplate",

--- a/pkg/drivers/k8scel/transform/vap_util.go
+++ b/pkg/drivers/k8scel/transform/vap_util.go
@@ -67,9 +67,6 @@ func IsVapAPIEnabled(log *logr.Logger) (bool, *schema.GroupVersion) {
 	checkGroupVersion := func(gv schema.GroupVersion) (bool, *schema.GroupVersion, error) {
 		resList, err := clientset.Discovery().ServerResourcesForGroupVersion(gv.String())
 		if err != nil {
-			// A NotFound error means the GroupVersion is not served — this is
-			// definitive, not transient. Treat it the same as "GV found but
-			// resource absent" by returning nil error.
 			if apierrors.IsNotFound(err) {
 				return false, nil, nil
 			}
@@ -100,12 +97,11 @@ func IsVapAPIEnabled(log *logr.Logger) (bool, *schema.GroupVersion) {
 	}
 
 	if discoveryErr != nil {
-		// Discovery failed — do not cache, allow retry on next reconcile
 		log.Error(discoveryErr, "error checking VAP API availability, will retry")
+		// Discovery failed — do not cache, allow retry on next reconcile
 		return false, nil
 	}
 
-	// Discovery succeeded but VAP API not found — cache this result
 	log.Info("ValidatingAdmissionPolicy API not found in cluster")
 	VapAPIEnabled = new(bool)
 	*VapAPIEnabled = false

--- a/test/bats/test.bats
+++ b/test/bats/test.bats
@@ -114,9 +114,9 @@ teardown_file() {
 
     wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl apply -f ${BATS_TESTS_DIR}/constraints/all_ns_must_have_label_provided_vapbinding.yaml"
     
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get ValidatingAdmissionPolicyBinding gatekeeper-all-must-have-label"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get ValidatingAdmissionPolicyBinding gatekeeper-k8srequiredlabelsvap-all-must-have-label"
 
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get ValidatingAdmissionPolicyBinding gatekeeper-all-must-have-label-scoped"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get ValidatingAdmissionPolicyBinding gatekeeper-k8srequiredlabelsvap-all-must-have-label-scoped"
 
     # Verify VAPB metrics with status=active shows at least 2 (we created 2 bindings)
     wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "vapb_count=\$(kubectl exec temp -- curl -s http://${pod_ip}.${GATEKEEPER_NAMESPACE}.pod:8888/metrics | grep -E '^gatekeeper_validating_admission_policy_bindings\{status=\"active\"\}' | awk '{print \$2}' | tr -d '\r'); [ -n \"\$vapb_count\" ] && [ \"\$vapb_count\" -gt 1 ]"
@@ -127,13 +127,13 @@ teardown_file() {
     assert_failure
     kubectl apply -f ${BATS_TESTS_DIR}/good/good_ns.yaml
 
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl delete ValidatingAdmissionPolicyBinding gatekeeper-all-must-have-label"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl delete ValidatingAdmissionPolicyBinding gatekeeper-k8srequiredlabelsvap-all-must-have-label"
 
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get ValidatingAdmissionPolicyBinding gatekeeper-all-must-have-label"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get ValidatingAdmissionPolicyBinding gatekeeper-k8srequiredlabelsvap-all-must-have-label"
 
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl delete ValidatingAdmissionPolicyBinding gatekeeper-all-must-have-label-scoped"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl delete ValidatingAdmissionPolicyBinding gatekeeper-k8srequiredlabelsvap-all-must-have-label-scoped"
 
-    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get ValidatingAdmissionPolicyBinding gatekeeper-all-must-have-label-scoped"
+    wait_for_process ${WAIT_TIME} ${SLEEP_TIME} "kubectl get ValidatingAdmissionPolicyBinding gatekeeper-k8srequiredlabelsvap-all-must-have-label-scoped"
 
     kubectl delete --ignore-not-found -f ${BATS_TESTS_DIR}/good/good_ns.yaml
     kubectl delete --ignore-not-found -f ${BATS_TESTS_DIR}/bad/bad_ns.yaml


### PR DESCRIPTION
Signed-off-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Co-authored-by: JaydipGabani <20255485+JaydipGabani@users.noreply.github.com>**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
