### PR TITLE
chore: use go-version-file in CI workflows instead of hardcoded version

### DIFF
--- a/.github/workflows/check-manifest.yaml
+++ b/.github/workflows/check-manifest.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
       - name: Check go.mod and manifests
         run: |

--- a/.github/workflows/license-lint.yaml
+++ b/.github/workflows/license-lint.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Set release version and target branch for vNext

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Get tag

--- a/.github/workflows/remote-cluster-e2e.yaml
+++ b/.github/workflows/remote-cluster-e2e.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Install dependencies

--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
       - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # unreleased, includes fix for golang/go#75908
 

--- a/.github/workflows/scan-vulns.yaml
+++ b/.github/workflows/scan-vulns.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version-file: go.mod
+          go-version: "1.26"
           check-latest: true
       - uses: golang/govulncheck-action@31f7c5463448f83528bd771c2d978d940080c9fd # unreleased, includes fix for golang/go#75908
 

--- a/.github/workflows/test-gator-policy.yaml
+++ b/.github/workflows/test-gator-policy.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Run unit tests with coverage
@@ -59,7 +59,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Bootstrap e2e

--- a/.github/workflows/test-gator.yaml
+++ b/.github/workflows/test-gator.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: gator test
@@ -64,7 +64,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Build gator

--- a/.github/workflows/unit-test.yaml
+++ b/.github/workflows/unit-test.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Cache envtest binaries
@@ -77,7 +77,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Cache envtest binaries
@@ -105,7 +105,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Cache envtest binaries

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Bootstrap e2e
@@ -177,7 +177,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
-        go-version: "1.26"
+        go-version-file: go.mod
         check-latest: true
 
     - name: Bootstrap e2e
@@ -233,7 +233,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.26"
+          go-version-file: go.mod
           check-latest: true
 
       - name: Bootstrap e2e


### PR DESCRIPTION
Replace `go-version: "1.25"` with `go-version-file: go.mod` across all ten workflow files (16 occurrences). This makes `actions/setup-go` derive the Go version from the single source of truth, so the version tracks `go.mod` automatically when it is bumped and cannot silently drift.

No functional change — the effective Go version remains the same.