### PR TITLE
feat: add status subresource to ConstraintTemplatePodStatus CRD

### DIFF
--- a/apis/status/v1beta1/constrainttemplatepodstatus_types.go
+++ b/apis/status/v1beta1/constrainttemplatepodstatus_types.go
@@ -46,6 +46,7 @@ type VAPGenerationStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:subresource:status
 
 // ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses API.
 type ConstraintTemplatePodStatus struct {

--- a/config/crd/bases/status.gatekeeper.sh_constrainttemplatepodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_constrainttemplatepodstatuses.yaml
@@ -89,3 +89,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -102,6 +102,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - status.gatekeeper.sh
+  resources:
+  - constrainttemplatepodstatuses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - externaldata.gatekeeper.sh
   resources:
   - providers

--- a/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -91,3 +91,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-manager-role-clusterrole.yaml
@@ -112,6 +112,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - status.gatekeeper.sh
+  resources:
+  - constrainttemplatepodstatuses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - externaldata.gatekeeper.sh
   resources:
   - providers

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -3145,6 +3145,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -5621,6 +5623,14 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - status.gatekeeper.sh
+  resources:
+  - constrainttemplatepodstatuses/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - externaldata.gatekeeper.sh
   resources:

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -504,7 +504,7 @@ func (r *ReconcileConstraintTemplate) persistPodStatus(ctx context.Context, stat
 	if apiequality.Semantic.DeepEqual(status.Status, *oldStatus) {
 		return nil
 	}
-	return r.Update(ctx, status)
+	return r.Status().Update(ctx, status)
 }
 
 func (r *ReconcileConstraintTemplate) handleUpdate(
@@ -653,6 +653,10 @@ func (r *ReconcileConstraintTemplate) getOrCreatePodStatus(ctx context.Context, 
 		return nil, err
 	}
 	if err := r.Create(ctx, statusObj); err != nil {
+		return nil, err
+	}
+	// With a status subresource, Create does not persist .status; write it explicitly.
+	if err := r.Status().Update(ctx, statusObj); err != nil {
 		return nil, err
 	}
 	return statusObj, nil

--- a/pkg/controller/constrainttemplate/podstatus_subresource_test.go
+++ b/pkg/controller/constrainttemplate/podstatus_subresource_test.go
@@ -1,0 +1,100 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constrainttemplate
+
+import (
+	"context"
+	"testing"
+
+	statusv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
+	"github.com/open-policy-agent/gatekeeper/v3/test/testutils"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestGetOrCreatePodStatus_PersistsInitialStatus(t *testing.T) {
+	ctx := t.Context()
+	testutils.Setenv(t, "POD_NAME", "no-pod")
+
+	mgr, _ := testutils.SetupManager(t, cfg)
+	require.NoError(t, testutils.CreateGatekeeperNamespace(mgr.GetConfig()))
+
+	c, err := client.New(cfg, client.Options{Scheme: mgr.GetScheme()})
+	require.NoError(t, err)
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
+	require.NoError(t, c.Create(ctx, pod))
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, pod))
+
+	r := &ReconcileConstraintTemplate{
+		Client: c,
+		scheme: mgr.GetScheme(),
+		getPod: func(context.Context) (*corev1.Pod, error) { return pod, nil },
+	}
+
+	const ctName = "persist-initial-status"
+	status, err := r.getOrCreatePodStatus(ctx, ctName)
+	require.NoError(t, err)
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, status))
+
+	require.Equal(t, "no-pod", status.Status.ID)
+	require.Equal(t, operations.AssignedStringList(), status.Status.Operations)
+
+	// Re-read from the API as a later reconcile would after the create path returns early.
+	stored := &statusv1beta1.ConstraintTemplatePodStatus{}
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(status), stored))
+	require.Equal(t, "no-pod", stored.Status.ID, "status subresource must persist ID after Create")
+	require.Equal(t, operations.AssignedStringList(), stored.Status.Operations, "status subresource must persist Operations after Create")
+}
+
+func TestGetOrCreatePodStatus_ReturnsPersistedStatus(t *testing.T) {
+	ctx := t.Context()
+	testutils.Setenv(t, "POD_NAME", "no-pod")
+
+	mgr, _ := testutils.SetupManager(t, cfg)
+	require.NoError(t, testutils.CreateGatekeeperNamespace(mgr.GetConfig()))
+
+	c, err := client.New(cfg, client.Options{Scheme: mgr.GetScheme()})
+	require.NoError(t, err)
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
+	require.NoError(t, c.Create(ctx, pod))
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, pod))
+
+	r := &ReconcileConstraintTemplate{
+		Client: c,
+		scheme: mgr.GetScheme(),
+		getPod: func(context.Context) (*corev1.Pod, error) { return pod, nil },
+	}
+
+	const ctName = "return-persisted-status"
+	created, err := r.getOrCreatePodStatus(ctx, ctName)
+	require.NoError(t, err)
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, created))
+
+	fetched, err := r.getOrCreatePodStatus(ctx, ctName)
+	require.NoError(t, err)
+	require.Equal(t, created.Name, fetched.Name)
+	require.Equal(t, "no-pod", fetched.Status.ID)
+	require.Equal(t, operations.AssignedStringList(), fetched.Status.Operations)
+}

--- a/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
+++ b/pkg/controller/constrainttemplatestatus/constrainttemplatestatus_controller_test.go
@@ -189,6 +189,10 @@ violation[{"msg": "denied!"}] {
 		if err != nil {
 			t.Fatal(err)
 		}
+		err = c.Status().Update(ctx, fakeTStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
 		g.Eventually(verifyTStatusCreated(ctx, c, true), timeout).Should(gomega.BeNil())
 		g.Eventually(verifyTByPodStatusCount(ctx, c, 2), timeout).Should(gomega.BeNil())
 		err = c.Delete(ctx, fakeTStatus)
@@ -214,6 +218,10 @@ violation[{"msg": "denied!"}] {
 		t.Cleanup(testutils.DeleteObject(t, c, fakeTStatus))
 
 		err = c.Create(ctx, fakeTStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = c.Status().Update(ctx, fakeTStatus)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -306,6 +314,10 @@ violation[{"msg": "denied!"}] {
 		}
 		fakeTStatus.Status.TemplateUID = templateCpy.UID
 		err = c.Create(ctx, fakeTStatus)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = c.Status().Update(ctx, fakeTStatus)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/bats/tests/remote-cluster/gatekeeper-remote-cluster-deployment.yaml
+++ b/test/bats/tests/remote-cluster/gatekeeper-remote-cluster-deployment.yaml
@@ -16,6 +16,9 @@ rules:
 - apiGroups: ["status.gatekeeper.sh"]
   resources: ["*"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: ["status.gatekeeper.sh"]
+  resources: ["constrainttemplatepodstatuses/status"]
+  verbs: ["get", "patch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds `+kubebuilder:subresource:status` to `ConstraintTemplatePodStatus` and updates CRD/manifests in `config/crd/bases` and `manifest_staging` only.
- Switches the ConstraintTemplate reconciler to write pod status via `Status().Update` instead of full-object `Update`.
- Persists initial pod status (`ID`, `Operations`) with a follow-up `Status().Update` after `Create`, since the apiserver strips `.status` on create once the subresource is enabled.
- Grants the manager ClusterRole explicit `patch`/`update` on `constrainttemplatepodstatuses/status` (in `config/rbac` and `manifest_staging` only).
- Adds envtest integration tests (`podstatus_subresource_test.go`) verifying initial status persists after create and is returned on subsequent `getOrCreatePodStatus` calls.

Separate from #4596: this changes the write API path to the conventional status subresource. It does not address stale informer cache conflicts on its own; that still needs the retry/refetch logic in #4596.

**Which issue(s) this PR fixes**:

Related to #4595

**Special notes for your reviewer**:

- CRD change is additive (`subresources.status: {}`); existing stored objects are unchanged.
- Root `deploy/` and `charts/` are not edited; those are promoted from `manifest_staging` at release time. Helm installs from the root `charts/` directory pick up the CRD/RBAC subresource changes at the next release promotion.
- After both PRs land, #4596's retry helper should use `Status().Update` instead of `Update`.