### PR TITLE
refactor: initialize violation export dependencies only when export is enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ import (
 	celSchema "github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel/schema"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/export"
+	exportutil "github.com/open-policy-agent/gatekeeper/v3/pkg/export/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/externaldata"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/metrics"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
@@ -510,7 +511,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 
 	mutationSystem := mutation.NewSystem(mutationOpts)
 	expansionSystem := expansion.NewSystem(mutationSystem)
-	exportSystem := export.NewSystem()
+	exportSystem := newExportSystem()
 
 	c := mgr.GetCache()
 	dc, ok := c.(watch.RemovableCache)
@@ -609,8 +610,10 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 			ProcessExcluder: processExcluder,
 			MutationSystem:  mutationSystem,
 			ExpansionSystem: expansionSystem,
-			ExportSystem:    exportSystem,
 			GetPod:          opts.GetPod,
+		}
+		if exportSystem != nil {
+			webhookDeps.ExportSystem = exportSystem
 		}
 		if err := webhook.AddToManager(mgr, webhookDeps); err != nil {
 			setupLog.Error(err, "unable to register webhooks with the manager")
@@ -642,6 +645,16 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 	}
 
 	return nil
+}
+
+// newExportSystem constructs the violation export system only when an export
+// feature is enabled. Disabled processes should not carry the unused export
+// dependency, and enabling export keeps consumers receiving a non-nil system.
+func newExportSystem() *export.System {
+	if !*exportutil.ExportEnabled && !*exportutil.AdmissionExportEnabled {
+		return nil
+	}
+	return export.NewSystem()
 }
 
 func setLoggerForProduction(encoder zapcore.LevelEncoder, dest io.Writer) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"testing"
+
+	exportutil "github.com/open-policy-agent/gatekeeper/v3/pkg/export/util"
+)
+
+func setExportFlags(t *testing.T, exportEnabled, admissionExportEnabled bool) {
+	t.Helper()
+	oldExport, oldAdmission := *exportutil.ExportEnabled, *exportutil.AdmissionExportEnabled
+	t.Cleanup(func() {
+		*exportutil.ExportEnabled = oldExport
+		*exportutil.AdmissionExportEnabled = oldAdmission
+	})
+	*exportutil.ExportEnabled = exportEnabled
+	*exportutil.AdmissionExportEnabled = admissionExportEnabled
+}
+
+func TestNewExportSystem(t *testing.T) {
+	tests := []struct {
+		name                   string
+		exportEnabled          bool
+		admissionExportEnabled bool
+		wantSystem             bool
+	}{
+		{name: "export disabled", exportEnabled: false, admissionExportEnabled: false, wantSystem: false},
+		{name: "audit export enabled", exportEnabled: true, admissionExportEnabled: false, wantSystem: true},
+		{name: "admission export enabled", exportEnabled: false, admissionExportEnabled: true, wantSystem: true},
+		{name: "both exports enabled", exportEnabled: true, admissionExportEnabled: true, wantSystem: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setExportFlags(t, tt.exportEnabled, tt.admissionExportEnabled)
+			system := newExportSystem()
+			if (system != nil) != tt.wantSystem {
+				t.Errorf("newExportSystem() = %v, want system present: %v", system, tt.wantSystem)
+			}
+		})
+	}
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -263,7 +263,7 @@ func AddToManager(m manager.Manager, deps *Dependencies) error {
 		if a2, ok := a.(GetPodInjector); ok {
 			a2.InjectGetPod(deps.GetPod)
 		}
-		if a2, ok := a.(ExportInjector); ok {
+		if a2, ok := a.(ExportInjector); ok && deps.ExportSystem != nil {
 			a2.InjectExportSystem(deps.ExportSystem)
 		}
 		if a2, ok := a.(CacheManagerInjector); ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of the controller dependency cleanup tracked in #3964.

`setupControllers` currently calls `export.NewSystem()` for every
operation set, even though violation export is disabled by default and
the export connection controller already skips registration in that
case. This constructs the export system only when
`--enable-violation-export` or `--enable-admission-violation-export`
is set, so disabled processes do not carry an unused dependency.

Consumers keep their current behavior when export is enabled:

- audit publishing and Connection reconciliation receive a non-nil
  system
- admission export already fails setup if the system or pod getter is
  missing (`webhook.AddValidationWebhook` returns an explicit error)

The export system is injected into controllers only when constructed,
and the webhook dependencies receive it through a guarded assignment so
a typed-nil `*export.System` is never boxed into the `export.Exporter`
interface.

**Which issue(s) this PR fixes**:

Fixes #4774

**Special notes for your reviewer**:

- Adds a focused `TestNewExportSystem` covering the disabled/enabled
  flag combinations; the disabled case fails if unconditional
  construction is restored.
- No behavior change for deployments with export enabled.
