### PR TITLE
chore: align helm version in CI workflows to 3.17.4

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Helm
       uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
       with:
-        version: "3.14.1"
+        version: "3.17.4"
       id: install
     
     - name: Lint Helm charts

--- a/.github/workflows/upgrade.yaml
+++ b/.github/workflows/upgrade.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        HELM_VERSION: ["3.14.1"]
+        HELM_VERSION: ["3.17.4"]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        HELM_VERSION: ["3.14.1"]
+        HELM_VERSION: ["3.17.4"]
         GATEKEEPER_NAMESPACE: ["gatekeeper-system", "custom-namespace"]
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Closes part of #4082.

The Makefile already pins `HELM_VERSION` to `3.17.4`, but three CI
workflow files still reference `3.14.1`:

- `.github/workflows/workflow.yaml` (helm_build_test matrix)
- `.github/workflows/upgrade.yaml` (helm_upgrade matrix)
- `.github/workflows/helm-lint.yaml` (azure/setup-helm action)

This aligns all of them to `3.17.4` so local and CI helm builds use
the same version.

Related tooling bump PRs: #4449 (YQ/BATS/ORAS), #4569 (kind).