### PR TITLE
ci: fix license-lint checkout order

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -35,7 +35,7 @@ jobs:
             [Running benchmark here...](${{ github.server.url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Check out base code into the Go module directory
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v3.5.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.base_ref }}
 
@@ -43,7 +43,7 @@ jobs:
         run: make benchmark-test BENCHMARK_FILE_NAME="../base_benchmarks.txt"
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v3.5.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Run benchmark with incoming changes
         run: make benchmark-test BENCHMARK_FILE_NAME="pr_benchmarks.txt"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,6 +22,6 @@ jobs:
           egress-policy: audit
 
       - name: 'Checkout Repository'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v3.5.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/license-lint.yaml
+++ b/.github/workflows/license-lint.yaml
@@ -27,14 +27,14 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v3.5.2
 
       - name: license-lint
         run: |

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -36,7 +36,7 @@ jobs:
           egress-policy: audit
 
       - name: "Checkout code"
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v3.5.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v3.5.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -69,7 +69,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v3.5.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - uses: crate-ci/typos@37bb98842b0d8c4ffebdb75301a13db0267cef89 # v1.47.2
         with:


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the checkout step before `actions/setup-go` in the `license-lint` workflow. The workflow configures `setup-go` with `go-version-file: go.mod`, so the repository must be checked out before that step runs.

Also normalizes stale `actions/checkout` version comments for the pinned `df4cb1c069e1874edd31b4311f1884172cec0e10` SHA from `v3.5.2` to `v6.0.3` in other workflow files.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:

N/A

**Special notes for your reviewer**:

This fixes the current `license-lint` failure:

```text
The specified go version file at: go.mod does not exist
```