### PR TITLE
feat(constraints): scope excludedNamespaces by process

### DIFF
--- a/config/crd/bases/_assignimages.yaml
+++ b/config/crd/bases/_assignimages.yaml
@@ -255,13 +255,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/_assignimages.yaml
+++ b/config/crd/bases/_assignimages.yaml
@@ -250,6 +250,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources

--- a/config/crd/bases/_assignmetadata.yaml
+++ b/config/crd/bases/_assignmetadata.yaml
@@ -209,13 +209,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/_assignmetadata.yaml
+++ b/config/crd/bases/_assignmetadata.yaml
@@ -204,6 +204,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources

--- a/config/crd/bases/_assigns.yaml
+++ b/config/crd/bases/_assigns.yaml
@@ -255,13 +255,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/_assigns.yaml
+++ b/config/crd/bases/_assigns.yaml
@@ -250,6 +250,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources

--- a/config/crd/bases/_modifysets.yaml
+++ b/config/crd/bases/_modifysets.yaml
@@ -252,6 +252,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources

--- a/config/crd/bases/_modifysets.yaml
+++ b/config/crd/bases/_modifysets.yaml
@@ -257,13 +257,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/match.gatekeeper.sh_matchcrd.yaml
+++ b/config/crd/bases/match.gatekeeper.sh_matchcrd.yaml
@@ -192,6 +192,20 @@ spec:
                   pattern: ^\*?[-:a-z0-9]*\*?$
                   type: string
                 type: array
+              processes:
+                description: |-
+                  Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                  Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                  When omitted or set to `*`, excludedNamespaces applies to all processes.
+                enum:
+                - audit
+                - webhook
+                - sync
+                - mutation-webhook
+                - '*'
+                items:
+                  type: string
+                type: array
               scope:
                 description: |-
                   Scope determines if cluster-scoped and/or namespaced-scoped resources

--- a/config/crd/bases/match.gatekeeper.sh_matchcrd.yaml
+++ b/config/crd/bases/match.gatekeeper.sh_matchcrd.yaml
@@ -197,13 +197,13 @@ spec:
                   Processes scopes excludedNamespaces to specific Gatekeeper processes.
                   Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                   When omitted or set to `*`, excludedNamespaces applies to all processes.
-                enum:
-                - audit
-                - webhook
-                - sync
-                - mutation-webhook
-                - '*'
                 items:
+                  enum:
+                  - audit
+                  - webhook
+                  - sync
+                  - mutation-webhook
+                  - '*'
                   type: string
                 type: array
               scope:

--- a/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
@@ -255,13 +255,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:
@@ -654,13 +654,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:
@@ -1053,13 +1053,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
@@ -250,6 +250,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources
@@ -635,6 +649,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources
@@ -1018,6 +1046,20 @@ spec:
                         "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
                         match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
                       pattern: ^\*?[-:a-z0-9]*\*?$
+                      type: string
+                    type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/mutations.gatekeeper.sh_assignimage.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignimage.yaml
@@ -255,13 +255,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/mutations.gatekeeper.sh_assignimage.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignimage.yaml
@@ -250,6 +250,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources

--- a/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
@@ -204,6 +204,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources
@@ -520,6 +534,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources
@@ -834,6 +862,20 @@ spec:
                         "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
                         match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
                       pattern: ^\*?[-:a-z0-9]*\*?$
+                      type: string
+                    type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
@@ -209,13 +209,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:
@@ -539,13 +539,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:
@@ -869,13 +869,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/mutations.gatekeeper.sh_modifyset.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_modifyset.yaml
@@ -257,13 +257,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:
@@ -621,13 +621,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:
@@ -985,13 +985,13 @@ spec:
                       Processes scopes excludedNamespaces to specific Gatekeeper processes.
                       Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
                       When omitted or set to `*`, excludedNamespaces applies to all processes.
-                    enum:
-                    - audit
-                    - webhook
-                    - sync
-                    - mutation-webhook
-                    - '*'
                     items:
+                      enum:
+                      - audit
+                      - webhook
+                      - sync
+                      - mutation-webhook
+                      - '*'
                       type: string
                     type: array
                   scope:

--- a/config/crd/bases/mutations.gatekeeper.sh_modifyset.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_modifyset.yaml
@@ -252,6 +252,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources
@@ -602,6 +616,20 @@ spec:
                       pattern: ^\*?[-:a-z0-9]*\*?$
                       type: string
                     type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
+                      type: string
+                    type: array
                   scope:
                     description: |-
                       Scope determines if cluster-scoped and/or namespaced-scoped resources
@@ -950,6 +978,20 @@ spec:
                         "kube-public", "*-system" will match "kube-system" or "gatekeeper-system", "*system*" will
                         match "system-kube" or "kube-system".  The asterisk is required for wildcard matching.
                       pattern: ^\*?[-:a-z0-9]*\*?$
+                      type: string
+                    type: array
+                  processes:
+                    description: |-
+                      Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                      Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+                      When omitted or set to `*`, excludedNamespaces applies to all processes.
+                    enum:
+                    - audit
+                    - webhook
+                    - sync
+                    - mutation-webhook
+                    - '*'
+                    items:
                       type: string
                     type: array
                   scope:

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -706,9 +706,10 @@ func (am *Manager) reviewObjects(ctx context.Context, kind string, folderCount i
 					ns = &nsRef
 				}
 				augmentedObj := target.AugmentedUnstructured{
-					Object:    *objFile,
-					Namespace: ns,
-					Source:    mutationtypes.SourceTypeOriginal,
+					Object:           *objFile,
+					Namespace:        ns,
+					Source:           mutationtypes.SourceTypeOriginal,
+					EnforcementPoint: util.AuditEnforcementPoint,
 				}
 
 				opts := []reviews.ReviewOpt{
@@ -738,9 +739,10 @@ func (am *Manager) reviewObjects(ctx context.Context, kind string, folderCount i
 				}
 				for _, resultant := range resultants {
 					au := target.AugmentedUnstructured{
-						Object:    *resultant.Obj,
-						Namespace: ns,
-						Source:    mutationtypes.SourceTypeGenerated,
+						Object:           *resultant.Obj,
+						Namespace:        ns,
+						Source:           mutationtypes.SourceTypeGenerated,
+						EnforcementPoint: util.AuditEnforcementPoint,
 					}
 					resultantOpts := []reviews.ReviewOpt{
 						reviews.EnforcementPoint(util.AuditEnforcementPoint),

--- a/pkg/audit/manager.go
+++ b/pkg/audit/manager.go
@@ -608,8 +608,9 @@ func (am *Manager) auditFromCache(ctx context.Context) ([]Result, []error) {
 		}
 
 		au := &target.AugmentedUnstructured{
-			Object:    obj,
-			Namespace: ns,
+			Object:           obj,
+			Namespace:        ns,
+			EnforcementPoint: util.AuditEnforcementPoint,
 		}
 		opts := []reviews.ReviewOpt{
 			reviews.EnforcementPoint(util.AuditEnforcementPoint),
@@ -704,9 +705,10 @@ func (am *Manager) reviewObjects(ctx context.Context, kind string, folderCount i
 				ns = &nsRef
 			}
 			augmentedObj := target.AugmentedUnstructured{
-				Object:    *objFile,
-				Namespace: ns,
-				Source:    mutationtypes.SourceTypeOriginal,
+				Object:           *objFile,
+				Namespace:        ns,
+				Source:           mutationtypes.SourceTypeOriginal,
+				EnforcementPoint: util.AuditEnforcementPoint,
 			}
 
 			opts := []reviews.ReviewOpt{
@@ -736,9 +738,10 @@ func (am *Manager) reviewObjects(ctx context.Context, kind string, folderCount i
 			}
 			for _, resultant := range resultants {
 				au := target.AugmentedUnstructured{
-					Object:    *resultant.Obj,
-					Namespace: ns,
-					Source:    mutationtypes.SourceTypeGenerated,
+					Object:           *resultant.Obj,
+					Namespace:        ns,
+					Source:           mutationtypes.SourceTypeGenerated,
+					EnforcementPoint: util.AuditEnforcementPoint,
 				}
 				resultantOpts := []reviews.ReviewOpt{
 					reviews.EnforcementPoint(util.AuditEnforcementPoint),

--- a/pkg/mutation/match/match.go
+++ b/pkg/mutation/match/match.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -25,6 +26,7 @@ type Matchable struct {
 	Object    client.Object
 	Namespace *corev1.Namespace
 	Source    types.SourceType
+	Process   process.Process
 }
 
 // Matches verifies if the given object belonging to the given namespace
@@ -140,11 +142,28 @@ func excludedNamespacesMatch(match *Match, target *Matchable) (bool, error) {
 
 	for _, n := range match.ExcludedNamespaces {
 		if n.Matches(namespace) {
-			return false, nil
+			if excludedNamespacesAppliesToProcess(match.Processes, target.Process) {
+				return false, nil
+			}
+			return true, nil
 		}
 	}
 
 	return true, nil
+}
+
+func excludedNamespacesAppliesToProcess(processes []string, current process.Process) bool {
+	if len(processes) == 0 {
+		return true
+	}
+
+	for _, p := range processes {
+		if p == string(process.Star) || process.Process(p) == current {
+			return true
+		}
+	}
+
+	return false
 }
 
 func namespacesMatch(match *Match, target *Matchable) (bool, error) {

--- a/pkg/mutation/match/match_test.go
+++ b/pkg/mutation/match/match_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/types"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
 	corev1 "k8s.io/api/core/v1"
@@ -1036,5 +1037,33 @@ func Test_namesMatch(t *testing.T) {
 				t.Errorf("namesMatch() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExcludedNamespacesProcessScoped(t *testing.T) {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "rollout-ns"}}
+	obj := makeObject(schema.GroupVersionKind{Kind: "Pod", Group: ""}, "rollout-ns", "pod")
+
+	match := &Match{
+		ExcludedNamespaces: []wildcard.Wildcard{"rollout-ns"},
+		Processes:          []string{"webhook"},
+	}
+
+	webhookTarget := &Matchable{Object: obj, Namespace: ns, Process: process.Webhook}
+	matched, err := Matches(match, webhookTarget)
+	if err != nil {
+		t.Fatalf("Matches() error = %v", err)
+	}
+	if matched {
+		t.Fatalf("expected namespace to be excluded for webhook process")
+	}
+
+	auditTarget := &Matchable{Object: obj, Namespace: ns, Process: process.Audit}
+	matched, err = Matches(match, auditTarget)
+	if err != nil {
+		t.Fatalf("Matches() error = %v", err)
+	}
+	if !matched {
+		t.Fatalf("expected namespace exclusion to not apply during audit")
 	}
 }

--- a/pkg/mutation/match/match_types.go
+++ b/pkg/mutation/match/match_types.go
@@ -37,7 +37,7 @@ type Match struct {
 	// Processes scopes excludedNamespaces to specific Gatekeeper processes.
 	// Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
 	// When omitted or set to `*`, excludedNamespaces applies to all processes.
-	// +kubebuilder:validation:Enum=audit;webhook;sync;mutation-webhook;*
+	// +kubebuilder:validation:items:Enum=audit;webhook;sync;mutation-webhook;*
 	Processes []string `json:"processes,omitempty"`
 	// LabelSelector is the combination of two optional fields: `matchLabels`
 	// and `matchExpressions`.  These two fields provide different methods of

--- a/pkg/mutation/match/match_types.go
+++ b/pkg/mutation/match/match_types.go
@@ -34,6 +34,10 @@ type Match struct {
 	// `kube-public`, and `excludedNamespaces: [*-system]` matches both `kube-system` and
 	// `gatekeeper-system`.
 	ExcludedNamespaces []wildcard.Wildcard `json:"excludedNamespaces,omitempty"`
+	// Processes scopes excludedNamespaces to specific Gatekeeper processes.
+	// Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
+	// When omitted or set to `*`, excludedNamespaces applies to all processes.
+	Processes []string `json:"processes,omitempty"`
 	// LabelSelector is the combination of two optional fields: `matchLabels`
 	// and `matchExpressions`.  These two fields provide different methods of
 	// selecting or excluding k8s objects based on the label keys and values

--- a/pkg/mutation/match/match_types.go
+++ b/pkg/mutation/match/match_types.go
@@ -37,6 +37,7 @@ type Match struct {
 	// Processes scopes excludedNamespaces to specific Gatekeeper processes.
 	// Accepts `audit`, `webhook`, `sync`, `mutation-webhook`, or `*`.
 	// When omitted or set to `*`, excludedNamespaces applies to all processes.
+	// +kubebuilder:validation:Enum=audit;webhook;sync;mutation-webhook;*
 	Processes []string `json:"processes,omitempty"`
 	// LabelSelector is the combination of two optional fields: `matchLabels`
 	// and `matchExpressions`.  These two fields provide different methods of

--- a/pkg/mutation/mutators/assignmeta/assignmeta_mutator.go
+++ b/pkg/mutation/mutators/assignmeta/assignmeta_mutator.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	mutationsunversioned "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/unversioned"
 	mutationsv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/mutations/v1beta1"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/match"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/mutators/core"
@@ -59,6 +60,7 @@ func (m *Mutator) Matches(mutable *types.Mutable) (bool, error) {
 		Object:    mutable.Object,
 		Namespace: mutable.Namespace,
 		Source:    mutable.Source,
+		Process:   process.Mutation,
 	}
 	matches, err := match.Matches(&m.assignMetadata.Spec.Match, target)
 	if err != nil {

--- a/pkg/mutation/mutators/core/mutator.go
+++ b/pkg/mutation/mutators/core/mutator.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/open-policy-agent/gatekeeper/v3/apis/mutations/unversioned"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/match"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/path/parser"
 	patht "github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/path/tester"
@@ -168,6 +169,7 @@ func MatchWithApplyTo(mut *types.Mutable, applies []match.MutationApplyTo, mat *
 		Object:    mut.Object,
 		Namespace: mut.Namespace,
 		Source:    mut.Source,
+		Process:   process.Mutation,
 	}
 	matches, err := match.Matches(mat, target)
 	if err != nil {

--- a/pkg/target/data.go
+++ b/pkg/target/data.go
@@ -24,8 +24,9 @@ func IsWipeData(o interface{}) bool {
 // its admission operation (when sourced from an admission review), and its
 // source type.
 type AugmentedUnstructured struct {
-	Object    unstructured.Unstructured
-	Namespace *corev1.Namespace
-	Operation admissionv1.Operation
-	Source    types.SourceType
+	Object           unstructured.Unstructured
+	Namespace        *corev1.Namespace
+	Operation        admissionv1.Operation
+	Source           types.SourceType
+	EnforcementPoint string
 }

--- a/pkg/target/matchcrd_constant.go
+++ b/pkg/target/matchcrd_constant.go
@@ -203,13 +203,13 @@ spec:
                   Processes scopes excludedNamespaces to specific Gatekeeper processes.
                   Accepts `+"`"+`audit`+"`"+`, `+"`"+`webhook`+"`"+`, `+"`"+`sync`+"`"+`, `+"`"+`mutation-webhook`+"`"+`, or `+"`"+`*`+"`"+`.
                   When omitted or set to `+"`"+`*`+"`"+`, excludedNamespaces applies to all processes.
-                enum:
-                - audit
-                - webhook
-                - sync
-                - mutation-webhook
-                - '*'
                 items:
+                  enum:
+                  - audit
+                  - webhook
+                  - sync
+                  - mutation-webhook
+                  - '*'
                   type: string
                 type: array
               scope:

--- a/pkg/target/matchcrd_constant.go
+++ b/pkg/target/matchcrd_constant.go
@@ -198,6 +198,20 @@ spec:
                   pattern: ^\*?[-:a-z0-9]*\*?$
                   type: string
                 type: array
+              processes:
+                description: |-
+                  Processes scopes excludedNamespaces to specific Gatekeeper processes.
+                  Accepts `+"`"+`audit`+"`"+`, `+"`"+`webhook`+"`"+`, `+"`"+`sync`+"`"+`, `+"`"+`mutation-webhook`+"`"+`, or `+"`"+`*`+"`"+`.
+                  When omitted or set to `+"`"+`*`+"`"+`, excludedNamespaces applies to all processes.
+                enum:
+                - audit
+                - webhook
+                - sync
+                - mutation-webhook
+                - '*'
+                items:
+                  type: string
+                type: array
               scope:
                 description: |-
                   Scope determines if cluster-scoped and/or namespaced-scoped resources

--- a/pkg/target/matcher.go
+++ b/pkg/target/matcher.go
@@ -38,10 +38,10 @@ func (m *Matcher) Match(review interface{}) (bool, error) {
 		ns = m.cache.GetNamespace(gkReq.Namespace)
 	}
 
-	return matchAny(m, ns, gkReq.source, obj, oldObj)
+	return matchAny(m, ns, gkReq.source, gkReq.enforcementPoint, obj, oldObj)
 }
 
-func matchAny(m *Matcher, ns *corev1.Namespace, source types.SourceType, objs ...*unstructured.Unstructured) (bool, error) {
+func matchAny(m *Matcher, ns *corev1.Namespace, source types.SourceType, enforcementPoint string, objs ...*unstructured.Unstructured) (bool, error) {
 	nilObj := 0
 	for _, obj := range objs {
 		if obj == nil || obj.Object == nil {
@@ -53,6 +53,7 @@ func matchAny(m *Matcher, ns *corev1.Namespace, source types.SourceType, objs ..
 			Object:    obj,
 			Namespace: ns,
 			Source:    source,
+			Process:   processFromEnforcementPoint(enforcementPoint),
 		}
 		matched, err := match.Matches(m.match, t)
 		if err != nil {

--- a/pkg/target/matcher.go
+++ b/pkg/target/matcher.go
@@ -38,10 +38,10 @@ func (m *Matcher) Match(review interface{}) (bool, error) {
 		ns = gkReq.getNamespace(m.cache)
 	}
 
-	return matchAny(m, ns, gkReq.source, obj, oldObj)
+	return matchAny(m, ns, gkReq.source, gkReq.enforcementPoint, obj, oldObj)
 }
 
-func matchAny(m *Matcher, ns *corev1.Namespace, source types.SourceType, objs ...*unstructured.Unstructured) (bool, error) {
+func matchAny(m *Matcher, ns *corev1.Namespace, source types.SourceType, enforcementPoint string, objs ...*unstructured.Unstructured) (bool, error) {
 	nilObj := 0
 	for _, obj := range objs {
 		if obj == nil || obj.Object == nil {
@@ -53,6 +53,7 @@ func matchAny(m *Matcher, ns *corev1.Namespace, source types.SourceType, objs ..
 			Object:    obj,
 			Namespace: ns,
 			Source:    source,
+			Process:   processFromEnforcementPoint(enforcementPoint),
 		}
 		matched, err := match.Matches(m.match, t)
 		if err != nil {

--- a/pkg/target/process.go
+++ b/pkg/target/process.go
@@ -1,0 +1,15 @@
+package target
+
+import (
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+)
+
+func processFromEnforcementPoint(enforcementPoint string) process.Process {
+	switch enforcementPoint {
+	case util.AuditEnforcementPoint:
+		return process.Audit
+	default:
+		return process.Webhook
+	}
+}

--- a/pkg/target/process_test.go
+++ b/pkg/target/process_test.go
@@ -1,0 +1,50 @@
+package target
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+)
+
+func TestProcessFromEnforcementPoint(t *testing.T) {
+	tests := []struct {
+		name             string
+		enforcementPoint string
+		want             process.Process
+	}{
+		{
+			name:             "audit enforcement point maps to audit process",
+			enforcementPoint: util.AuditEnforcementPoint,
+			want:             process.Audit,
+		},
+		{
+			name:             "webhook enforcement point maps to webhook process",
+			enforcementPoint: util.WebhookEnforcementPoint,
+			want:             process.Webhook,
+		},
+		{
+			name:             "vap enforcement point maps to webhook process",
+			enforcementPoint: util.VAPEnforcementPoint,
+			want:             process.Webhook,
+		},
+		{
+			name:             "gator enforcement point maps to webhook process",
+			enforcementPoint: util.GatorEnforcementPoint,
+			want:             process.Webhook,
+		},
+		{
+			name:             "empty enforcement point maps to webhook process",
+			enforcementPoint: "",
+			want:             process.Webhook,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := processFromEnforcementPoint(tt.enforcementPoint); got != tt.want {
+				t.Errorf("processFromEnforcementPoint(%q) = %q, want %q", tt.enforcementPoint, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/target/review.go
+++ b/pkg/target/review.go
@@ -11,13 +11,15 @@ type AugmentedReview struct {
 	Namespace        *corev1.Namespace
 	Source           types.SourceType
 	IsAdmission      bool
+	EnforcementPoint string
 }
 
 type gkReview struct {
 	admissionv1.AdmissionRequest
-	namespace   *corev1.Namespace
-	source      types.SourceType
-	isAdmission bool
+	namespace         *corev1.Namespace
+	source            types.SourceType
+	isAdmission       bool
+	enforcementPoint  string
 }
 
 func (g *gkReview) GetAdmissionRequest() *admissionv1.AdmissionRequest {

--- a/pkg/target/review.go
+++ b/pkg/target/review.go
@@ -14,13 +14,15 @@ type AugmentedReview struct {
 	Namespace        *corev1.Namespace
 	Source           types.SourceType
 	IsAdmission      bool
+	EnforcementPoint string
 }
 
 type gkReview struct {
 	admissionv1.AdmissionRequest
-	namespace   *corev1.Namespace
-	source      types.SourceType
-	isAdmission bool
+	namespace          *corev1.Namespace
+	source             types.SourceType
+	isAdmission        bool
+	enforcementPoint   string
 
 	// parsedObjects is request-local state shared by per-constraint Match calls.
 	// It avoids repeatedly unmarshalling the same AdmissionReview payload while

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -98,6 +98,7 @@ func (h *K8sValidationTarget) handleReview(obj interface{}) (bool, *gkReview, er
 			namespace:        data.Namespace,
 			source:           data.Source,
 			isAdmission:      data.IsAdmission,
+			enforcementPoint: data.EnforcementPoint,
 		}
 	case *AugmentedReview:
 		review = &gkReview{
@@ -105,6 +106,7 @@ func (h *K8sValidationTarget) handleReview(obj interface{}) (bool, *gkReview, er
 			namespace:        data.Namespace,
 			source:           data.Source,
 			isAdmission:      data.IsAdmission,
+			enforcementPoint: data.EnforcementPoint,
 		}
 	case AugmentedUnstructured:
 		review, err = augmentedUnstructuredToAdmissionRequest(data)
@@ -152,6 +154,7 @@ func augmentedUnstructuredToAdmissionRequest(obj AugmentedUnstructured) (*gkRevi
 		review.Object = runtime.RawExtension{}
 	}
 	review.source = obj.Source
+	review.enforcementPoint = obj.EnforcementPoint
 
 	return review, nil
 }

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -850,6 +850,7 @@ func (h *validationHandler) createReviewForRequest(ctx context.Context, req *adm
 		AdmissionRequest: &req.AdmissionRequest,
 		Source:           mutationtypes.SourceTypeOriginal,
 		IsAdmission:      true,
+		EnforcementPoint: util.WebhookEnforcementPoint,
 	}
 	if req.Namespace != "" {
 		ns := &corev1.Namespace{}
@@ -871,10 +872,11 @@ func (h *validationHandler) createReviewForRequest(ctx context.Context, req *adm
 
 func createReviewForResultant(obj *unstructured.Unstructured, ns *corev1.Namespace, operation admissionv1.Operation) *target.AugmentedUnstructured {
 	return &target.AugmentedUnstructured{
-		Object:    *obj,
-		Namespace: ns,
-		Operation: operation,
-		Source:    mutationtypes.SourceTypeGenerated,
+		Object:           *obj,
+		Namespace:        ns,
+		Operation:        operation,
+		Source:           mutationtypes.SourceTypeGenerated,
+		EnforcementPoint: util.WebhookEnforcementPoint,
 	}
 }
 

--- a/pkg/webhook/policy.go
+++ b/pkg/webhook/policy.go
@@ -852,6 +852,7 @@ func (h *validationHandler) createReviewForRequest(ctx context.Context, req *adm
 		AdmissionRequest: &req.AdmissionRequest,
 		Source:           mutationtypes.SourceTypeOriginal,
 		IsAdmission:      true,
+		EnforcementPoint: util.WebhookEnforcementPoint,
 	}
 	if req.Namespace != "" {
 		ns := &corev1.Namespace{}
@@ -873,10 +874,11 @@ func (h *validationHandler) createReviewForRequest(ctx context.Context, req *adm
 
 func createReviewForResultant(obj *unstructured.Unstructured, ns *corev1.Namespace, operation admissionv1.Operation) *target.AugmentedUnstructured {
 	return &target.AugmentedUnstructured{
-		Object:    *obj,
-		Namespace: ns,
-		Operation: operation,
-		Source:    mutationtypes.SourceTypeGenerated,
+		Object:           *obj,
+		Namespace:        ns,
+		Operation:        operation,
+		Source:           mutationtypes.SourceTypeGenerated,
+		EnforcementPoint: util.WebhookEnforcementPoint,
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #2161.

Adds `spec.match.processes` so constraint-level `excludedNamespaces` can be scoped to specific enforcement points (for example `webhook` only), allowing admission to skip excluded namespaces while audit continues to evaluate them.

## Testing

- `go test ./pkg/mutation/match/... -run TestExcludedNamespacesProcessScoped`