### PR TITLE
refactor: scope expansion ingestion to operations that evaluate expanded resources

### DIFF
--- a/main.go
+++ b/main.go
@@ -321,7 +321,7 @@ func innerMain() int {
 	}
 
 	// Setup tracker and register readiness probe.
-	tracker, err := readiness.SetupTracker(mgr, mutation.Enabled(), *externaldata.ExternalDataEnabled, *expansion.ExpansionEnabled)
+	tracker, err := readiness.SetupTracker(mgr, mutation.Enabled(), *externaldata.ExternalDataEnabled, *expansion.ExpansionEnabled && operations.HasExpansionEvaluationOperations())
 	if err != nil {
 		setupLog.Error(err, "unable to register readiness tracker")
 		return 1

--- a/pkg/controller/expansion/expansion_controller.go
+++ b/pkg/controller/expansion/expansion_controller.go
@@ -11,6 +11,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/logging"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/metrics"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
@@ -44,6 +45,9 @@ type Adder struct {
 
 func (a *Adder) Add(mgr manager.Manager) error {
 	if !*expansion.ExpansionEnabled {
+		return nil
+	}
+	if !operations.HasExpansionEvaluationOperations() {
 		return nil
 	}
 	r := newReconciler(mgr, a.ExpansionSystem, a.GetPod, a.Tracker)

--- a/pkg/controller/expansion/expansion_controller_test.go
+++ b/pkg/controller/expansion/expansion_controller_test.go
@@ -3,6 +3,7 @@ package expansion
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"testing"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation/match"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	testclient "github.com/open-policy-agent/gatekeeper/v3/test/clients"
 	"github.com/open-policy-agent/gatekeeper/v3/test/testutils"
@@ -201,4 +203,36 @@ func newET(name string) *v1beta1.ExpansionTemplate {
 	}
 	et.SetGroupVersionKind(v1alpha1.GroupVersion.WithKind("ExpansionTemplate"))
 	return et
+}
+
+func TestAddSkipsWhenExpansionDisabled(t *testing.T) {
+	operations.ResetForTest()
+	t.Cleanup(operations.ResetForTest)
+
+	old := *expansion.ExpansionEnabled
+	*expansion.ExpansionEnabled = false
+	t.Cleanup(func() { *expansion.ExpansionEnabled = old })
+
+	// Add must return before touching the manager when the feature is off.
+	a := &Adder{}
+	if err := a.Add(nil); err != nil {
+		t.Fatalf("Add() with expansion disabled = %v, want nil", err)
+	}
+}
+
+func TestAddSkipsNonEvaluationOperations(t *testing.T) {
+	operations.ResetForTest()
+	t.Cleanup(operations.ResetForTest)
+
+	// A process that does not evaluate expanded resources (no webhook or
+	// audit operation) must not register the ingestion controller, even
+	// though expansion defaults to enabled.
+	if err := flag.Set("operation", "status"); err != nil {
+		t.Fatalf("setting operation flag: %v", err)
+	}
+
+	a := &Adder{}
+	if err := a.Add(nil); err != nil {
+		t.Fatalf("Add() without evaluation operations = %v, want nil", err)
+	}
 }

--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -131,3 +131,20 @@ func AssignedStringList() []string {
 func HasValidationOperations() bool {
 	return IsAssigned(Audit) || IsAssigned(Status) || IsAssigned(Webhook)
 }
+
+// HasExpansionEvaluationOperations returns true when the pod runs operations
+// that evaluate expanded resources, namely the validating webhook or audit.
+// Expansion status aggregation is tracked separately by the status
+// operation.
+func HasExpansionEvaluationOperations() bool {
+	return IsAssigned(Webhook) || IsAssigned(Audit)
+}
+
+// ResetForTest restores the process-wide operation set to its uninitialized
+// state where all operations are assigned. It is intended for tests that
+// override the --operation flag and need to clean up after themselves.
+func ResetForTest() {
+	operationsMtx.Lock()
+	defer operationsMtx.Unlock()
+	operations = newOperationSet()
+}

--- a/pkg/operations/operations_test.go
+++ b/pkg/operations/operations_test.go
@@ -48,3 +48,35 @@ func Test_Flags(t *testing.T) {
 		})
 	}
 }
+
+func Test_HasExpansionEvaluationOperations(t *testing.T) {
+	tests := map[string]struct {
+		input    []string
+		expected bool
+	}{
+		"default":                   {input: []string{}, expected: true},
+		"audit only":                {input: []string{"-operation", "audit"}, expected: true},
+		"webhook only":              {input: []string{"-operation", "webhook"}, expected: true},
+		"status only":               {input: []string{"-operation", "status"}, expected: false},
+		"generate only":             {input: []string{"-operation", "generate"}, expected: false},
+		"mutation only":             {input: []string{"-operation", "mutation-webhook,mutation-controller,mutation-status"}, expected: false},
+		"audit+status+mut+generate": {input: []string{"-operation", "audit,status,mutation-status,generate"}, expected: true},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ResetForTest()
+			t.Cleanup(ResetForTest)
+
+			flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+			flagSet.Var(operations, "operation", "test operation flag")
+			if err := flagSet.Parse(tc.input); err != nil {
+				t.Fatalf("parsing: %v", err)
+			}
+
+			if got := HasExpansionEvaluationOperations(); got != tc.expected {
+				t.Errorf("HasExpansionEvaluationOperations() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of the controller dependency cleanup tracked in #3964.

The ExpansionTemplate ingestion controller checked only
`--enable-generator-resource-expansion`, which defaults to true, so
status-only, generate-only and other processes that never evaluate
admission or audit resources still registered it.

Changes:

- Add `operations.HasExpansionEvaluationOperations`, true only for the
  validating webhook and audit operations — the consumers that actually
  evaluate expanded resources.
- Register the ingestion controller only when the feature is enabled
  and one of those consumers is assigned. Expansion status aggregation
  keeps its existing, separate status-operation gate.
- Wire the readiness tracker with the same predicate, so pods that do
  not ingest ExpansionTemplates also do not build unsatisfiable
  expectations for them (otherwise readiness would never be reached on
  e.g. status-only pods with ExpansionTemplates present).

Default all-operations behavior is unchanged.

**Which issue(s) this PR fixes**:

Fixes #4773

**Special notes for your reviewer**:

- `Test_HasExpansionEvaluationOperations` covers the isolated operation
  sets plus the shipped `audit+status+mutation-status+generate`
  combination.
- `TestAddSkipsWhenExpansionDisabled` and
  `TestAddSkipsNonEvaluationOperations` prove the Adder returns before
  touching the manager when the feature flag is off or no evaluation
  operation is assigned.
