### PR TITLE
fix: quote webhook exempt label values

### DIFF
--- a/cmd/build/helmify/replacements.go
+++ b/cmd/build/helmify/replacements.go
@@ -176,7 +176,7 @@ var replacements = map[string]string{
         {{- $list = append $value $.Release.Namespace | uniq -}}
       {{- end }}
       {{- range $list }}
-      - {{ . }}
+      - {{ . | quote }}
       {{- end }}
     {{- end }}`,
 
@@ -238,7 +238,7 @@ var replacements = map[string]string{
         {{- $list = append $value $.Release.Namespace | uniq -}}
       {{- end }}
       {{- range $list }}
-      - {{ . }}
+      - {{ . | quote }}
       {{- end }}
     {{- end }}`,
 

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml
@@ -52,7 +52,7 @@ webhooks:
         {{- $list = append $value $.Release.Namespace | uniq -}}
       {{- end }}
       {{- range $list }}
-      - {{ . }}
+      - {{ . | quote }}
       {{- end }}
     {{- end }}
   objectSelector: {{ toYaml .Values.mutatingWebhookObjectSelector | nindent 4 }}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
@@ -52,7 +52,7 @@ webhooks:
         {{- $list = append $value $.Release.Namespace | uniq -}}
       {{- end }}
       {{- range $list }}
-      - {{ . }}
+      - {{ . | quote }}
       {{- end }}
     {{- end }}
   objectSelector: {{ toYaml .Values.validatingWebhookObjectSelector | nindent 4 }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Quote rendered values for `validatingWebhookExemptNamespacesLabels` and `mutatingWebhookExemptNamespacesLabels` in the generated Helm chart. Without quoting, YAML-like label values such as `true`, `false`, or numeric strings can render as non-string scalars in `namespaceSelector.matchExpressions[].values`, which expects strings.

This updates both the helmify replacement source and the generated `manifest_staging` chart templates.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #4211

**Special notes for your reviewer**:

Validation:
- `helm lint manifest_staging/charts/gatekeeper`
- `helm lint cmd/build/helmify/static`
- `helm template gatekeeper manifest_staging/charts/gatekeeper --namespace gatekeeper-system --set-json 'validatingWebhookExemptNamespacesLabels={"example.com/exclude":["true"]}' --show-only templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml`
- `helm template gatekeeper manifest_staging/charts/gatekeeper --namespace gatekeeper-system --set-json 'mutatingWebhookExemptNamespacesLabels={"example.com/exclude":["true"]}' --show-only templates/gatekeeper-mutating-webhook-configuration-mutatingwebhookconfiguration.yaml`
- `GOCACHE=/private/tmp/gatekeeper-go-cache GOMODCACHE=/private/tmp/gatekeeper-go-mod go test ./cmd/build/helmify`
- `git diff --check`