### PR TITLE
fix: make generated VAP deterministic to stop reconcile loop

### DIFF
--- a/pkg/controller/config/process/excluder.go
+++ b/pkg/controller/config/process/excluder.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"reflect"
+	"sort"
 	"sync"
 
 	configv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/config/v1alpha1"
@@ -112,6 +113,8 @@ func (s *Excluder) GetExcludedNamespaces(process Process) []string {
 	for ns := range s.excludedNamespaces[process] {
 		excludedNamespaces = append(excludedNamespaces, string(ns))
 	}
+	// Sort for deterministic ordering; map iteration order is not stable.
+	sort.Strings(excludedNamespaces)
 
 	return excludedNamespaces
 }

--- a/pkg/controller/config/process/excluder_test.go
+++ b/pkg/controller/config/process/excluder_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -166,5 +167,30 @@ func TestGetExcludedNamespaces(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGetExcludedNamespacesSorted ensures the returned slice is deterministically sorted.
+func TestGetExcludedNamespacesSorted(t *testing.T) {
+	excluder := New()
+	excluder.Add([]configv1alpha1.MatchEntry{
+		{
+			ExcludedNamespaces: []wildcard.Wildcard{"zeta", "alpha", "monitoring", "kube-system", "app-*"},
+			Processes:          []string{"webhook"},
+		},
+	})
+
+	want := []string{"alpha", "app-*", "kube-system", "monitoring", "zeta"}
+
+	// Call repeatedly: map iteration order varies between calls, so a single
+	// pass could pass by luck even without the sort.
+	for i := 0; i < 20; i++ {
+		got := excluder.GetExcludedNamespaces(Webhook)
+		if !sort.StringsAreSorted(got) {
+			t.Fatalf("GetExcludedNamespaces returned unsorted slice: %v", got)
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("GetExcludedNamespaces = %v, want %v", got, want)
+		}
 	}
 }

--- a/pkg/drivers/k8scel/transform/make_vap_objects.go
+++ b/pkg/drivers/k8scel/transform/make_vap_objects.go
@@ -109,7 +109,12 @@ func convertWebhookRulesToResourceRules(rules []admissionregistrationv1beta1.Rul
 			if !intersection.Equal(ctOpsSet) {
 				errs = append(errs, ErrOperationMismatch)
 			}
-			operations = intersection.UnsortedList()
+			// Emit in canonical allOps order for deterministic output.
+			for _, op := range allOps {
+				if intersection.Has(op) {
+					operations = append(operations, op)
+				}
+			}
 		}
 
 		resourceRules = append(resourceRules, admissionregistrationv1beta1.NamedRuleWithOperations{

--- a/pkg/drivers/k8scel/transform/make_vap_objects_test.go
+++ b/pkg/drivers/k8scel/transform/make_vap_objects_test.go
@@ -885,6 +885,59 @@ func TestConvertWebhookRulesToResourceRules(t *testing.T) {
 	}
 }
 
+// TestConvertWebhookRulesToResourceRulesOperationOrder asserts operations are
+// emitted in canonical order (CREATE, UPDATE, DELETE, CONNECT).
+func TestConvertWebhookRulesToResourceRulesOperationOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleOps  []admissionregistrationv1beta1.OperationType
+		ctOps    []admissionregistrationv1beta1.OperationType
+		expected []admissionregistrationv1beta1.OperationType
+	}{
+		{
+			name:     "intersection preserves canonical order",
+			ruleOps:  []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Delete, admissionregistrationv1beta1.Update, admissionregistrationv1beta1.Create},
+			ctOps:    []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Update, admissionregistrationv1beta1.Create},
+			expected: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
+		},
+		{
+			name:     "wildcard rule intersected with all ops is canonical",
+			ruleOps:  []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.OperationAll},
+			ctOps:    []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.OperationAll},
+			expected: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update, admissionregistrationv1beta1.Delete, admissionregistrationv1beta1.Connect},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rules := []admissionregistrationv1beta1.RuleWithOperations{
+				{
+					Operations: test.ruleOps,
+					Rule: admissionregistrationv1beta1.Rule{
+						APIGroups:   []string{"apps"},
+						APIVersions: []string{"v1"},
+						Resources:   []string{"deployments"},
+					},
+				},
+			}
+
+			// Repeat: set iteration order varies between calls.
+			for i := 0; i < 20; i++ {
+				result, err := convertWebhookRulesToResourceRules(rules, test.ctOps)
+				if err != nil && !errors.Is(err, ErrOperationMismatch) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(result) != 1 {
+					t.Fatalf("expected 1 resource rule, got %d", len(result))
+				}
+				if !reflect.DeepEqual(result[0].Operations, test.expected) {
+					t.Fatalf("operations = %v, want %v", result[0].Operations, test.expected)
+				}
+			}
+		})
+	}
+}
+
 func TestExpandWildcardOperations(t *testing.T) {
 	allOps := []admissionregistrationv1beta1.OperationType{
 		admissionregistrationv1beta1.Create,

--- a/pkg/webhook/namespacelabel.go
+++ b/pkg/webhook/namespacelabel.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
@@ -98,5 +99,7 @@ func GetAllExemptedNamespacesWithWildcard() []string {
 	for ns := range exemptNamespaceSuffix {
 		namespaces = append(namespaces, "*"+ns)
 	}
+	// Sort for deterministic ordering; map iteration order is not stable.
+	sort.Strings(namespaces)
 	return namespaces
 }

--- a/pkg/webhook/namespacelabel_test.go
+++ b/pkg/webhook/namespacelabel_test.go
@@ -3,6 +3,8 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"slices"
+	"sort"
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -493,5 +495,35 @@ func TestGetAllExemptedNamespacesWithWildcard(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGetAllExemptedNamespacesWithWildcardSorted ensures the returned slice is deterministically sorted.
+func TestGetAllExemptedNamespacesWithWildcardSorted(t *testing.T) {
+	origExemptNamespace := exemptNamespace
+	origExemptNamespacePrefix := exemptNamespacePrefix
+	origExemptNamespaceSuffix := exemptNamespaceSuffix
+	defer func() {
+		exemptNamespace = origExemptNamespace
+		exemptNamespacePrefix = origExemptNamespacePrefix
+		exemptNamespaceSuffix = origExemptNamespaceSuffix
+	}()
+
+	exemptNamespace = map[string]bool{"zeta": true, "alpha": true, "kube-system": true}
+	exemptNamespacePrefix = map[string]bool{"openshift-": true, "dev-": true}
+	exemptNamespaceSuffix = map[string]bool{"-system": true, "-prod": true}
+
+	want := []string{"*-prod", "*-system", "alpha", "dev-*", "kube-system", "openshift-*", "zeta"}
+
+	// Call repeatedly: map iteration order varies between calls, so a single
+	// pass could pass by luck even without the sort.
+	for i := 0; i < 20; i++ {
+		got := GetAllExemptedNamespacesWithWildcard()
+		if !sort.StringsAreSorted(got) {
+			t.Fatalf("GetAllExemptedNamespacesWithWildcard returned unsorted slice: %v", got)
+		}
+		if !slices.Equal(got, want) {
+			t.Fatalf("GetAllExemptedNamespacesWithWildcard = %v, want %v", got, want)
+		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

GetExcludedNamespaces and GetAllExemptedNamespacesWithWildcard built their returned slices by ranging over maps, so the order was nondeterministic.

These slices are rendered (via sync-vap-enforcement-scope) into the generated ValidatingAdmissionPolicy's CEL match conditions. Because the order varied each reconcile, the freshly-built VAP never matched the stored one, so the ConstraintTemplate controller issued a VAP Update every reconcile. The VAP change re-enqueued its owner ConstraintTemplate, producing a self-sustaining reconcile loop — constant VAP updates and ConstraintTemplate status rewrites (resourceVersion climbing with no spec change), and the resulting etcd write pressure.

Fix: sort both slices before returning, so VAP generation is byte-stable across reconciles. With stable ordering no Update is issued, and the loop stops.

Added regression tests asserting both functions return sorted output.

The diff in the screenshot shows the issue. The dumps were taken just seconds apart:
<img width="2958" height="556" alt="image" src="https://github.com/user-attachments/assets/d6f8a9ad-69eb-4af5-b2ce-fcf204f0fc08" />

<!--
**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #--> 

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

<!--
**Special notes for your reviewer**:
-->