### PR TITLE
chore: bump controller-gen from v0.19.0 to v0.21.0

### DIFF
--- a/build/tooling/Dockerfile
+++ b/build/tooling/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.26-trixie@sha256:4ee9ffa999b4583ce281939cdff828763083610292f252279a0cee77473bd9a7
 
-RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.19.0
+RUN GO111MODULE=on go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.21.0
 RUN GO111MODULE=on go install k8s.io/code-generator/cmd/conversion-gen@v0.29.3
 
 RUN mkdir /gatekeeper

--- a/config/crd/bases/_assignimages.yaml
+++ b/config/crd/bases/_assignimages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: assignimages.
 spec:
   group: ""

--- a/config/crd/bases/_assignmetadata.yaml
+++ b/config/crd/bases/_assignmetadata.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: assignmetadata.
 spec:
   group: ""

--- a/config/crd/bases/_assigns.yaml
+++ b/config/crd/bases/_assigns.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: assigns.
 spec:
   group: ""

--- a/config/crd/bases/_expansiontemplate.yaml
+++ b/config/crd/bases/_expansiontemplate.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: expansiontemplate.
 spec:
   group: ""

--- a/config/crd/bases/_modifysets.yaml
+++ b/config/crd/bases/_modifysets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: modifysets.
 spec:
   group: ""

--- a/config/crd/bases/config.gatekeeper.sh_configs.yaml
+++ b/config/crd/bases/config.gatekeeper.sh_configs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: configs.config.gatekeeper.sh
 spec:
   group: config.gatekeeper.sh

--- a/config/crd/bases/connection.gatekeeper.sh_connections.yaml
+++ b/config/crd/bases/connection.gatekeeper.sh_connections.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: connections.connection.gatekeeper.sh
 spec:
   group: connection.gatekeeper.sh

--- a/config/crd/bases/expansion.gatekeeper.sh_expansiontemplate.yaml
+++ b/config/crd/bases/expansion.gatekeeper.sh_expansiontemplate.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: expansiontemplate.expansion.gatekeeper.sh
 spec:
   group: expansion.gatekeeper.sh

--- a/config/crd/bases/gvkmanifest.gatekeeper.sh_gvkmanifests.yaml
+++ b/config/crd/bases/gvkmanifest.gatekeeper.sh_gvkmanifests.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: gvkmanifests.gvkmanifest.gatekeeper.sh
 spec:
   group: gvkmanifest.gatekeeper.sh

--- a/config/crd/bases/match.gatekeeper.sh_matchcrd.yaml
+++ b/config/crd/bases/match.gatekeeper.sh_matchcrd.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: matchcrd.match.gatekeeper.sh
 spec:
   group: match.gatekeeper.sh

--- a/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assign.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: assign.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh

--- a/config/crd/bases/mutations.gatekeeper.sh_assignimage.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignimage.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: assignimage.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh

--- a/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_assignmetadata.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: assignmetadata.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh

--- a/config/crd/bases/mutations.gatekeeper.sh_modifyset.yaml
+++ b/config/crd/bases/mutations.gatekeeper.sh_modifyset.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: modifyset.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_configpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_configpodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: configpodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_connectionpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_connectionpodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: connectionpodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_constraintpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_constraintpodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: constraintpodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_constrainttemplatepodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_constrainttemplatepodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: constrainttemplatepodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_expansiontemplatepodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_expansiontemplatepodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: expansiontemplatepodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_mutatorpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_mutatorpodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: mutatorpodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/status.gatekeeper.sh_providerpodstatuses.yaml
+++ b/config/crd/bases/status.gatekeeper.sh_providerpodstatuses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: providerpodstatuses.status.gatekeeper.sh
 spec:
   group: status.gatekeeper.sh

--- a/config/crd/bases/syncset.gatekeeper.sh_syncsets.yaml
+++ b/config/crd/bases/syncset.gatekeeper.sh_syncsets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: syncsets.syncset.gatekeeper.sh
 spec:
   group: syncset.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assign.mutations.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignimage-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignimage.mutations.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignmetadata.mutations.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/config-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/config-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: configs.config.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/configpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/configpodstatus-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: configpodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/connection-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/connection-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: connections.connection.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/connectionpodstatus-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: connectionpodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constraintpodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplatepodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/expansiontemplate-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplate.expansion.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/expansiontemplatepodstatus-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplatepodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/modifyset-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: modifyset.mutations.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: mutatorpodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/providerpodstatus-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: providerpodstatuses.status.gatekeeper.sh

--- a/manifest_staging/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
+++ b/manifest_staging/charts/gatekeeper/crds/syncset-customresourcedefinition.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: syncsets.syncset.gatekeeper.sh

--- a/manifest_staging/deploy/gatekeeper.yaml
+++ b/manifest_staging/deploy/gatekeeper.yaml
@@ -34,7 +34,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assign.mutations.gatekeeper.sh
@@ -1211,7 +1211,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignimage.mutations.gatekeeper.sh
@@ -1579,7 +1579,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: assignmetadata.mutations.gatekeeper.sh
@@ -2549,7 +2549,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: configpodstatuses.status.gatekeeper.sh
@@ -2620,7 +2620,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: configs.config.gatekeeper.sh
@@ -2774,7 +2774,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: connectionpodstatuses.status.gatekeeper.sh
@@ -2855,7 +2855,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: connections.connection.gatekeeper.sh
@@ -2957,7 +2957,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constraintpodstatuses.status.gatekeeper.sh
@@ -3057,7 +3057,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: constrainttemplatepodstatuses.status.gatekeeper.sh
@@ -3624,7 +3624,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplate.expansion.gatekeeper.sh
@@ -3880,7 +3880,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: expansiontemplatepodstatuses.status.gatekeeper.sh
@@ -3957,7 +3957,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: modifyset.mutations.gatekeeper.sh
@@ -5029,7 +5029,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: mutatorpodstatuses.status.gatekeeper.sh
@@ -5109,7 +5109,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: providerpodstatuses.status.gatekeeper.sh
@@ -5422,7 +5422,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   labels:
     gatekeeper.sh/system: "yes"
   name: syncsets.syncset.gatekeeper.sh

--- a/pkg/target/matchcrd_constant.go
+++ b/pkg/target/matchcrd_constant.go
@@ -9,7 +9,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: matchcrd.match.gatekeeper.sh
 spec:
   group: match.gatekeeper.sh


### PR DESCRIPTION
Bumps controller-gen from v0.19.0 to v0.21.0 in the tooling image and regenerates the CRDs and staged manifests.

The only change in the generated output is the `controller-gen.kubebuilder.io/version` annotation. The CRD schemas themselves are unchanged, so this is a low-risk refresh that keeps the generator current.

Tested with `make manifests` and `make generate` (tooling image rebuilt with the new version); the regenerated files match what is committed here, and `go build ./pkg/target/...` passes.

Part of #4082, one tool per PR as discussed.
