### PR TITLE
fix: prevent generated VAP update churn from defaulted scope

### DIFF
--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -828,6 +828,7 @@ func v1beta1ToV1(v1beta1Obj *admissionregistrationv1beta1.ValidatingAdmissionPol
 						APIGroups:   rule.APIGroups,
 						APIVersions: rule.APIVersions,
 						Resources:   rule.Resources,
+						Scope:       rule.Scope,
 					},
 				},
 			}

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -2292,6 +2292,43 @@ func TestManageVAP_VAPAPIDisabledPreservesRetry(t *testing.T) {
 	}
 }
 
+func TestV1beta1ToV1PreservesResourceRuleScope(t *testing.T) {
+	scope := admissionregistrationv1beta1.AllScopes
+	failurePolicy := admissionregistrationv1beta1.Fail
+	v1beta1VAP := &admissionregistrationv1beta1.ValidatingAdmissionPolicy{
+		Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicySpec{
+			ParamKind: &admissionregistrationv1beta1.ParamKind{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestConstraint",
+			},
+			MatchConstraints: &admissionregistrationv1beta1.MatchResources{
+				ResourceRules: []admissionregistrationv1beta1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1beta1.RuleWithOperations{
+							Operations: []admissionregistrationv1beta1.OperationType{
+								admissionregistrationv1beta1.Create,
+							},
+							Rule: admissionregistrationv1beta1.Rule{
+								APIGroups:   []string{"*"},
+								APIVersions: []string{"*"},
+								Resources:   []string{"*"},
+								Scope:       &scope,
+							},
+						},
+					},
+				},
+			},
+			FailurePolicy: &failurePolicy,
+		},
+	}
+
+	v1VAP, err := v1beta1ToV1(v1beta1VAP)
+	require.NoError(t, err)
+	require.NotNil(t, v1VAP.Spec.MatchConstraints)
+	require.Len(t, v1VAP.Spec.MatchConstraints.ResourceRules, 1)
+	require.Equal(t, &scope, v1VAP.Spec.MatchConstraints.ResourceRules[0].Scope)
+}
+
 func TestReconcile_VAPV1Beta1RecreatedWhenDeleted(t *testing.T) {
 	ctx, c := setupVersionPinnedReconcileTest(t, &admissionregistrationv1beta1.SchemeGroupVersion)
 	suffix := "VapV1Beta1ShouldBeRecreated"

--- a/pkg/drivers/k8scel/transform/make_vap_objects.go
+++ b/pkg/drivers/k8scel/transform/make_vap_objects.go
@@ -166,6 +166,7 @@ func buildDefaultMatchConstraints() *admissionregistrationv1beta1.MatchResources
 						APIGroups:   []string{"*"},
 						APIVersions: []string{"*"},
 						Resources:   []string{"*"},
+						Scope:       ptr.To(admissionregistrationv1beta1.AllScopes),
 					},
 				},
 			},

--- a/pkg/drivers/k8scel/transform/make_vap_objects_test.go
+++ b/pkg/drivers/k8scel/transform/make_vap_objects_test.go
@@ -67,7 +67,12 @@ func TestTemplateToPolicyDefinition(t *testing.T) {
 							{
 								RuleWithOperations: admissionregistrationv1beta1.RuleWithOperations{
 									Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
-									Rule:       admissionregistrationv1beta1.Rule{APIGroups: []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*"}},
+									Rule: admissionregistrationv1beta1.Rule{
+										APIGroups:   []string{"*"},
+										APIVersions: []string{"*"},
+										Resources:   []string{"*"},
+										Scope:       ptr.To(admissionregistrationv1beta1.AllScopes),
+									},
 								},
 							},
 						},
@@ -1697,6 +1702,9 @@ func TestBuildDefaultMatchConstraints(t *testing.T) {
 	}
 	if len(rule.Resources) != 1 || rule.Resources[0] != "*" {
 		t.Errorf("expected wildcard Resources, got %v", rule.Resources)
+	}
+	if rule.Scope == nil || *rule.Scope != admissionregistrationv1beta1.AllScopes {
+		t.Errorf("expected all scopes, got %v", rule.Scope)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Explicitly sets the default ValidatingAdmissionPolicy resource-rule scope to `AllScopes` and preserves that scope when converting a v1beta1 VAP to v1.

Kubernetes defaults an omitted `resourceRules[].scope` to `"*"`. Gatekeeper's default VAP construction omitted the field, so the desired object could contain a nil scope while the object returned by the API server contained `"*"`.

That difference caused the ConstraintTemplate controller to repeatedly consider an otherwise unchanged VAP out of date. Each unnecessary update incremented the VAP generation and could race the Kubernetes VAP status controller, producing resource-version conflicts.

Setting the default explicitly makes the desired and persisted specifications converge. Copying the field during v1beta1-to-v1 conversion preserves that behavior when Gatekeeper uses the v1 VAP API.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
N/A


**Special notes for your reviewer**:

Testing:

- Added coverage verifying default match constraints use `AllScopes`.
- Added coverage verifying v1beta1-to-v1 conversion preserves resource-rule scope.
- Reproduced on Kubernetes 1.34 with five generated CEL VAPs.
- Across 30 consecutive policy synchronization runs, all five VAPs retained
  generation 1 and unchanged resource versions, with no VAP update decisions or  VAP update conflicts.
