### PR TITLE
feat: add default-failure-policy flag to fix #4567

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,6 +56,7 @@ spec:
             - "--operation=webhook"
             - "--operation=mutation-webhook"
             - "--disable-opa-builtin={http.send}"
+            - "--default-failure-policy=Fail"
           image: openpolicyagent/gatekeeper:v3.23.0-beta.0
           imagePullPolicy: Always
           name: manager
@@ -149,6 +150,7 @@ spec:
             - --logtostderr
             - --disable-opa-builtin={http.send}
             - --disable-cert-rotation
+            - --default-failure-policy=Fail
           command:
             - /manager
           image: openpolicyagent/gatekeeper:v3.23.0-beta.0

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -83,6 +83,7 @@ spec:
         {{- if not .Values.audit.disableStatusOperation }}
         - --operation=status
         {{- end }}
+        {{ if hasKey .Values "defaultFailurePolicy" }}- --default-failure-policy={{ .Values.defaultFailurePolicy }}{{- end }}
         {{ if hasKey .Values "enableViolationExport" }}
         - --enable-violation-export={{ .Values.enableViolationExport }}
         {{- end }}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -82,6 +82,7 @@ spec:
         {{- if not .Values.controllerManager.disableGenerateOperation }}
         - --operation=generate
         {{- end }}
+        {{ if hasKey .Values "defaultFailurePolicy" }}- --default-failure-policy={{ .Values.defaultFailurePolicy }}{{- end }}
         - --enable-external-data={{ .Values.enableExternalData }}
         - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion
           }}

--- a/manifest_staging/charts/gatekeeper/values.yaml
+++ b/manifest_staging/charts/gatekeeper/values.yaml
@@ -11,6 +11,7 @@ disableValidatingWebhook: false
 validatingWebhookName: gatekeeper-validating-webhook-configuration
 validatingWebhookTimeoutSeconds: 3
 validatingWebhookFailurePolicy: Ignore
+defaultFailurePolicy: Fail
 validatingWebhookAnnotations: {}
 validatingWebhookExemptNamespacesLabels: {}
 validatingWebhookObjectSelector: {}

--- a/pkg/drivers/k8scel/schema/schema.go
+++ b/pkg/drivers/k8scel/schema/schema.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
@@ -24,6 +25,8 @@ const (
 	// ObjectName is the VAP variable that describes either an object or (on DELETE requests) oldObject.
 	ObjectName = "anyObject"
 )
+
+var DefaultFailurePolicy = flag.String("default-failure-policy", "Fail", "Default failure policy for ConstraintTemplate and ValidatingAdmissionPolicy. Can be set to 'Fail' or 'Ignore'.")
 
 type Validation struct {
 	// A CEL expression. Maps to ValidationAdmissionPolicy's `spec.validations`.
@@ -198,7 +201,13 @@ func (in *Source) GetMessageExpressions() ([]cel.ExpressionAccessor, error) {
 
 func (in *Source) GetFailurePolicy() (*admissionv1.FailurePolicyType, error) {
 	if in.FailurePolicy == nil {
-		return nil, nil
+		var out admissionv1.FailurePolicyType
+		if DefaultFailurePolicy != nil && *DefaultFailurePolicy == string(admissionv1.Ignore) {
+			out = admissionv1.Ignore
+		} else {
+			out = admissionv1.Fail
+		}
+		return &out, nil
 	}
 
 	var out admissionv1.FailurePolicyType
@@ -218,7 +227,11 @@ func (in *Source) GetFailurePolicy() (*admissionv1.FailurePolicyType, error) {
 func (in *Source) GetV1Beta1FailurePolicy() (*admissionv1beta1.FailurePolicyType, error) {
 	var out admissionv1beta1.FailurePolicyType
 	if in.FailurePolicy == nil {
-		out = admissionv1beta1.Fail
+		if DefaultFailurePolicy != nil && *DefaultFailurePolicy == string(admissionv1beta1.Ignore) {
+			out = admissionv1beta1.Ignore
+		} else {
+			out = admissionv1beta1.Fail
+		}
 		return &out, nil
 	}
 

--- a/pkg/drivers/k8scel/schema/schema_test.go
+++ b/pkg/drivers/k8scel/schema/schema_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	"k8s.io/utils/ptr"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 )
 
 func TestValidationErrors(t *testing.T) {
@@ -275,6 +277,110 @@ func TestHasCELEngine(t *testing.T) {
 			got := HasCELEngine(tt.template)
 			if got != tt.expected {
 				t.Errorf("HasCELEngine() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetFailurePolicy(t *testing.T) {
+	originalDefault := *DefaultFailurePolicy
+	defer func() {
+		*DefaultFailurePolicy = originalDefault
+	}()
+
+	tests := []struct {
+		name                 string
+		source               *Source
+		defaultFailurePolicy string
+		expected             admissionv1.FailurePolicyType
+	}{
+		{
+			name:                 "Uses specified failure policy Fail",
+			source:               &Source{FailurePolicy: ptr.To[string]("Fail")},
+			defaultFailurePolicy: "Ignore",
+			expected:             admissionv1.Fail,
+		},
+		{
+			name:                 "Uses specified failure policy Ignore",
+			source:               &Source{FailurePolicy: ptr.To[string]("Ignore")},
+			defaultFailurePolicy: "Fail",
+			expected:             admissionv1.Ignore,
+		},
+		{
+			name:                 "Falls back to DefaultFailurePolicy (Fail)",
+			source:               &Source{FailurePolicy: nil},
+			defaultFailurePolicy: "Fail",
+			expected:             admissionv1.Fail,
+		},
+		{
+			name:                 "Falls back to DefaultFailurePolicy (Ignore)",
+			source:               &Source{FailurePolicy: nil},
+			defaultFailurePolicy: "Ignore",
+			expected:             admissionv1.Ignore,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			*DefaultFailurePolicy = tt.defaultFailurePolicy
+			got, err := tt.source.GetFailurePolicy()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || *got != tt.expected {
+				t.Errorf("GetFailurePolicy() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetV1Beta1FailurePolicy(t *testing.T) {
+	originalDefault := *DefaultFailurePolicy
+	defer func() {
+		*DefaultFailurePolicy = originalDefault
+	}()
+
+	tests := []struct {
+		name                 string
+		source               *Source
+		defaultFailurePolicy string
+		expected             admissionv1beta1.FailurePolicyType
+	}{
+		{
+			name:                 "Uses specified failure policy Fail",
+			source:               &Source{FailurePolicy: ptr.To[string]("Fail")},
+			defaultFailurePolicy: "Ignore",
+			expected:             admissionv1beta1.Fail,
+		},
+		{
+			name:                 "Uses specified failure policy Ignore",
+			source:               &Source{FailurePolicy: ptr.To[string]("Ignore")},
+			defaultFailurePolicy: "Fail",
+			expected:             admissionv1beta1.Ignore,
+		},
+		{
+			name:                 "Falls back to DefaultFailurePolicy (Fail)",
+			source:               &Source{FailurePolicy: nil},
+			defaultFailurePolicy: "Fail",
+			expected:             admissionv1beta1.Fail,
+		},
+		{
+			name:                 "Falls back to DefaultFailurePolicy (Ignore)",
+			source:               &Source{FailurePolicy: nil},
+			defaultFailurePolicy: "Ignore",
+			expected:             admissionv1beta1.Ignore,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			*DefaultFailurePolicy = tt.defaultFailurePolicy
+			got, err := tt.source.GetV1Beta1FailurePolicy()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got == nil || *got != tt.expected {
+				t.Errorf("GetV1Beta1FailurePolicy() = %v, want %v", got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #4567 This pull request introduces a global `--default-failure-policy` flag to configure the default failure policy for admission requests and VAPs when a `ConstraintTemplate` does not explicitly define one.

### Changes:
- Added `DefaultFailurePolicy` to `pkg/drivers/k8scel/schema/schema.go`.
- Updated `GetV1Beta1FailurePolicy()` and `GetFailurePolicy()` to use the new flag as a fallback instead of the hardcoded `Fail`.
- Added the `--default-failure-policy` flag to the controller manager and audit deployments in `values.yaml` and raw manifests.
- Added comprehensive unit tests in `schema_test.go` to ensure correct fallback logic.

### Testing Performed
- Implemented explicit unit tests to guarantee that the new global flag (`--default-failure-policy`) behaves perfectly as a fallback, while respecting any explicitly defined template failure policies.
- Added test suites `TestGetFailurePolicy` and `TestGetV1Beta1FailurePolicy` to `pkg/drivers/k8scel/schema/schema_test.go` checking all four edge cases (fallback when default is Fail/Ignore, explicit overrides).
- Ran standard Go test suite with passing results:
```bash
$ go test ./pkg/drivers/k8scel/schema
ok      github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel/schema    4.239s
```