### PR TITLE
chore: bump bats from 1.13.0 to 1.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ KIND_CLUSTER_FILE ?= ""
 # note: k8s version pinned since KIND image availability lags k8s releases
 KUBERNETES_VERSION ?= 1.33.0
 KUSTOMIZE_VERSION ?= 5.8.1
-BATS_VERSION ?= 1.13.0
+BATS_VERSION ?= 1.14.0
 ORAS_VERSION ?= 1.3.2
 BATS_TESTS_FILE ?= test/bats/test.bats
 HELM_VERSION ?= 3.17.4


### PR DESCRIPTION
Bumps bats-core from 1.13.0 to 1.14.0 in the test image.

1.14.0 is the latest release of the bats test framework used by the e2e suite. The install method in the test image is unchanged, it just pulls the new tag.

Tested by rebuilding the test image (`make __test-image`) with the new version and confirming bats reports 1.14.0.

Part of #4082, one tool per PR.
