### PR TITLE
Harden admission violation export: Dapr guard, recovery, and docs

### DIFF
--- a/pkg/export/dapr/dapr.go
+++ b/pkg/export/dapr/dapr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	daprClient "github.com/dapr/go-sdk/client"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/export/util"
 )
 
 type Connection struct {
@@ -29,6 +30,15 @@ var Connections = &Dapr{
 }
 
 func (r *Dapr) Publish(_ context.Context, connectionName string, data interface{}, topic string) error {
+	// Admission violation export is an alpha feature that relies on the durable,
+	// bounded on-disk spool implemented only by the disk driver (record-size
+	// limits, rotation, retention, and crash recovery). The Dapr driver provides
+	// none of those guarantees, so reject admission violations here to fail fast
+	// instead of silently publishing them over the message bus.
+	if isAdmissionViolation(data) {
+		return fmt.Errorf("admission violation export is not supported by the Dapr driver; set the export backend to disk")
+	}
+
 	jsonData, err := json.Marshal(data)
 	if err != nil {
 		return fmt.Errorf("error marshaling data: %w", err)
@@ -44,6 +54,26 @@ func (r *Dapr) Publish(_ context.Context, connectionName string, data interface{
 	}
 
 	return nil
+}
+
+// isAdmissionViolation reports whether data is an admission violation export
+// message. It mirrors the message shapes accepted by the disk driver so the
+// guard holds regardless of how the caller passes the payload.
+func isAdmissionViolation(data interface{}) bool {
+	switch value := data.(type) {
+	case util.ExportMsg:
+		return value.EventType == util.AdmissionViolationEventType
+	case *util.ExportMsg:
+		return value != nil && value.EventType == util.AdmissionViolationEventType
+	case json.RawMessage:
+		var msg util.ExportMsg
+		if err := json.Unmarshal(value, &msg); err != nil {
+			return false
+		}
+		return msg.EventType == util.AdmissionViolationEventType
+	default:
+		return false
+	}
 }
 
 func (r *Dapr) CloseConnection(connectionName string) error {

--- a/pkg/export/dapr/dapr_test.go
+++ b/pkg/export/dapr/dapr_test.go
@@ -2,10 +2,12 @@ package dapr
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/export/driver"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/export/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -103,6 +105,52 @@ func TestDapr_Publish(t *testing.T) {
 				connectionName: "test",
 			},
 			wantErr: true,
+		},
+		{
+			name: "admission violation is rejected",
+			args: args{
+				ctx: ctx,
+				data: util.ExportMsg{
+					EventType: util.AdmissionViolationEventType,
+				},
+				topic:          "test",
+				connectionName: "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "admission violation pointer is rejected",
+			args: args{
+				ctx: ctx,
+				data: &util.ExportMsg{
+					EventType: util.AdmissionViolationEventType,
+				},
+				topic:          "test",
+				connectionName: "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "admission violation raw message is rejected",
+			args: args{
+				ctx:            ctx,
+				data:           json.RawMessage(`{"eventType":"` + util.AdmissionViolationEventType + `"}`),
+				topic:          "test",
+				connectionName: "test",
+			},
+			wantErr: true,
+		},
+		{
+			name: "audit violation is published",
+			args: args{
+				ctx: ctx,
+				data: util.ExportMsg{
+					EventType: "violation_audited",
+				},
+				topic:          "test",
+				connectionName: "test",
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/export/disk/admission_file.go
+++ b/pkg/export/disk/admission_file.go
@@ -1,6 +1,7 @@
 package disk
 
 import (
+	"bytes"
 	"container/heap"
 	"context"
 	"crypto/rand"
@@ -1014,7 +1015,7 @@ func recoverAdmissionOpenFile(path string, maxBytes int64) error {
 		return err
 	}
 	limit := info.Size()
-	if limit > maxBytes {
+	if maxBytes > 0 && limit > maxBytes {
 		limit = maxBytes
 		if err := file.Truncate(limit); err != nil {
 			return err
@@ -1041,8 +1042,39 @@ func recoverAdmissionOpenFile(path string, maxBytes int64) error {
 	if err := unlockAndClose(); err != nil {
 		return err
 	}
-	readyPath := strings.TrimSuffix(path, admissionOpenExtension) + ".recovered" + admissionReadyExtension
+	readyPath, err := recoveredReadyPath(path)
+	if err != nil {
+		return err
+	}
 	return os.Rename(path, readyPath)
+}
+
+// recoveredReadyPath returns a ready-file path for a recovered admission segment
+// that does not overwrite an existing file. It prefers the deterministic
+// ".recovered.log" name and, only if that is already taken, appends a short
+// random token so a second recovery of the same base name cannot clobber the
+// first recovered segment before a reader consumes it.
+func recoveredReadyPath(openPath string) (string, error) {
+	base := strings.TrimSuffix(openPath, admissionOpenExtension) + ".recovered"
+	candidate := base + admissionReadyExtension
+	if _, err := os.Lstat(candidate); errors.Is(err, os.ErrNotExist) {
+		return candidate, nil
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return "", err
+	}
+	for i := 0; i < 8; i++ {
+		token := make([]byte, 8)
+		if _, err := rand.Read(token); err != nil {
+			return "", err
+		}
+		candidate = base + "-" + hex.EncodeToString(token) + admissionReadyExtension
+		if _, err := os.Lstat(candidate); errors.Is(err, os.ErrNotExist) {
+			return candidate, nil
+		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return "", err
+		}
+	}
+	return "", fmt.Errorf("unable to allocate a unique recovered ready path for %s", openPath)
 }
 
 func findLastNewline(file *os.File, size int64) (int64, error) {
@@ -1053,10 +1085,11 @@ func findLastNewline(file *os.File, size int64) (int64, error) {
 			start = 0
 		}
 		chunk := buffer[:end-start]
-		if _, err := file.ReadAt(chunk, start); err != nil && !errors.Is(err, io.EOF) {
+		n, err := file.ReadAt(chunk, start)
+		if err != nil && !errors.Is(err, io.EOF) {
 			return -1, err
 		}
-		if index := strings.LastIndexByte(string(chunk), '\n'); index >= 0 {
+		if index := bytes.LastIndexByte(chunk[:n], '\n'); index >= 0 {
 			return start + int64(index), nil
 		}
 		end = start

--- a/pkg/export/disk/admission_file_test.go
+++ b/pkg/export/disk/admission_file_test.go
@@ -1126,3 +1126,103 @@ func TestIndependentWritersUseUniqueAdmissionFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestRecoverAdmissionOpenFileDoesNotClobberExistingRecovered(t *testing.T) {
+	dir := t.TempDir()
+	openPath := filepath.Join(dir, admissionFilePrefix+"crash"+admissionOpenExtension)
+	if err := os.WriteFile(openPath, []byte(completeAdmissionRecord+"{\"partial\":"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	existing := strings.TrimSuffix(openPath, admissionOpenExtension) + ".recovered" + admissionReadyExtension
+	priorContent := "{\"prior\":true}\n"
+	if err := os.WriteFile(existing, []byte(priorContent), 0o600); err != nil {
+		t.Fatalf("WriteFile(existing) error = %v", err)
+	}
+
+	if err := recoverAdmissionOpenFile(openPath, 4096); err != nil {
+		t.Fatalf("recoverAdmissionOpenFile() error = %v", err)
+	}
+
+	// The pre-existing recovered segment must survive untouched.
+	content, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatalf("ReadFile(existing) error = %v", err)
+	}
+	if string(content) != priorContent {
+		t.Fatalf("existing recovered file was clobbered: %q", content)
+	}
+
+	// The newly recovered complete record must land in a distinct file.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	var recoveredNew string
+	for _, entry := range entries {
+		name := entry.Name()
+		if strings.HasSuffix(name, admissionReadyExtension) && filepath.Join(dir, name) != existing {
+			recoveredNew = filepath.Join(dir, name)
+		}
+	}
+	if recoveredNew == "" {
+		t.Fatal("expected a new recovered file distinct from the existing one")
+	}
+	newContent, err := os.ReadFile(recoveredNew)
+	if err != nil {
+		t.Fatalf("ReadFile(new) error = %v", err)
+	}
+	if string(newContent) != completeAdmissionRecord {
+		t.Fatalf("unexpected new recovered content %q", newContent)
+	}
+	if _, err := os.Stat(openPath); !os.IsNotExist(err) {
+		t.Fatalf("expected open file to be consumed, stat err = %v", err)
+	}
+}
+
+func TestRecoverAdmissionOpenFileNonPositiveMaxBytesKeepsCompleteRecords(t *testing.T) {
+	dir := t.TempDir()
+	openPath := filepath.Join(dir, admissionFilePrefix+"nolimit"+admissionOpenExtension)
+	if err := os.WriteFile(openPath, []byte(completeAdmissionRecord+"{\"partial\":"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	// A zero bound must not collapse the recovery window and delete the file.
+	if err := recoverAdmissionOpenFile(openPath, 0); err != nil {
+		t.Fatalf("recoverAdmissionOpenFile() error = %v", err)
+	}
+
+	recovered := strings.TrimSuffix(openPath, admissionOpenExtension) + ".recovered" + admissionReadyExtension
+	content, err := os.ReadFile(recovered)
+	if err != nil {
+		t.Fatalf("ReadFile(recovered) error = %v", err)
+	}
+	if string(content) != completeAdmissionRecord {
+		t.Fatalf("unexpected recovered content %q", content)
+	}
+}
+
+func TestFindLastNewlineAcrossBufferBoundary(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "records")
+	// One complete record spanning several buffer windows followed by a partial
+	// record with no trailing newline. The boundary is the final newline.
+	firstRecord := strings.Repeat("a", 10000) + "\n"
+	payload := firstRecord + strings.Repeat("b", 5000)
+	if err := os.WriteFile(filePath, []byte(payload), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	file, err := os.Open(filePath)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	defer file.Close()
+
+	got, err := findLastNewline(file, int64(len(payload)))
+	if err != nil {
+		t.Fatalf("findLastNewline() error = %v", err)
+	}
+	want := int64(len(firstRecord) - 1)
+	if got != want {
+		t.Fatalf("findLastNewline() = %d, want %d", got, want)
+	}
+}

--- a/pkg/export/disk/disk.go
+++ b/pkg/export/disk/disk.go
@@ -96,6 +96,11 @@ const (
 	defaultAdmissionFileTTL        = 24 * time.Hour
 	// Keep direct disk publishes under the same complete-record bound enforced
 	// by the webhook queue so they cannot bypass its memory and spool protection.
+	// The bound is applied to the full JSON-encoded record (message, details,
+	// annotations, resource labels, and request identity), not just the violation
+	// message. See defaultAdmissionExportMaxMessageBytes for the full rationale on
+	// why 64 KiB is generous for realistic policies yet still caps the
+	// user-influenced details and label fields that are otherwise unbounded.
 	defaultMaxAdmissionRecordBytes = 64 << 10
 	defaultMinAdmissionFreeBytes   = 16 << 20
 	minAdmissionFileAge            = time.Second

--- a/pkg/webhook/export.go
+++ b/pkg/webhook/export.go
@@ -25,9 +25,26 @@ import (
 const (
 	defaultAdmissionExportQueueSize = 1024
 	defaultAdmissionExportBatchSize = 64
-	// Bound the complete encoded record, not only the violation message. 64 KiB
-	// leaves room for normal policy and request metadata while preventing one
-	// user-influenced result from consuming a disproportionate share of the queue.
+	// defaultAdmissionExportMaxMessageBytes bounds the complete encoded record,
+	// not only the violation message. The limit is measured against the full
+	// JSON-marshaled ExportMsg: the violation message and constraint annotations,
+	// but also details emitted by the policy, every label on the reviewed
+	// resource, and the request identity (user, groups, UID).
+	//
+	// 64 KiB is a good limit because it is generous for realistic policies while
+	// still capping the fields an author or requester can inflate without bound.
+	// A typical violation from community policy libraries encodes to only a few
+	// kilobytes (short messages, empty or tiny details, a handful of
+	// annotations), so 64 KiB leaves roughly an order of magnitude of headroom
+	// for normal policy and request metadata. At the same time the two fields
+	// that are not bounded by any policy catalog -- the policy-provided details
+	// and the reviewed resource's labels -- cannot grow the record without limit:
+	// a single hostile or verbose result is prevented from consuming a
+	// disproportionate share of the in-memory queue and the on-disk spool, which
+	// are themselves bounded (see defaultAdmissionExportMaxQueueBytes and the
+	// disk spool limits). Records above the limit are dropped before enqueue and
+	// reported with drop reason message_too_large rather than silently truncated,
+	// so a torn partial record is never exported.
 	defaultAdmissionExportMaxMessageBytes = 64 * 1024
 	defaultAdmissionExportMaxQueueBytes   = 16 * 1024 * 1024
 	defaultAdmissionExportStatusInterval  = 10 * time.Second

--- a/website/docs/export.md
+++ b/website/docs/export.md
@@ -111,7 +111,7 @@ enableAdmissionViolationExport: true
 exportBackend: disk
 ```
 
-Admission violation export currently supports only the disk driver. The Helm chart rejects `enableAdmissionViolationExport: true` unless `exportBackend: disk`; the Dapr driver is not supported for admission export. The supported configuration routes audit and admission export through the same `Connection`, channel, path, and volume. Admission segment retention and other spool limits are fixed internal defaults while the feature is alpha; `maxAuditResults` continues to apply only to audit results. Additional admission-specific configuration can be added later if operational feedback requires it.
+Admission violation export currently supports only the disk driver; the Dapr driver is not supported for admission export. This is enforced at two layers: the Helm chart rejects `enableAdmissionViolationExport: true` unless `exportBackend: disk`, and the Dapr driver itself rejects admission violation messages at publish time (returning an error surfaced through the webhook export status, logs, and metrics) so the restriction holds even when Gatekeeper is deployed with raw manifests that bypass the chart. The supported configuration routes audit and admission export through the same `Connection`, channel, path, and volume. Admission segment retention and other spool limits are fixed internal defaults while the feature is alpha; `maxAuditResults` continues to apply only to audit results. Additional admission-specific configuration can be added later if operational feedback requires it.
 
 The chart mounts `audit.exportVolume` at `audit.exportVolumeMount.path` in every controller-manager pod when admission export is enabled. The reader sidecar is disabled by default; configure a production reader or explicitly enable the demonstration reader with `admission.disableExportSidecar: false`. Each pod writes its own spool, so multiple webhook replicas and separate audit/webhook deployments do not contend for one file.
 
@@ -156,7 +156,22 @@ Admission export limits are fixed while the feature is alpha and apply independe
 | Disk spool | Maximum completed-segment age | 24 hours |
 | Filesystem | Free-space reserve | 16 MiB |
 
-The 64 KiB record limit applies to the entire JSON object after encoding, not only to the violation message. JSON field names and escaping, policy-provided details, constraint annotations, resource labels, and request identity all count toward the limit. KiB measures bytes, so the number of characters that fit varies with UTF-8 and JSON escaping. The limit leaves room for normal policy and request metadata while preventing one user-influenced result from consuming a disproportionate share of the queue and disk spool. The `kubectl.kubernetes.io/last-applied-configuration` constraint annotation is omitted, but other annotations still count. An oversized record is dropped before enqueue and reported with drop reason `message_too_large`.
+#### Understanding the 64 KiB record limit
+
+The 64 KiB record limit applies to the **entire JSON object after encoding**, not only to the violation message. Every part of the exported record counts toward the limit:
+
+- the violation message,
+- policy-provided `details`,
+- constraint annotations,
+- all labels on the reviewed resource,
+- the request identity (username, UID, and groups),
+- and the JSON structure itself (field names, quotes, and escaping).
+
+Because the limit is measured in bytes, the number of characters that fit depends on encoding. A 64 KiB record holds up to 65,536 bytes: roughly 65,000 plain ASCII characters, about half that for accented Latin or other two-byte UTF-8 text, and fewer still for three-byte (for example, CJK) or four-byte (for example, emoji) characters. Characters that must be JSON-escaped, such as `"`, `\`, and newlines, cost two bytes each.
+
+**Why 64 KiB is a good limit.** It is generous for realistic policies while still capping the fields a policy author or a request submitter can inflate without bound. A typical violation from common policy libraries encodes to only a few kilobytes, because their messages are short, their `details` are usually empty, and they carry a small number of annotations. That leaves roughly an order of magnitude of headroom for normal policy and request metadata. At the same time, the two fields that no policy catalog constrains, the policy-provided `details` and the reviewed resource's labels, cannot grow a record without limit. This keeps any single hostile or unusually verbose result from consuming a disproportionate share of the bounded in-memory queue (16 MiB) and on-disk spool (20 MiB). The `kubectl.kubernetes.io/last-applied-configuration` constraint annotation, which is often large, is omitted from the record, but all other annotations still count.
+
+An oversized record is dropped **before** it enters the queue and is reported with drop reason `message_too_large`; it is never truncated, so a torn partial record is never exported. If your policies legitimately produce large `details` or you review resources with unusually large label sets and you see `message_too_large` drops, reduce the size of the emitted `details` in the policy rather than relying on the record limit to carry them; retain full history in the downstream system instead.
 
 Segment rotation occurs when any byte, record-count, or age limit is reached. The spool limits bound unconsumed backlog; they do not guarantee that records remain available for 24 hours. Cleanup removes the oldest completed segments until the count, byte, and age limits all hold, so count or byte pressure can remove a segment long before its maximum age. When one-minute age rotation is the limiting factor, 20 completed segments provide roughly 20 minutes of backlog; higher volume can rotate segments sooner. A reader must therefore drain segments fast enough for the workload.
 


### PR DESCRIPTION
## Summary

Three focused, independent follow-ups to the webhook/admission violation export feature. Each commit is self-contained, compiles, and carries its own tests; the series bisects cleanly.

### 1. Reject admission violation export on the Dapr driver
Admission violation export relies on the disk driver's durable, bounded on-disk spool (record-size limits, rotation, retention, crash recovery). The Dapr driver provides none of these guarantees. The Helm chart already blocks `enableAdmissionViolationExport` unless `exportBackend: disk`, but raw-manifest deployments bypass that guard. This adds a runtime check in `Dapr.Publish` that rejects admission violation messages (across `ExportMsg`, `*ExportMsg`, and `json.RawMessage` shapes), surfaced through the existing export status, logs, and metrics.

### 2. Harden `recoverAdmissionOpenFile`
- Guard against a non-positive `maxBytes` truncating away complete records.
- Avoid clobbering an existing `.recovered.log` when the same base segment is recovered more than once (deterministic name first, random suffix as fallback).
- Fix `findLastNewline` to scan only the bytes actually read (`bytes.LastIndexByte(chunk[:n])`) instead of the whole buffer converted from a possibly short read.

### 3. Document admission export record and disk limits
Expand the code comments and `website/docs/export.md` to explain what the 64 KiB complete-record limit measures (the full encoded record, including policy `details` and resource labels, not just the message), why it is well chosen, character-capacity guidance, and how it protects the bounded queue and spool. Also notes the new Dapr driver guard.

## Testing
- `go build` / `go vet` on `pkg/export/...` and `pkg/webhook/...`
- `go test -race` for the Dapr publish guard, disk recovery, and webhook export packages
- `gofmt` clean

Docs-only content in commit 3 (aside from the code comments) needs no test.
