### PR TITLE
fix: skip mutation system construction when no mutation operation is assigned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,14 +196,14 @@ all: lint test manager
 native-test: envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	GO111MODULE=on \
-	go test ./pkg/... ./apis/... ./cmd/gator/... -coverprofile cover.out
+	go test . ./pkg/... ./apis/... ./cmd/gator/... -coverprofile cover.out
 
 # Run tests with race detector
 .PHONY: native-race-test
 native-race-test: envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(KUBERNETES_VERSION) --bin-dir $(LOCALBIN) -p path)" \
 	GO111MODULE=on \
-	go test ./pkg/... ./apis/... ./cmd/gator/... -race -timeout 20m
+	go test . ./pkg/... ./apis/... ./cmd/gator/... -race -timeout 20m
 
 # Run benchmarks only (no unit tests)
 .PHONY: native-bench-test

--- a/main.go
+++ b/main.go
@@ -510,7 +510,10 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		}
 	}
 
-	mutationSystem := mutation.NewSystem(mutationOpts)
+	var mutationSystem *mutation.System
+	if mutation.Enabled() {
+		mutationSystem = mutation.NewSystem(mutationOpts)
+	}
 	expansionSystem := expansion.NewSystem(mutationSystem)
 	exportSystem := export.NewSystem()
 

--- a/main.go
+++ b/main.go
@@ -416,6 +416,18 @@ blockingLoop:
 	return 0
 }
 
+// newMutationSystem returns a *mutation.System built from opts, or nil when no
+// mutation operation (mutation-webhook, mutation-controller, mutation-status) is
+// assigned to this pod. expansion.NewSystem already treats a nil mutation system
+// as "skip mutation" (see pkg/expansion/system.go), so callers can pass the result
+// straight through without an additional nil check.
+func newMutationSystem(opts mutation.SystemOpts) *mutation.System {
+	if !mutation.Enabled() {
+		return nil
+	}
+	return mutation.NewSystem(opts)
+}
+
 func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.Tracker, setupFinished chan struct{}) error {
 	// Block until the setup (certificate generation) finishes.
 	<-setupFinished
@@ -510,10 +522,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		}
 	}
 
-	var mutationSystem *mutation.System
-	if mutation.Enabled() {
-		mutationSystem = mutation.NewSystem(mutationOpts)
-	}
+	mutationSystem := newMutationSystem(mutationOpts)
 	expansionSystem := expansion.NewSystem(mutationSystem)
 	exportSystem := export.NewSystem()
 

--- a/main_test.go
+++ b/main_test.go
@@ -26,7 +26,7 @@ const gatekeeperMainTestOperationEnvVar = "GATEKEEPER_MAIN_TEST_OPERATION"
 func runNewMutationSystemInSubprocess(t *testing.T, testName, op string) (string, error) {
 	t.Helper()
 
-	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$")
+	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$") //nolint:gosec // os.Args[0] is the current test binary; testName is always a compile-time string literal passed by the callers below
 	cmd.Env = append(os.Environ(),
 		gatekeeperMainSubprocessEnvVar+"=1",
 		gatekeeperMainTestOperationEnvVar+"="+op,

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
+)
+
+// gatekeeperMainSubprocessEnvVar marks a re-exec'd child process that actually
+// calls newMutationSystem. pkg/operations only allows the process-wide
+// "operation" flag to be narrowed once (subsequent Set calls add to the
+// existing set rather than replacing it), so each of the tests below runs its
+// assertion in a fresh subprocess instead of sharing that global state, the
+// same isolation approach used in
+// pkg/controller/mutators/instances/mutator_controllers_test.go.
+const gatekeeperMainSubprocessEnvVar = "GATEKEEPER_MAIN_SUBPROCESS"
+
+// gatekeeperMainTestOperationEnvVar carries the desired --operation value into
+// the subprocess.
+const gatekeeperMainTestOperationEnvVar = "GATEKEEPER_MAIN_TEST_OPERATION"
+
+func runNewMutationSystemInSubprocess(t *testing.T, testName, op string) (string, error) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$")
+	cmd.Env = append(os.Environ(),
+		gatekeeperMainSubprocessEnvVar+"=1",
+		gatekeeperMainTestOperationEnvVar+"="+op,
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// TestNewMutationSystemDisabledWhenNoMutationOperation guards against
+// setupControllers unconditionally constructing a *mutation.System: when only
+// a non-mutation operation (e.g. audit) is assigned, newMutationSystem must
+// return nil.
+func TestNewMutationSystemDisabledWhenNoMutationOperation(t *testing.T) {
+	if os.Getenv(gatekeeperMainSubprocessEnvVar) == "1" {
+		op := os.Getenv(gatekeeperMainTestOperationEnvVar)
+		if err := flag.CommandLine.Set("operation", op); err != nil {
+			t.Fatalf("setting operation flag to %q: %v", op, err)
+		}
+
+		if got := newMutationSystem(mutation.SystemOpts{}); got != nil {
+			t.Fatalf("newMutationSystem() = %v, want nil for operation %q", got, op)
+		}
+		return
+	}
+
+	out, err := runNewMutationSystemInSubprocess(t, "TestNewMutationSystemDisabledWhenNoMutationOperation", string(operations.Audit))
+	if err != nil {
+		t.Fatalf("audit-only subprocess failed: %v\n%s", err, out)
+	}
+}
+
+// TestNewMutationSystemEnabledWhenMutationOperationAssigned is the mutation-only
+// counterpart: when a mutation operation is assigned, newMutationSystem must
+// return a non-nil *mutation.System.
+func TestNewMutationSystemEnabledWhenMutationOperationAssigned(t *testing.T) {
+	if os.Getenv(gatekeeperMainSubprocessEnvVar) == "1" {
+		op := os.Getenv(gatekeeperMainTestOperationEnvVar)
+		if err := flag.CommandLine.Set("operation", op); err != nil {
+			t.Fatalf("setting operation flag to %q: %v", op, err)
+		}
+
+		if got := newMutationSystem(mutation.SystemOpts{}); got == nil {
+			t.Fatalf("newMutationSystem() = nil, want non-nil for operation %q", op)
+		}
+		return
+	}
+
+	out, err := runNewMutationSystemInSubprocess(t, "TestNewMutationSystemEnabledWhenMutationOperationAssigned", string(operations.MutationWebhook))
+	if err != nil {
+		t.Fatalf("mutation-webhook-only subprocess failed: %v\n%s", err, out)
+	}
+}

--- a/pkg/controller/mutators/instances/mutator_controllers.go
+++ b/pkg/controller/mutators/instances/mutator_controllers.go
@@ -62,6 +62,10 @@ func routeConflictEvents(ctx context.Context, events <-chan event.GenericEvent, 
 
 // Add creates all mutation controllers and adds them to the manager.
 func (a *Adder) Add(mgr manager.Manager) error {
+	if !mutation.Enabled() {
+		return nil
+	}
+
 	// events is shared across all mutators that can affect the implied schema
 	// of kinds to be mutated, since these mutators can set each other into conflict
 	events := make(chan event.GenericEvent, eventQueueSize)

--- a/pkg/controller/mutators/instances/mutator_controllers_test.go
+++ b/pkg/controller/mutators/instances/mutator_controllers_test.go
@@ -2,13 +2,40 @@ package instances
 
 import (
 	"context"
+	"flag"
 	"testing"
 	"time"
 
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
+
+// TestAddSkipsRegistrationWhenMutationDisabled guards against unconditionally
+// registering the conflict-routing runnable (and the mutator controllers behind
+// it) for pods that have no mutation operation assigned. Before this guard,
+// Add dereferenced the manager (e.g. mgr.GetScheme()) before ever consulting
+// mutation.Enabled(), so passing a nil manager panics unless the early return
+// below is in place.
+//
+// This test narrows the process-wide "operation" flag to audit-only and
+// deliberately does not restore it afterward: opSet.Set (pkg/operations)
+// only resets the assigned-operation set on the very first call in the
+// process and merely adds to it on every call thereafter, so widening back
+// to "all operations" here would make the flag permanently un-narrowable and
+// break this test under repeated runs (e.g. `go test -count=2`). No other
+// test in this package depends on the default operation set.
+func TestAddSkipsRegistrationWhenMutationDisabled(t *testing.T) {
+	if err := flag.CommandLine.Set("operation", string(operations.Audit)); err != nil {
+		t.Fatalf("setting operation flag: %v", err)
+	}
+
+	a := &Adder{}
+	if err := a.Add(nil); err != nil {
+		t.Fatalf("Add returned error: %v", err)
+	}
+}
 
 func TestRouteConflictEventsRoutesByKind(t *testing.T) {
 	t.Parallel()

--- a/pkg/controller/mutators/instances/mutator_controllers_test.go
+++ b/pkg/controller/mutators/instances/mutator_controllers_test.go
@@ -30,7 +30,7 @@ const gatekeeperTestOperationEnvVar = "GATEKEEPER_TEST_OPERATION"
 func runAddInSubprocess(t *testing.T, testName, op string) (string, error) {
 	t.Helper()
 
-	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$")
+	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$") //nolint:gosec // os.Args[0] is the current test binary; testName is always a compile-time string literal passed by the callers below
 	cmd.Env = append(os.Environ(),
 		gatekeeperInstancesAdderSubprocessEnvVar+"=1",
 		gatekeeperTestOperationEnvVar+"="+op,

--- a/pkg/controller/mutators/instances/mutator_controllers_test.go
+++ b/pkg/controller/mutators/instances/mutator_controllers_test.go
@@ -3,6 +3,8 @@ package instances
 import (
 	"context"
 	"flag"
+	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -12,28 +14,87 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
+// gatekeeperInstancesAdderSubprocessEnvVar marks a re-exec'd child process that
+// actually calls Adder.Add. pkg/operations only allows the process-wide
+// "operation" flag to be narrowed once (subsequent Set calls add to the
+// existing set rather than replacing it), so TestAddSkipsRegistrationWhenMutationDisabled
+// and TestAddProceedsWhenMutationEnabled each run their assertion in a fresh
+// subprocess instead of sharing that global state.
+const gatekeeperInstancesAdderSubprocessEnvVar = "GATEKEEPER_INSTANCES_ADDER_SUBPROCESS"
+
+// gatekeeperTestOperationEnvVar carries the desired --operation value into the subprocess.
+const gatekeeperTestOperationEnvVar = "GATEKEEPER_TEST_OPERATION"
+
+// runAddInSubprocess re-execs the current test binary, running only testName with
+// the "operation" flag set to op before Add is called.
+func runAddInSubprocess(t *testing.T, testName, op string) (string, error) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^"+testName+"$")
+	cmd.Env = append(os.Environ(),
+		gatekeeperInstancesAdderSubprocessEnvVar+"=1",
+		gatekeeperTestOperationEnvVar+"="+op,
+	)
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+func setOperationFromEnv(t *testing.T) {
+	t.Helper()
+
+	op := os.Getenv(gatekeeperTestOperationEnvVar)
+	if err := flag.CommandLine.Set("operation", op); err != nil {
+		t.Fatalf("setting operation flag to %q: %v", op, err)
+	}
+}
+
 // TestAddSkipsRegistrationWhenMutationDisabled guards against unconditionally
 // registering the conflict-routing runnable (and the mutator controllers behind
 // it) for pods that have no mutation operation assigned. Before this guard,
 // Add dereferenced the manager (e.g. mgr.GetScheme()) before ever consulting
 // mutation.Enabled(), so passing a nil manager panics unless the early return
 // below is in place.
-//
-// This test narrows the process-wide "operation" flag to audit-only and
-// deliberately does not restore it afterward: opSet.Set (pkg/operations)
-// only resets the assigned-operation set on the very first call in the
-// process and merely adds to it on every call thereafter, so widening back
-// to "all operations" here would make the flag permanently un-narrowable and
-// break this test under repeated runs (e.g. `go test -count=2`). No other
-// test in this package depends on the default operation set.
 func TestAddSkipsRegistrationWhenMutationDisabled(t *testing.T) {
-	if err := flag.CommandLine.Set("operation", string(operations.Audit)); err != nil {
-		t.Fatalf("setting operation flag: %v", err)
+	if os.Getenv(gatekeeperInstancesAdderSubprocessEnvVar) == "1" {
+		setOperationFromEnv(t)
+
+		a := &Adder{}
+		if err := a.Add(nil); err != nil {
+			t.Fatalf("Add returned error: %v", err)
+		}
+		return
 	}
 
-	a := &Adder{}
-	if err := a.Add(nil); err != nil {
-		t.Fatalf("Add returned error: %v", err)
+	out, err := runAddInSubprocess(t, "TestAddSkipsRegistrationWhenMutationDisabled", string(operations.Audit))
+	if err != nil {
+		t.Fatalf("audit-only Add(nil) should return nil without touching the manager: %v\n%s", err, out)
+	}
+}
+
+// TestAddProceedsWhenMutationEnabled is the mutation-only counterpart to
+// TestAddSkipsRegistrationWhenMutationDisabled: it verifies Add does not take the
+// early-return path when a mutation operation is assigned. It can't exercise full
+// controller registration without a real manager, so it instead confirms Add moves
+// past the mutation.Enabled() guard by asserting it panics on mgr.GetScheme()
+// against the nil manager, the same signal the pre-fix code panicked on unconditionally.
+func TestAddProceedsWhenMutationEnabled(t *testing.T) {
+	if os.Getenv(gatekeeperInstancesAdderSubprocessEnvVar) == "1" {
+		setOperationFromEnv(t)
+
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("Add(nil) returned without touching the manager; expected it to proceed past the mutation.Enabled() guard and panic dereferencing the nil manager")
+			}
+		}()
+
+		a := &Adder{}
+		_ = a.Add(nil)
+		return
+	}
+
+	out, err := runAddInSubprocess(t, "TestAddProceedsWhenMutationEnabled", string(operations.MutationWebhook))
+	if err != nil {
+		t.Fatalf("mutation-webhook-only Add(nil) subprocess failed: %v\n%s", err, out)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Gatekeeper unconditionally constructs a `mutation.System` in `setupControllers` and unconditionally creates the mutator conflict-routing channels plus registers the `routeConflictEvents` runnable in `pkg/controller/mutators/instances.Adder.Add`, even for pods where no mutation operation (`mutation-webhook`, `mutation-controller`, `mutation-status`) is assigned (e.g. `--operation=audit` or `--operation=generate` only). That means a status-only, audit-only, or generate-only process still pays for an unused mutation system and an unused runnable/goroutine.

This PR gates both of those on the existing `mutation.Enabled()` single source of truth (already used by `pkg/controller/mutators/core.Adder.add`), so:
- `mutationSystem` in `main.go` stays `nil` unless a mutation operation is assigned. `expansion.NewSystem` already supports a `nil` mutation system (see `pkg/expansion/system.go`, `s.mutationSystem == nil` short-circuits `expand`), so expansion of generated resources continues to work unchanged: it applies mutators when a mutation operation is present, and simply skips mutation when one isn't.
- `instances.Adder.Add` now returns immediately when `mutation.Enabled()` is false, before creating the conflict-routing channels or registering `routeConflictEvents` with the manager.

This is a minimal, surgical subset of the full scope described in the issue (it does not additionally restructure how the external-data provider cache / client cert watcher options are wired into `mutationOpts`, since those are simply unused when `mutation.NewSystem` is never called — no behavior change needed there).

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:

I traced every consumer of `MutationSystem`/`mutationSystem` that could now receive `nil`:
- `pkg/webhook/mutation.go` `AddMutatingWebhook` already returns early unless `operations.IsAssigned(operations.MutationWebhook)` is true, before touching `deps.MutationSystem`.
- `pkg/webhook/policy.go` stores a `mutationSystem` field but never dereferences it.
- `pkg/controller/mutators/core/adder.go` `(*Adder).add` already guarded on `mutation.Enabled()` before this change (pre-existing).
- `pkg/controller/controller.go`'s `MutationSystemInjector` interface is implemented only by `instances.Adder`, which now guards on `mutation.Enabled()` itself, per this diff.
- `pkg/expansion/system.go` already nil-checks `s.mutationSystem` before calling `Mutate`.

So there is no remaining path where a `nil` `*mutation.System` gets dereferenced.

**Validation**: `go build ./...`, `go vet ./...`, and `golangci-lint run ./pkg/controller/mutators/instances/... .` (locally installed golangci-lint v2.12.2; repo pins v2.9.0 via Docker in `make lint`, which I could not run here because Docker wasn't available in this environment — the local binary run against the same config found 0 issues on both the changed packages and the whole repo) are all clean. I added a targeted unit test, `TestAddSkipsRegistrationWhenMutationDisabled`, that narrows the process `--operation` flag to `audit` and calls `(&Adder{}).Add(nil)`; it fails with a nil-pointer panic on `mgr.GetScheme()` against the pre-fix code and passes against the fix (verified both ways, including repeated runs with `-count=5` and `-race -count=3` to confirm the flag-mutating test itself is stable). I also ran the full existing suites for the directly affected packages with envtest: `go test ./pkg/controller/mutators/... ./pkg/webhook/... ./pkg/expansion/...` (KUBEBUILDER_ASSETS via `setup-envtest`) and the broader `go test ./pkg/controller/...` — all pass. I could not run the full `make native-test`/`make native-race-test` targets across the entire repo (`./pkg/... ./apis/... ./cmd/gator/...`) or any live e2e/dev-stack scenario in this environment; I believe this change is safe based on the nil-safety trace above plus the passing targeted and package-level tests.

Fixes #4772