### PR TITLE
chore: bump kubectl from v1.36.4 to v1.37.0

### DIFF
--- a/crd.Dockerfile
+++ b/crd.Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$TARGETPLATFORM registry.k8s.io/kubectl:v1.36.4 AS builder
+FROM --platform=$TARGETPLATFORM registry.k8s.io/kubectl:v1.37.0 AS builder
 
 ARG TARGETPLATFORM
 ARG TARGETOS


### PR DESCRIPTION
**What this PR does / why we need it**:
bumps kubectl from v1.36.4 to v1.37.0.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
