### PR TITLE
fix: prevent generated VAP update churn from defaulted scope (#4793) CP

### DIFF
--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -828,6 +828,7 @@ func v1beta1ToV1(v1beta1Obj *admissionregistrationv1beta1.ValidatingAdmissionPol
 						APIGroups:   rule.APIGroups,
 						APIVersions: rule.APIVersions,
 						Resources:   rule.Resources,
+						Scope:       rule.Scope,
 					},
 				},
 			}

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -2292,6 +2292,43 @@ func TestManageVAP_VAPAPIDisabledPreservesRetry(t *testing.T) {
 	}
 }
 
+func TestV1beta1ToV1PreservesResourceRuleScope(t *testing.T) {
+	scope := admissionregistrationv1beta1.AllScopes
+	failurePolicy := admissionregistrationv1beta1.Fail
+	v1beta1VAP := &admissionregistrationv1beta1.ValidatingAdmissionPolicy{
+		Spec: admissionregistrationv1beta1.ValidatingAdmissionPolicySpec{
+			ParamKind: &admissionregistrationv1beta1.ParamKind{
+				APIVersion: "constraints.gatekeeper.sh/v1beta1",
+				Kind:       "TestConstraint",
+			},
+			MatchConstraints: &admissionregistrationv1beta1.MatchResources{
+				ResourceRules: []admissionregistrationv1beta1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionregistrationv1beta1.RuleWithOperations{
+							Operations: []admissionregistrationv1beta1.OperationType{
+								admissionregistrationv1beta1.Create,
+							},
+							Rule: admissionregistrationv1beta1.Rule{
+								APIGroups:   []string{"*"},
+								APIVersions: []string{"*"},
+								Resources:   []string{"*"},
+								Scope:       &scope,
+							},
+						},
+					},
+				},
+			},
+			FailurePolicy: &failurePolicy,
+		},
+	}
+
+	v1VAP, err := v1beta1ToV1(v1beta1VAP)
+	require.NoError(t, err)
+	require.NotNil(t, v1VAP.Spec.MatchConstraints)
+	require.Len(t, v1VAP.Spec.MatchConstraints.ResourceRules, 1)
+	require.Equal(t, &scope, v1VAP.Spec.MatchConstraints.ResourceRules[0].Scope)
+}
+
 func TestReconcile_VAPV1Beta1RecreatedWhenDeleted(t *testing.T) {
 	ctx, c := setupVersionPinnedReconcileTest(t, &admissionregistrationv1beta1.SchemeGroupVersion)
 	suffix := "VapV1Beta1ShouldBeRecreated"

--- a/pkg/drivers/k8scel/transform/make_vap_objects.go
+++ b/pkg/drivers/k8scel/transform/make_vap_objects.go
@@ -166,6 +166,7 @@ func buildDefaultMatchConstraints() *admissionregistrationv1beta1.MatchResources
 						APIGroups:   []string{"*"},
 						APIVersions: []string{"*"},
 						Resources:   []string{"*"},
+						Scope:       ptr.To(admissionregistrationv1beta1.AllScopes),
 					},
 				},
 			},

--- a/pkg/drivers/k8scel/transform/make_vap_objects_test.go
+++ b/pkg/drivers/k8scel/transform/make_vap_objects_test.go
@@ -67,7 +67,12 @@ func TestTemplateToPolicyDefinition(t *testing.T) {
 							{
 								RuleWithOperations: admissionregistrationv1beta1.RuleWithOperations{
 									Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Create, admissionregistrationv1beta1.Update},
-									Rule:       admissionregistrationv1beta1.Rule{APIGroups: []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*"}},
+									Rule: admissionregistrationv1beta1.Rule{
+										APIGroups:   []string{"*"},
+										APIVersions: []string{"*"},
+										Resources:   []string{"*"},
+										Scope:       ptr.To(admissionregistrationv1beta1.AllScopes),
+									},
 								},
 							},
 						},
@@ -1697,6 +1702,9 @@ func TestBuildDefaultMatchConstraints(t *testing.T) {
 	}
 	if len(rule.Resources) != 1 || rule.Resources[0] != "*" {
 		t.Errorf("expected wildcard Resources, got %v", rule.Resources)
+	}
+	if rule.Scope == nil || *rule.Scope != admissionregistrationv1beta1.AllScopes {
+		t.Errorf("expected all scopes, got %v", rule.Scope)
 	}
 }
 


### PR DESCRIPTION
(cherry-picked from 80050b0)
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
