### PR TITLE
refactor: separate Config process exclusions from validation data sync

### DIFF
--- a/main.go
+++ b/main.go
@@ -542,41 +542,47 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 	// Setup all Controllers
 	setupLog.Info("setting up controllers")
 
-	// Events ch will be used to receive events from dynamic watches registered
-	// via the registrar below.
-	events := make(chan event.GenericEvent, 1024)
-	reg, err := wm.NewRegistrar(
-		cachemanager.RegistrarName,
-		events)
-	if err != nil {
-		setupLog.Error(err, "unable to set up watch registrar for cache manager")
-		return err
-	}
+	// The cache manager and everything hanging off it only exist for operations
+	// that sync referential data for validation. Other operations read process
+	// exclusions from the Config resource without any of this.
+	var (
+		events chan event.GenericEvent
+		cm     *cachemanager.CacheManager
+	)
+	if operations.NeedsValidationDataSync() {
+		// Events ch will be used to receive events from dynamic watches registered
+		// via the registrar below.
+		events = make(chan event.GenericEvent, 1024)
+		reg, err := wm.NewRegistrar(
+			cachemanager.RegistrarName,
+			events)
+		if err != nil {
+			setupLog.Error(err, "unable to set up watch registrar for cache manager")
+			return err
+		}
 
-	syncMetricsCache := syncutil.NewMetricsCache()
+		cmConfig := &cachemanager.Config{
+			SyncMetricsCache: syncutil.NewMetricsCache(),
+			Tracker:          tracker,
+			ProcessExcluder:  processExcluder,
+			Registrar:        reg,
+			Reader:           mgr.GetCache(),
+		}
 
-	cmConfig := &cachemanager.Config{
-		SyncMetricsCache: syncMetricsCache,
-		Tracker:          tracker,
-		ProcessExcluder:  processExcluder,
-		Registrar:        reg,
-		Reader:           mgr.GetCache(),
-	}
+		if client != nil {
+			cmConfig.CfClient = client
+		}
 
-	if client != nil {
-		cmConfig.CfClient = client
-	}
+		cm, err = cachemanager.NewCacheManager(cmConfig)
+		if err != nil {
+			setupLog.Error(err, "unable to create cache manager")
+			return err
+		}
 
-	cm, err := cachemanager.NewCacheManager(cmConfig)
-	if err != nil {
-		setupLog.Error(err, "unable to create cache manager")
-		return err
-	}
-
-	err = mgr.Add(pruner.NewExpectationsPruner(cm, tracker))
-	if err != nil {
-		setupLog.Error(err, "adding expectations pruner to manager")
-		return err
+		if err := mgr.Add(pruner.NewExpectationsPruner(cm, tracker)); err != nil {
+			setupLog.Error(err, "adding expectations pruner to manager")
+			return err
+		}
 	}
 
 	opts := controller.Dependencies{

--- a/pkg/controller/config/config_capability_test.go
+++ b/pkg/controller/config/config_capability_test.go
@@ -34,26 +34,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// TestAdderSkipsPodsThatDoNotUseConfig pins the registration gate: a pod that
-// neither excludes processes nor syncs data must not build the Config
-// controller, while a pod that does must still fail loudly on a missing
-// dependency.
-func TestAdderSkipsPodsThatDoNotUseConfig(t *testing.T) {
-	mgr, _ := setupManager(t)
+// TestAdderRegistersWithoutDataSync pins that the Config controller is built
+// for operation sets that do not sync validation data - mutation-only pods
+// included, because this reconciler is the only consumer of
+// Config.spec.readiness.statsEnabled - and that a missing dependency still
+// fails setup loudly instead of silently skipping registration.
+func TestAdderRegistersWithoutDataSync(t *testing.T) {
+	for _, op := range []operations.Operation{operations.MutationStatus, operations.MutationWebhook} {
+		t.Run(string(op), func(t *testing.T) {
+			t.Cleanup(operations.AssignForTest(op))
 
-	t.Run("mutation status only", func(t *testing.T) {
-		t.Cleanup(operations.AssignForTest(operations.MutationStatus))
+			mgr, _ := setupManager(t)
+			require.NoError(t, (&Adder{ProcessExcluder: process.New()}).Add(mgr))
 
-		// Neither a cache manager nor a process excluder is set, so building the
-		// reconciler would fail: a nil error proves nothing was registered.
-		require.NoError(t, (&Adder{}).Add(mgr))
-	})
-
-	t.Run("mutation webhook", func(t *testing.T) {
-		t.Cleanup(operations.AssignForTest(operations.MutationWebhook))
-
-		require.Error(t, (&Adder{}).Add(mgr))
-	})
+			// Without a process excluder there is nowhere to put the exclusions
+			// the reconciler parses, so setup has to fail.
+			mgr, _ = setupManager(t)
+			require.Error(t, (&Adder{}).Add(mgr))
+		})
+	}
 }
 
 // TestReconcileWithoutDataSync covers the mutation-webhook-only pod: process

--- a/pkg/controller/config/config_capability_test.go
+++ b/pkg/controller/config/config_capability_test.go
@@ -1,0 +1,126 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"testing"
+
+	configv1alpha1 "github.com/open-policy-agent/gatekeeper/v3/apis/config/v1alpha1"
+	statusv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/wildcard"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// TestAdderSkipsPodsThatDoNotUseConfig pins the registration gate: a pod that
+// neither excludes processes nor syncs data must not build the Config
+// controller, while a pod that does must still fail loudly on a missing
+// dependency.
+func TestAdderSkipsPodsThatDoNotUseConfig(t *testing.T) {
+	mgr, _ := setupManager(t)
+
+	t.Run("mutation status only", func(t *testing.T) {
+		t.Cleanup(operations.AssignForTest(operations.MutationStatus))
+
+		// Neither a cache manager nor a process excluder is set, so building the
+		// reconciler would fail: a nil error proves nothing was registered.
+		require.NoError(t, (&Adder{}).Add(mgr))
+	})
+
+	t.Run("mutation webhook", func(t *testing.T) {
+		t.Cleanup(operations.AssignForTest(operations.MutationWebhook))
+
+		require.Error(t, (&Adder{}).Add(mgr))
+	})
+}
+
+// TestReconcileWithoutDataSync covers the mutation-webhook-only pod: process
+// exclusions from the Config resource still land, with no cache manager and no
+// constraint client behind it.
+func TestReconcileWithoutDataSync(t *testing.T) {
+	t.Cleanup(operations.AssignForTest(operations.MutationWebhook))
+
+	ctx := context.Background()
+	mgr, _ := setupManager(t)
+
+	// Read and write directly: this test drives Reconcile by hand rather than
+	// starting the manager.
+	c, err := client.New(cfg, client.Options{Scheme: mgr.GetScheme()})
+	require.NoError(t, err)
+
+	instance := &configv1alpha1.Config{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "config",
+			Namespace: "gatekeeper-system",
+		},
+		Spec: configv1alpha1.ConfigSpec{
+			Sync: configv1alpha1.Sync{
+				SyncOnly: []configv1alpha1.SyncOnlyEntry{
+					{Group: "", Version: "v1", Kind: "Pod"},
+				},
+			},
+			Match: []configv1alpha1.MatchEntry{
+				{
+					ExcludedNamespaces: []wildcard.Wildcard{"excluded-ns"},
+					Processes:          []string{"mutation-webhook"},
+				},
+			},
+		},
+	}
+	require.NoError(t, c.Create(ctx, instance))
+	t.Cleanup(func() { require.NoError(t, client.IgnoreNotFound(c.Delete(ctx, instance))) })
+
+	tracker, err := readiness.SetupTrackerNoReadyz(mgr, false, false, false)
+	require.NoError(t, err)
+
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
+	processExcluder := process.New()
+
+	rec, err := newReconciler(mgr, nil, processExcluder, tracker, func(context.Context) (*v1.Pod, error) { return pod, nil }, nil)
+	require.NoError(t, err)
+	rec.reader = c
+	rec.writer = c
+	rec.statusClient = c
+
+	_, err = rec.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{
+		Namespace: instance.GetNamespace(),
+		Name:      instance.GetName(),
+	}})
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"excluded-ns"}, processExcluder.GetExcludedNamespaces(process.Mutation),
+		"mutation webhook exclusions should be applied without a cache manager")
+
+	// ConfigPodStatus is still reported for this operation set.
+	statusName, err := statusv1beta1.KeyForConfig(pod.Name, instance.GetNamespace(), instance.GetName())
+	require.NoError(t, err)
+	status := &statusv1beta1.ConfigPodStatus{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: statusName}, status))
+	require.Empty(t, status.Status.Errors)
+	t.Cleanup(func() { require.NoError(t, client.IgnoreNotFound(c.Delete(ctx, status))) })
+}

--- a/pkg/controller/config/config_controller.go
+++ b/pkg/controller/config/config_controller.go
@@ -154,7 +154,10 @@ func (e *ChannelFullError) Temporary() bool {
 type Adder struct {
 	Tracker      *readiness.Tracker
 	CacheManager *cm.CacheManager
-	CtEvents     chan<- event.GenericEvent
+	// ProcessExcluder holds the namespace exclusions the admission, audit and
+	// sync paths read. It is required even when validation data sync is off.
+	ProcessExcluder *process.Excluder
+	CtEvents        chan<- event.GenericEvent
 	// GetPod returns an instance of the currently running Gatekeeper pod
 	GetPod func(context.Context) (*corev1.Pod, error)
 }
@@ -162,7 +165,11 @@ type Adder struct {
 // Add creates a new ConfigController and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (a *Adder) Add(mgr manager.Manager) error {
-	r, err := newReconciler(mgr, a.CacheManager, a.Tracker, a.GetPod, a.CtEvents)
+	if !operations.NeedsConfigReconciliation() {
+		return nil
+	}
+
+	r, err := newReconciler(mgr, a.CacheManager, a.ProcessExcluder, a.Tracker, a.GetPod, a.CtEvents)
 	if err != nil {
 		return err
 	}
@@ -178,6 +185,10 @@ func (a *Adder) InjectCacheManager(cm *cm.CacheManager) {
 	a.CacheManager = cm
 }
 
+func (a *Adder) InjectProcessExcluder(processExcluder *process.Excluder) {
+	a.ProcessExcluder = processExcluder
+}
+
 func (a *Adder) InjectGetPod(getPod func(ctx context.Context) (*corev1.Pod, error)) {
 	a.GetPod = getPod
 }
@@ -186,21 +197,26 @@ func (a *Adder) InjectConstraintTemplateEvent(ctEvents chan event.GenericEvent) 
 	a.CtEvents = ctEvents
 }
 
-// newReconciler returns a new reconcile.Reconciler.
-func newReconciler(mgr manager.Manager, cm *cm.CacheManager, tracker *readiness.Tracker, getPod func(context.Context) (*corev1.Pod, error), ctEvents chan<- event.GenericEvent) (*ReconcileConfig, error) {
-	if cm == nil {
-		return nil, fmt.Errorf("cacheManager must be non-nil")
+// newReconciler returns a new reconcile.Reconciler. cm is only required when
+// the pod syncs validation data; processExcluder is always required.
+func newReconciler(mgr manager.Manager, cm *cm.CacheManager, processExcluder *process.Excluder, tracker *readiness.Tracker, getPod func(context.Context) (*corev1.Pod, error), ctEvents chan<- event.GenericEvent) (*ReconcileConfig, error) {
+	if processExcluder == nil {
+		return nil, fmt.Errorf("processExcluder must be non-nil")
+	}
+	if cm == nil && operations.NeedsValidationDataSync() {
+		return nil, fmt.Errorf("cacheManager must be non-nil when validation data sync is required")
 	}
 
 	return &ReconcileConfig{
-		reader:       mgr.GetCache(),
-		writer:       mgr.GetClient(),
-		statusClient: mgr.GetClient(),
-		scheme:       mgr.GetScheme(),
-		cacheManager: cm,
-		tracker:      tracker,
-		getPod:       getPod,
-		ctEvents:     ctEvents,
+		reader:          mgr.GetCache(),
+		writer:          mgr.GetClient(),
+		statusClient:    mgr.GetClient(),
+		scheme:          mgr.GetScheme(),
+		cacheManager:    cm,
+		processExcluder: processExcluder,
+		tracker:         tracker,
+		getPod:          getPod,
+		ctEvents:        ctEvents,
 	}, nil
 }
 
@@ -235,8 +251,10 @@ type ReconcileConfig struct {
 	writer       client.Writer
 	statusClient client.StatusClient
 
-	scheme       *runtime.Scheme
-	cacheManager *cm.CacheManager
+	scheme *runtime.Scheme
+	// cacheManager is nil when the pod does not sync validation data.
+	cacheManager    *cm.CacheManager
+	processExcluder *process.Excluder
 
 	tracker *readiness.Tracker
 
@@ -246,6 +264,31 @@ type ReconcileConfig struct {
 
 	dirtyMu        sync.Mutex
 	dirtyTemplates map[string]*v1beta1.ConstraintTemplate
+}
+
+// excludeProcesses installs the exclusions parsed from the Config resource.
+// While validation data is being synced the cache manager owns the excluder:
+// swapping it there also schedules the re-list the new exclusions require.
+func (r *ReconcileConfig) excludeProcesses(newExcluder *process.Excluder) {
+	if r.cacheManager != nil {
+		r.cacheManager.ExcludeProcesses(newExcluder)
+		return
+	}
+
+	if r.processExcluder.Equals(newExcluder) {
+		return
+	}
+	r.processExcluder.Replace(newExcluder)
+}
+
+// excluderChangedForProcess reports whether the exclusions for the given
+// process differ from the ones currently installed.
+func (r *ReconcileConfig) excluderChangedForProcess(p process.Process, newExcluder *process.Excluder) bool {
+	if r.cacheManager != nil {
+		return r.cacheManager.ExcluderChangedForProcess(p, newExcluder)
+	}
+
+	return !r.processExcluder.EqualsForProcess(p, newExcluder)
 }
 
 // +kubebuilder:rbac:groups=*,resources=*,verbs=get;list;watch
@@ -302,14 +345,16 @@ func (r *ReconcileConfig) Reconcile(ctx context.Context, request reconcile.Reque
 		r.tracker.DisableStats()
 	}
 
+	notifyGenerate := operations.NeedsGenerateConfigNotifications() && *transform.SyncVAPScope && r.ctEvents != nil
+
 	var configChanged bool
-	if operations.IsAssigned(operations.Generate) && *transform.SyncVAPScope && r.ctEvents != nil {
-		configChanged = r.cacheManager.ExcluderChangedForProcess(process.Webhook, newExcluder)
+	if notifyGenerate {
+		configChanged = r.excluderChangedForProcess(process.Webhook, newExcluder)
 	}
 
-	r.cacheManager.ExcludeProcesses(newExcluder)
+	r.excludeProcesses(newExcluder)
 	var ctTriggerError error
-	if operations.IsAssigned(operations.Generate) && *transform.SyncVAPScope && r.ctEvents != nil {
+	if notifyGenerate {
 		if configChanged {
 			ctTriggerError = r.triggerConstraintTemplateReconciliation(ctx)
 			if ctTriggerError != nil {
@@ -323,12 +368,16 @@ func (r *ReconcileConfig) Reconcile(ctx context.Context, request reconcile.Reque
 		}
 	}
 
-	// Directly accessing the NamespaceName.String(), as NamespaceName is embedded within reconcile.Request.
-	configSourceKey := aggregator.Key{Source: "config", ID: request.String()}
-	if err := r.cacheManager.UpsertSource(ctx, configSourceKey, gvksToSync); err != nil {
-		r.tracker.For(configGVK).TryCancelExpect(instance)
+	// Without a cache manager this pod does not sync referential data, so the
+	// syncOnly entries are not ours to act on.
+	if r.cacheManager != nil {
+		// Directly accessing the NamespaceName.String(), as NamespaceName is embedded within reconcile.Request.
+		configSourceKey := aggregator.Key{Source: "config", ID: request.String()}
+		if err := r.cacheManager.UpsertSource(ctx, configSourceKey, gvksToSync); err != nil {
+			r.tracker.For(configGVK).TryCancelExpect(instance)
 
-		return reconcile.Result{Requeue: true}, r.updateOrCreatePodStatus(ctx, instance, err)
+			return reconcile.Result{Requeue: true}, r.updateOrCreatePodStatus(ctx, instance, err)
+		}
 	}
 
 	r.tracker.For(configGVK).Observe(instance)

--- a/pkg/controller/config/config_controller_test.go
+++ b/pkg/controller/config/config_controller_test.go
@@ -164,7 +164,7 @@ func TestReconcile(t *testing.T) {
 		fakes.WithName("no-pod"),
 	)
 
-	rec, err := newReconciler(mgr, cacheManager, tracker, func(context.Context) (*v1.Pod, error) { return pod, nil }, nil)
+	rec, err := newReconciler(mgr, cacheManager, processExcluder, tracker, func(context.Context) (*v1.Pod, error) { return pod, nil }, nil)
 	require.NoError(t, err)
 
 	// Wrap the Controller Reconcile function so it writes each request to a map when it is finished reconciling.
@@ -456,7 +456,7 @@ func setupController(ctx context.Context, mgr manager.Manager, wm *watch.Manager
 		fakes.WithName("no-pod"),
 	)
 
-	rec, err := newReconciler(mgr, cacheManager, tracker, func(context.Context) (*v1.Pod, error) { return pod, nil }, nil)
+	rec, err := newReconciler(mgr, cacheManager, processExcluder, tracker, func(context.Context) (*v1.Pod, error) { return pod, nil }, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating reconciler: %w", err)
 	}
@@ -634,7 +634,7 @@ func TestConfig_Retries(t *testing.T) {
 		fakes.WithName("no-pod"),
 	)
 
-	rec, _ := newReconciler(mgr, cacheManager, tracker, func(context.Context) (*v1.Pod, error) { return pod, nil }, nil)
+	rec, _ := newReconciler(mgr, cacheManager, processExcluder, tracker, func(context.Context) (*v1.Pod, error) { return pod, nil }, nil)
 	err = add(mgr, rec)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -32,6 +32,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/export"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
@@ -130,6 +131,32 @@ type Dependencies struct {
 	WebhookConfigCache *webhookconfigcache.WebhookConfigCache
 }
 
+// Validate rejects a dependency plan that does not match the assigned
+// operations. Every controller we go on to register expects its own
+// dependencies to be non-nil, so a mismatch has to fail setup rather than
+// surface later as a nil dereference.
+func (deps *Dependencies) Validate() error {
+	if operations.NeedsValidationDataSync() {
+		if deps.CacheMgr == nil {
+			return fmt.Errorf("cache manager is required for operations %v", operations.AssignedStringList())
+		}
+		if deps.SyncEventsCh == nil {
+			return fmt.Errorf("sync events channel is required for operations %v", operations.AssignedStringList())
+		}
+		if deps.WatchManger == nil {
+			return fmt.Errorf("watch manager is required for operations %v", operations.AssignedStringList())
+		}
+	} else if deps.CacheMgr != nil {
+		return fmt.Errorf("cache manager was built but no operation in %v syncs validation data", operations.AssignedStringList())
+	}
+
+	if operations.NeedsProcessExclusions() && deps.ProcessExcluder == nil {
+		return fmt.Errorf("process excluder is required for operations %v", operations.AssignedStringList())
+	}
+
+	return nil
+}
+
 type defaultPodGetter struct {
 	client client.Client
 	scheme *runtime.Scheme
@@ -176,6 +203,10 @@ func (g *defaultPodGetter) GetPod(ctx context.Context) (*corev1.Pod, error) {
 
 // AddToManager adds all Controllers to the Manager.
 func AddToManager(m manager.Manager, deps *Dependencies) error {
+	if err := deps.Validate(); err != nil {
+		return fmt.Errorf("invalid controller dependencies: %w", err)
+	}
+
 	if *remoteCluster && *debugUseFakePod {
 		return fmt.Errorf("--enable-remote-cluster and --debug-use-fake-pod are mutually exclusive")
 	}
@@ -227,19 +258,23 @@ func AddToManager(m manager.Manager, deps *Dependencies) error {
 		}
 	}
 
-	// Adding the CacheManager as a runnable;
-	// manager will start CacheManager.
-	if err := m.Add(deps.CacheMgr); err != nil {
-		return fmt.Errorf("error adding cache manager as a runnable: %w", err)
-	}
+	// The cache manager and the sync controller only exist for operations that
+	// sync validation data.
+	if deps.CacheMgr != nil {
+		// Adding the CacheManager as a runnable;
+		// manager will start CacheManager.
+		if err := m.Add(deps.CacheMgr); err != nil {
+			return fmt.Errorf("error adding cache manager as a runnable: %w", err)
+		}
 
-	syncAdder := syncc.Adder{
-		Events:       deps.SyncEventsCh,
-		CacheManager: deps.CacheMgr,
-	}
-	// Create subordinate controller - we will feed it events dynamically via watch
-	if err := syncAdder.Add(m); err != nil {
-		return fmt.Errorf("registering sync controller: %w", err)
+		syncAdder := syncc.Adder{
+			Events:       deps.SyncEventsCh,
+			CacheManager: deps.CacheMgr,
+		}
+		// Create subordinate controller - we will feed it events dynamically via watch
+		if err := syncAdder.Add(m); err != nil {
+			return fmt.Errorf("registering sync controller: %w", err)
+		}
 	}
 
 	for _, a := range Injectors {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -150,7 +150,10 @@ func (deps *Dependencies) Validate() error {
 		return fmt.Errorf("cache manager was built but no operation in %v syncs validation data", operations.AssignedStringList())
 	}
 
-	if operations.NeedsProcessExclusions() && deps.ProcessExcluder == nil {
+	// The Config reconciler writes the exclusions it parses into this excluder,
+	// so it is required wherever the Config controller registers, not only where
+	// the exclusions are read back.
+	if operations.NeedsConfigReconciliation() && deps.ProcessExcluder == nil {
 		return fmt.Errorf("process excluder is required for operations %v", operations.AssignedStringList())
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,123 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	cm "github.com/open-policy-agent/gatekeeper/v3/pkg/cachemanager"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/config/process"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestDependenciesValidate(t *testing.T) {
+	dataSyncDeps := func() *Dependencies {
+		return &Dependencies{
+			CacheMgr:        &cm.CacheManager{},
+			SyncEventsCh:    make(chan event.GenericEvent, 1),
+			WatchManger:     &watch.Manager{},
+			ProcessExcluder: process.New(),
+		}
+	}
+
+	tests := []struct {
+		name     string
+		assigned []operations.Operation
+		deps     func() *Dependencies
+		wantErr  bool
+	}{
+		{
+			name:     "data sync operations with a complete plan",
+			assigned: []operations.Operation{operations.Audit},
+			deps:     dataSyncDeps,
+		},
+		{
+			name:     "data sync operations without a cache manager",
+			assigned: []operations.Operation{operations.Audit},
+			deps: func() *Dependencies {
+				deps := dataSyncDeps()
+				deps.CacheMgr = nil
+				return deps
+			},
+			wantErr: true,
+		},
+		{
+			name:     "data sync operations without sync events",
+			assigned: []operations.Operation{operations.Webhook},
+			deps: func() *Dependencies {
+				deps := dataSyncDeps()
+				deps.SyncEventsCh = nil
+				return deps
+			},
+			wantErr: true,
+		},
+		{
+			name:     "data sync operations without a watch manager",
+			assigned: []operations.Operation{operations.Webhook},
+			deps: func() *Dependencies {
+				deps := dataSyncDeps()
+				deps.WatchManger = nil
+				return deps
+			},
+			wantErr: true,
+		},
+		{
+			name:     "mutation webhook keeps process exclusions without data sync",
+			assigned: []operations.Operation{operations.MutationWebhook},
+			deps: func() *Dependencies {
+				return &Dependencies{ProcessExcluder: process.New()}
+			},
+		},
+		{
+			name:     "mutation webhook without a process excluder",
+			assigned: []operations.Operation{operations.MutationWebhook},
+			deps:     func() *Dependencies { return &Dependencies{} },
+			wantErr:  true,
+		},
+		{
+			name:     "cache manager built for operations that do not sync data",
+			assigned: []operations.Operation{operations.MutationWebhook},
+			deps: func() *Dependencies {
+				return &Dependencies{
+					CacheMgr:        &cm.CacheManager{},
+					ProcessExcluder: process.New(),
+				}
+			},
+			wantErr: true,
+		},
+		{
+			name:     "mutation status needs nothing",
+			assigned: []operations.Operation{operations.MutationStatus},
+			deps:     func() *Dependencies { return &Dependencies{} },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(operations.AssignForTest(tt.assigned...))
+
+			err := tt.deps().Validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("Validate() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -101,9 +101,20 @@ func TestDependenciesValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:     "mutation status needs nothing",
+			// Mutation status syncs no data, but the Config controller still
+			// registers for the readiness stats switch and needs somewhere to
+			// put the exclusions it parses.
+			name:     "mutation status needs only a process excluder",
+			assigned: []operations.Operation{operations.MutationStatus},
+			deps: func() *Dependencies {
+				return &Dependencies{ProcessExcluder: process.New()}
+			},
+		},
+		{
+			name:     "mutation status without a process excluder",
 			assigned: []operations.Operation{operations.MutationStatus},
 			deps:     func() *Dependencies { return &Dependencies{} },
+			wantErr:  true,
 		},
 	}
 

--- a/pkg/operations/capabilities.go
+++ b/pkg/operations/capabilities.go
@@ -1,0 +1,54 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operations
+
+// The predicates below name the capabilities controller setup has to decide on,
+// so wiring code can ask "does this pod need X?" instead of re-deriving the
+// operation set at every call site.
+
+// NeedsValidationDataSync returns true when the pod has to keep referential
+// data in sync for validation. It gates the cache manager, its watch registrar,
+// the sync controller and the expectations pruner.
+func NeedsValidationDataSync() bool {
+	return HasValidationOperations()
+}
+
+// NeedsProcessExclusions returns true when the pod evaluates the per-process
+// namespace exclusions carried by the Config resource. Generate is included
+// because synced VAP enforcement scope inherits the webhook exclusions.
+func NeedsProcessExclusions() bool {
+	return IsAssigned(Audit) ||
+		IsAssigned(Webhook) ||
+		IsAssigned(MutationWebhook) ||
+		IsAssigned(Generate) ||
+		NeedsValidationDataSync()
+}
+
+// NeedsGenerateConfigNotifications returns true when the pod turns Config
+// changes into constraint template reconciliation so that generated VAP objects
+// track Gatekeeper's enforcement scope. Callers must also honor
+// --sync-vap-enforcement-scope.
+func NeedsGenerateConfigNotifications() bool {
+	return IsAssigned(Generate)
+}
+
+// NeedsConfigReconciliation returns true when the Config controller has work to
+// do: process exclusions, validation data sync, or generate notifications.
+func NeedsConfigReconciliation() bool {
+	return NeedsProcessExclusions() ||
+		NeedsValidationDataSync() ||
+		NeedsGenerateConfigNotifications()
+}

--- a/pkg/operations/capabilities.go
+++ b/pkg/operations/capabilities.go
@@ -45,10 +45,23 @@ func NeedsGenerateConfigNotifications() bool {
 	return IsAssigned(Generate)
 }
 
+// NeedsReadinessStats returns true when the pod runs a readiness tracker whose
+// verbose logging Config.spec.readiness.statsEnabled switches on. Setup builds
+// a tracker for every operation set - mutation-only pods included, and their
+// mutator expectations are exactly what that logging reports - so this holds
+// unconditionally. It is named rather than inlined because the Config
+// reconciler is the only place that reads the field, which is what forces
+// Config reconciliation onto pods that use nothing else from the resource.
+func NeedsReadinessStats() bool {
+	return true
+}
+
 // NeedsConfigReconciliation returns true when the Config controller has work to
-// do: process exclusions, validation data sync, or generate notifications.
+// do: process exclusions, validation data sync, generate notifications, or the
+// readiness stats switch.
 func NeedsConfigReconciliation() bool {
 	return NeedsProcessExclusions() ||
 		NeedsValidationDataSync() ||
-		NeedsGenerateConfigNotifications()
+		NeedsGenerateConfigNotifications() ||
+		NeedsReadinessStats()
 }

--- a/pkg/operations/capabilities_test.go
+++ b/pkg/operations/capabilities_test.go
@@ -27,9 +27,12 @@ func TestCapabilities(t *testing.T) {
 		configReconciliation  bool
 	}{
 		{
+			// Even here: the readiness tracker exists regardless of the
+			// operation set, and only the Config controller can switch its
+			// verbose logging on.
 			name:                 "no operations",
 			assigned:             nil,
-			configReconciliation: false,
+			configReconciliation: true,
 		},
 		{
 			name:                 "audit",
@@ -52,14 +55,16 @@ func TestCapabilities(t *testing.T) {
 			configReconciliation: true,
 		},
 		{
+			// Mutation-only pods read nothing else off the Config resource, but
+			// their readiness stats switch still lives there.
 			name:                 "mutation status only",
 			assigned:             []Operation{MutationStatus},
-			configReconciliation: false,
+			configReconciliation: true,
 		},
 		{
 			name:                 "mutation controller only",
 			assigned:             []Operation{MutationController},
-			configReconciliation: false,
+			configReconciliation: true,
 		},
 		{
 			name:                  "generate only",
@@ -90,6 +95,9 @@ func TestCapabilities(t *testing.T) {
 			}
 			if got := NeedsGenerateConfigNotifications(); got != tt.generateNotifications {
 				t.Errorf("NeedsGenerateConfigNotifications() = %t, want %t", got, tt.generateNotifications)
+			}
+			if got := NeedsReadinessStats(); !got {
+				t.Errorf("NeedsReadinessStats() = %t, want true", got)
 			}
 			if got := NeedsConfigReconciliation(); got != tt.configReconciliation {
 				t.Errorf("NeedsConfigReconciliation() = %t, want %t", got, tt.configReconciliation)

--- a/pkg/operations/capabilities_test.go
+++ b/pkg/operations/capabilities_test.go
@@ -1,0 +1,119 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operations
+
+import "testing"
+
+func TestCapabilities(t *testing.T) {
+	tests := []struct {
+		name                  string
+		assigned              []Operation
+		dataSync              bool
+		processExclusions     bool
+		generateNotifications bool
+		configReconciliation  bool
+	}{
+		{
+			name:                 "no operations",
+			assigned:             nil,
+			configReconciliation: false,
+		},
+		{
+			name:                 "audit",
+			assigned:             []Operation{Audit},
+			dataSync:             true,
+			processExclusions:    true,
+			configReconciliation: true,
+		},
+		{
+			name:                 "validating webhook",
+			assigned:             []Operation{Webhook},
+			dataSync:             true,
+			processExclusions:    true,
+			configReconciliation: true,
+		},
+		{
+			name:                 "mutation webhook only",
+			assigned:             []Operation{MutationWebhook},
+			processExclusions:    true,
+			configReconciliation: true,
+		},
+		{
+			name:                 "mutation status only",
+			assigned:             []Operation{MutationStatus},
+			configReconciliation: false,
+		},
+		{
+			name:                 "mutation controller only",
+			assigned:             []Operation{MutationController},
+			configReconciliation: false,
+		},
+		{
+			name:                  "generate only",
+			assigned:              []Operation{Generate},
+			processExclusions:     true,
+			generateNotifications: true,
+			configReconciliation:  true,
+		},
+		{
+			name:                  "all operations",
+			assigned:              allOperations,
+			dataSync:              true,
+			processExclusions:     true,
+			generateNotifications: true,
+			configReconciliation:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(AssignForTest(tt.assigned...))
+
+			if got := NeedsValidationDataSync(); got != tt.dataSync {
+				t.Errorf("NeedsValidationDataSync() = %t, want %t", got, tt.dataSync)
+			}
+			if got := NeedsProcessExclusions(); got != tt.processExclusions {
+				t.Errorf("NeedsProcessExclusions() = %t, want %t", got, tt.processExclusions)
+			}
+			if got := NeedsGenerateConfigNotifications(); got != tt.generateNotifications {
+				t.Errorf("NeedsGenerateConfigNotifications() = %t, want %t", got, tt.generateNotifications)
+			}
+			if got := NeedsConfigReconciliation(); got != tt.configReconciliation {
+				t.Errorf("NeedsConfigReconciliation() = %t, want %t", got, tt.configReconciliation)
+			}
+		})
+	}
+}
+
+func TestAssignForTestRestores(t *testing.T) {
+	before := AssignedStringList()
+
+	restore := AssignForTest(Audit)
+	if got := AssignedStringList(); len(got) != 1 || got[0] != string(Audit) {
+		t.Fatalf("AssignedStringList() = %v, want [audit]", got)
+	}
+	restore()
+
+	after := AssignedStringList()
+	if len(before) != len(after) {
+		t.Fatalf("AssignedStringList() = %v, want %v", after, before)
+	}
+	for i := range before {
+		if before[i] != after[i] {
+			t.Fatalf("AssignedStringList() = %v, want %v", after, before)
+		}
+	}
+}

--- a/pkg/operations/testing.go
+++ b/pkg/operations/testing.go
@@ -1,0 +1,41 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operations
+
+// AssignForTest replaces the assigned operations with ops and returns a
+// function that restores the previous set. The --operation flag is write-once
+// per process, so tests covering more than one operation set need this.
+func AssignForTest(ops ...Operation) func() {
+	operationsMtx.Lock()
+	defer operationsMtx.Unlock()
+
+	previous := operations
+
+	assigned := newOperationSet()
+	assigned.assignedOperations = make(map[Operation]bool)
+	assigned.initialized = true
+	for _, op := range ops {
+		assigned.assignedOperations[op] = true
+	}
+	operations = assigned
+
+	return func() {
+		operationsMtx.Lock()
+		defer operationsMtx.Unlock()
+
+		operations = previous
+	}
+}

--- a/pkg/readiness/ready_tracker.go
+++ b/pkg/readiness/ready_tracker.go
@@ -858,8 +858,12 @@ func (t *Tracker) trackConfigAndSyncSets(ctx context.Context, errChan chan<- err
 			if !cfg.GetDeletionTimestamp().IsZero() {
 				log.Info("config resource is being deleted - skipping for readiness")
 			} else {
-				t.config.Expect(cfg)
-				log.V(logging.DebugLevel).Info("setting expectations for config", "configCount", 1)
+				// Only wait for the Config resource if a controller in this pod
+				// will actually observe it.
+				if operations.NeedsConfigReconciliation() {
+					t.config.Expect(cfg)
+					log.V(logging.DebugLevel).Info("setting expectations for config", "configCount", 1)
+				}
 
 				for _, entry := range cfg.Spec.Sync.SyncOnly {
 					dataGVKs[entry.ToGroupVersionKind()] = struct{}{}


### PR DESCRIPTION
**What this PR does / why we need it**:

`setupControllers` always built the cache-manager registrar, the sync metrics cache, the cache manager and the expectations pruner, and `controller.AddToManager` always registered the cache manager runnable and the sync controller. #4423 made that stack tolerate a missing constraint client via a no-op `CFDataClient`, which unblocked the mutation-webhook startup fix but left mutation-only pods carrying validation data-sync infrastructure only so the Config controller could update process exclusions.

This splits the two responsibilities of the Config resource apart.

`pkg/operations/capabilities.go` names the four capabilities the wiring depends on:

| predicate | gates |
| --- | --- |
| `NeedsValidationDataSync` | cache manager, its registrar, sync controller, expectations pruner |
| `NeedsProcessExclusions` | the excluder the admission/audit/sync paths read |
| `NeedsGenerateConfigNotifications` | Config-triggered CT reconciliation for VAP scope |
| `NeedsConfigReconciliation` | whether the Config controller runs at all |

With those in place:

- `setupControllers` only builds the registrar, sync metrics cache, cache manager and pruner when an operation syncs validation data. Mutation-webhook-only no longer instantiates a no-op `CFDataClient` or registers data watches.
- `AddToManager` only adds the cache manager runnable and the sync controller when a cache manager exists.
- `Dependencies.Validate` fails setup with a message naming the assigned operations when the plan does not match them — a missing cache manager / sync channel / watch manager for data-sync operations, a cache manager built for operations that do not sync, or a missing process excluder. Previously a mismatch would have surfaced as a nil dereference somewhere downstream.
- The Config reconciler takes the `*process.Excluder` directly. With a cache manager it still swaps through `ExcludeProcesses` so the re-list scheduling is unchanged; without one it replaces the excluder in place and skips `UpsertSource` entirely.
- The Config controller is not registered when nothing in the pod reads the Config resource (subsets of `mutation-controller` / `mutation-status`). The readiness tracker stops expecting Config for exactly that case, so `--operation=mutation-status` does not wait forever on an observation that can no longer arrive.

Audit, validating webhook and generate keep their current behavior: audit and webhook still sync referential data, generate still gets Config-triggered VAP scope reconciliation, and `ConfigPodStatus` is still written for every operation set that reconciles Config. Default all-operations behavior is unchanged.

`NeedsValidationDataSync` is defined in terms of `HasValidationOperations` rather than re-deriving the operation list, so status-only pods drop the cache manager, sync controller and pruner as soon as #4770 / #4780 lands — no change needed here.

**Which issue(s) this PR fixes**:
Fixes #4775

**Special notes for your reviewer**:

Tests:

- `pkg/operations/capabilities_test.go` walks each capability across the operation sets that matter (audit, validating webhook, mutation-webhook-only, mutation-status-only, mutation-controller-only, generate-only, all).
- `pkg/controller/controller_test.go` covers `Dependencies.Validate`, including the case where a cache manager is handed to operations that do not sync data.
- `pkg/controller/config/config_capability_test.go` pins the registration gate (mutation-status-only registers nothing even with no dependencies set; mutation-webhook still errors on a missing excluder) and reconciles a Config with a nil cache manager, asserting the mutation-webhook exclusions land and `ConfigPodStatus` is still written. Reverting either gate fails these.

I deliberately left `main_test.go` alone — #4779 and #4780 are both creating it, and #4776 covers the table-driven `setupControllers` matrix.

This touches `main.go` alongside #4777 / #4778 / #4779 / #4780, but in a different block; happy to rebase in whatever order you merge them.

<!-- oss-radar:idempotency=auto-20260825-191241.w0.open-policy-agent_gatekeeper.4775 -->
