### PR TITLE
test: add t.Parallel() to pkg/gator unit tests

### DIFF
--- a/pkg/gator/fileext_test.go
+++ b/pkg/gator/fileext_test.go
@@ -3,6 +3,7 @@ package gator
 import "testing"
 
 func TestIsYAMLExtension(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		ext      string
 		expected bool
@@ -24,6 +25,7 @@ func TestIsYAMLExtension(t *testing.T) {
 }
 
 func TestIsSupportedExtension(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		ext      string
 		expected bool

--- a/pkg/gator/policy/exitcodes_test.go
+++ b/pkg/gator/policy/exitcodes_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestExitError(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		createErr    func() *ExitError
@@ -66,6 +67,7 @@ func TestExitError(t *testing.T) {
 }
 
 func TestExitCodes(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, 0, ExitSuccess)
 	assert.Equal(t, 1, ExitGeneralError)
 	assert.Equal(t, 2, ExitClusterError)

--- a/pkg/gator/policy/labels/labels_test.go
+++ b/pkg/gator/policy/labels/labels_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAddManagedLabels(t *testing.T) {
+	t.Parallel()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "templates.gatekeeper.sh/v1",
@@ -36,6 +37,7 @@ func TestAddManagedLabels(t *testing.T) {
 }
 
 func TestAddManagedLabels_WithoutBundle(t *testing.T) {
+	t.Parallel()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "templates.gatekeeper.sh/v1",
@@ -55,6 +57,7 @@ func TestAddManagedLabels_WithoutBundle(t *testing.T) {
 }
 
 func TestAddManagedLabels_PreservesExistingLabels(t *testing.T) {
+	t.Parallel()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"apiVersion": "templates.gatekeeper.sh/v1",
@@ -76,6 +79,7 @@ func TestAddManagedLabels_PreservesExistingLabels(t *testing.T) {
 }
 
 func TestIsManagedByGator(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name        string
 		labels      map[string]string
@@ -149,6 +153,7 @@ func TestIsManagedByGator(t *testing.T) {
 }
 
 func TestGetPolicyVersion(t *testing.T) {
+	t.Parallel()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{
@@ -176,6 +181,7 @@ func TestGetPolicyVersion(t *testing.T) {
 }
 
 func TestGetBundle(t *testing.T) {
+	t.Parallel()
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{
 			"metadata": map[string]interface{}{

--- a/pkg/gator/policy/output/output_test.go
+++ b/pkg/gator/policy/output/output_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestTablePrinter_PrintPolicies(t *testing.T) {
+	t.Parallel()
 	printer := &TablePrinter{}
 	var buf bytes.Buffer
 
@@ -35,6 +36,7 @@ func TestTablePrinter_PrintPolicies(t *testing.T) {
 }
 
 func TestTablePrinter_PrintPolicies_Empty(t *testing.T) {
+	t.Parallel()
 	printer := &TablePrinter{}
 	var buf bytes.Buffer
 
@@ -46,6 +48,7 @@ func TestTablePrinter_PrintPolicies_Empty(t *testing.T) {
 }
 
 func TestTablePrinter_PrintSearchResults(t *testing.T) {
+	t.Parallel()
 	printer := &TablePrinter{}
 	var buf bytes.Buffer
 
@@ -67,6 +70,7 @@ func TestTablePrinter_PrintSearchResults(t *testing.T) {
 }
 
 func TestTablePrinter_PrintSearchResults_TruncatesLongDescription(t *testing.T) {
+	t.Parallel()
 	printer := &TablePrinter{}
 	var buf bytes.Buffer
 
@@ -84,6 +88,7 @@ func TestTablePrinter_PrintSearchResults_TruncatesLongDescription(t *testing.T) 
 }
 
 func TestJSONPrinter_PrintPolicies(t *testing.T) {
+	t.Parallel()
 	printer := &JSONPrinter{}
 	var buf bytes.Buffer
 
@@ -107,6 +112,7 @@ func TestJSONPrinter_PrintPolicies(t *testing.T) {
 }
 
 func TestJSONPrinter_PrintSearchResults(t *testing.T) {
+	t.Parallel()
 	printer := &JSONPrinter{}
 	var buf bytes.Buffer
 
@@ -130,6 +136,7 @@ func TestJSONPrinter_PrintSearchResults(t *testing.T) {
 }
 
 func TestNewPrinter(t *testing.T) {
+	t.Parallel()
 	tablePrinter, err := NewPrinter(FormatTable)
 	require.NoError(t, err)
 	assert.IsType(t, &TablePrinter{}, tablePrinter)
@@ -150,6 +157,7 @@ func TestNewPrinter(t *testing.T) {
 }
 
 func TestTablePrinter_PrintInstallResult(t *testing.T) {
+	t.Parallel()
 	printer := &TablePrinter{}
 	var buf bytes.Buffer
 
@@ -176,6 +184,7 @@ func TestTablePrinter_PrintInstallResult(t *testing.T) {
 }
 
 func TestTablePrinter_PrintInstallResult_DryRun(t *testing.T) {
+	t.Parallel()
 	printer := &TablePrinter{}
 	var buf bytes.Buffer
 
@@ -196,6 +205,7 @@ func TestTablePrinter_PrintInstallResult_DryRun(t *testing.T) {
 }
 
 func TestTablePrinter_PrintUninstallResult(t *testing.T) {
+	t.Parallel()
 	printer := &TablePrinter{}
 	var buf bytes.Buffer
 
@@ -218,6 +228,7 @@ func TestTablePrinter_PrintUninstallResult(t *testing.T) {
 }
 
 func TestTablePrinter_PrintUpgradeResult(t *testing.T) {
+	t.Parallel()
 	printer := &TablePrinter{}
 	var buf bytes.Buffer
 
@@ -240,6 +251,7 @@ func TestTablePrinter_PrintUpgradeResult(t *testing.T) {
 }
 
 func TestJSONPrinter_PrintInstallResult(t *testing.T) {
+	t.Parallel()
 	printer := &JSONPrinter{}
 	var buf bytes.Buffer
 
@@ -268,6 +280,7 @@ func TestJSONPrinter_PrintInstallResult(t *testing.T) {
 }
 
 func TestJSONPrinter_PrintUninstallResult(t *testing.T) {
+	t.Parallel()
 	printer := &JSONPrinter{}
 	var buf bytes.Buffer
 
@@ -293,6 +306,7 @@ func TestJSONPrinter_PrintUninstallResult(t *testing.T) {
 }
 
 func TestJSONPrinter_PrintUpgradeResult(t *testing.T) {
+	t.Parallel()
 	printer := &JSONPrinter{}
 	var buf bytes.Buffer
 

--- a/pkg/gator/verify/assertion_test.go
+++ b/pkg/gator/verify/assertion_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAssertion_Run(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		assertion *Assertion


### PR DESCRIPTION
Add `t.Parallel()` to 25 top-level test functions across five pure unit test files in `pkg/gator/**`:

- `pkg/gator/fileext_test.go` (2 functions)
- `pkg/gator/policy/exitcodes_test.go` (2 functions)
- `pkg/gator/policy/labels/labels_test.go` (6 functions)
- `pkg/gator/verify/assertion_test.go` (1 function)
- `pkg/gator/policy/output/output_test.go` (14 functions)

None of these files have package-level mutable state. Verified with `go test -race ./pkg/gator/...` — all pass.