### PR TITLE
chore: bump kind version from 0.29.0 to 0.30.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ SYNC_VAP_ENFORCEMENT_SCOPE ?= true
 
 VERSION := v3.23.0-beta.0
 
-KIND_VERSION ?= 0.29.0
+KIND_VERSION ?= 0.30.0
 KIND_CLUSTER_FILE ?= ""
 # note: k8s version pinned since KIND image availability lags k8s releases
 KUBERNETES_VERSION ?= 1.33.0


### PR DESCRIPTION
Bump `KIND_VERSION` in the Makefile from `0.29.0` to `0.30.0`.

### Why

- Two minor versions behind upstream (0.29.0 → 0.30.0)
- 0.30.0 adds Kubernetes 1.34 support and bundles containerd 2.1.4
- All Kubernetes versions exercised in CI (1.31.6, 1.32.3, 1.33.2) are still supported via `kindest/node` images for 0.30.0

### Why not 0.31.0

0.31.0 defaults to Kubernetes 1.35 and starts phasing out cgroup v1 support. That feels like a separate, more disruptive bump that should be evaluated independently once the cgroup v1 transition is clearer for CI runners. Happy to follow up with that as a separate PR.

### Scope

Single line change in `Makefile`. No workflow or script updates needed (kind is only referenced via `KIND_VERSION` in the Makefile).

Part of #4082

Refs prior tooling bumps in this series:
- #4449 (YQ, BATS, ORAS)
- #4466 (kustomize 3.8.9 → 5.6.0)