### PR TITLE
ci: Check out release PR workflow before Go setup

### DIFF
--- a/.github/workflows/release-pr.yaml
+++ b/.github/workflows/release-pr.yaml
@@ -22,6 +22,10 @@ jobs:
         with:
           egress-policy: audit
 
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -61,10 +65,6 @@ jobs:
           if [[ "${NEWVERSION}" =~ "beta" ]]; then
             echo "TARGET_BRANCH=master" >> ${GITHUB_ENV}
           fi
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-        with:
-          fetch-depth: 0
 
       - name: Create release branch if needed
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Moves the `release-pr.yaml` checkout step before `actions/setup-go` so `go-version-file: go.mod` can be resolved when the `create_release_pull_request` workflow is dispatched.

The workflow currently fails before it can parse the requested release version or create the release PR:

```text
Set up Go
error: The specified go version file at: go.mod does not exist
```

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
N/A

**Special notes for your reviewer**:
Checked all `.github/workflows/*` usages of `go-version-file`; `release-pr.yaml` was the only workflow where it appeared before an `actions/checkout` step. `scan-vulns.yaml` runs `setup-go` before checkout, but it uses a literal `go-version` instead of `go-version-file`, so it does not hit this failure mode.
