### PR TITLE
chore: bump golangci-lint to v2.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ GATEKEEPER_NAMESPACE ?= gatekeeper-system
 
 # When updating this, make sure to update the corresponding action in
 # workflow.yaml
-GOLANGCI_LINT_VERSION := v2.4.0
+GOLANGCI_LINT_VERSION := v2.5.0
 
 # Detects the location of the user golangci-lint cache.
 GOLANGCI_LINT_CACHE := $(shell pwd)/.tmp/golangci-lint


### PR DESCRIPTION
## What this PR does / why we need it

Bump golangci-lint from `v2.4.0` (released 2025-08-14) to `v2.5.0` (released 2025-09-21). This is a single-minor-version step intended to keep the linter close to upstream without skipping ahead too far in one go.

The v2.5.0 release is mostly dependency bumps for underlying linters (e.g. `revive` 1.11.0 to 1.12.0, `gosec` 2.22.7 to 2.22.8, `testifylint` 1.6.1 to 1.6.4) plus one new linter (`unqueryvet`). The gatekeeper `.golangci.yaml` uses `default: none` with an explicit enable list, so `unqueryvet` is not activated automatically.

## Which issue(s) this PR fixes

Part of keeping tooling current; no specific issue.

## Special notes for your reviewer

If CI lint passes here, a follow-up PR can step to v2.6.x or v2.7.x. Skipping straight to v2.12.x would lump several minor releases together and make any new lint failures harder to diagnose.

Full v2.5.0 changelog: https://golangci-lint.run/docs/product/changelog/#250