### PR TITLE
fix: surface namespace cache errors and avoid redundant VAP status updates (CP #4656, CP #4703)

### DIFF
--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -40,10 +40,10 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
-	errorpkg "github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -257,6 +257,22 @@ func add(mgr manager.Manager, r reconcile.Reconciler, events <-chan event.Generi
 
 var _ reconcile.Reconciler = &ReconcileConstraint{}
 
+type reportedStatusError struct {
+	err     error
+	message string
+}
+
+func (e *reportedStatusError) Error() string { return e.err.Error() }
+func (e *reportedStatusError) Unwrap() error { return e.err }
+
+type combinedStatusError struct {
+	message string
+	errs    []error
+}
+
+func (e *combinedStatusError) Error() string   { return e.message }
+func (e *combinedStatusError) Unwrap() []error { return e.errs }
+
 // ReconcileConstraint reconciles an arbitrary constraint object described by Kind.
 type ReconcileConstraint struct {
 	reader       client.Reader
@@ -281,7 +297,7 @@ type ReconcileConstraint struct {
 
 // Reconcile reads that state of the cluster for a constraint object and makes changes based on the state read
 // and what is in the constraint.Spec.
-func (r *ReconcileConstraint) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileConstraint) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, reconcileErr error) {
 	gvk, unpackedRequest, err := util.UnpackRequest(request)
 	if err != nil {
 		// Unrecoverable, do not retry.
@@ -340,6 +356,43 @@ func (r *ReconcileConstraint) Reconcile(ctx context.Context, request reconcile.R
 			log.Info("could not get/create pod status object", "error", err)
 			return reconcile.Result{}, err
 		}
+		oldStatus := status.Status.DeepCopy()
+		var statusBeforeVAPB *constraintstatusv1beta1.ConstraintPodStatusStatus
+		defer func() {
+			var reportedErr *reportedStatusError
+			reported := errors.As(reconcileErr, &reportedErr)
+			if reconcileErr != nil && !reported {
+				if statusBeforeVAPB == nil {
+					return
+				}
+				status.Status = *statusBeforeVAPB.DeepCopy()
+			}
+			if reconcileErr == nil && statusBeforeVAPB == nil {
+				return
+			}
+
+			if persistErr := r.persistPodStatus(ctx, status, oldStatus); persistErr != nil {
+				baseStatusChanged := statusBeforeVAPB != nil && !apiequality.Semantic.DeepEqual(*statusBeforeVAPB, *oldStatus)
+				switch {
+				case baseStatusChanged:
+					result = reconcile.Result{Requeue: true}
+					reconcileErr = nil
+				case reported:
+					log.Error(persistErr, reportedErr.message, "error", "could not update constraint status")
+					reconcileErr = &combinedStatusError{
+						message: fmt.Sprintf("%s, could not update constraint status: %s: %s", reportedErr.message, persistErr, reportedErr.err),
+						errs:    []error{reportedErr.err, persistErr},
+					}
+				default:
+					reconcileErr = persistErr
+				}
+				return
+			}
+			if reported {
+				reconcileErr = reportedErr.err
+			}
+		}()
+
 		status.Status.ConstraintUID = instance.GetUID()
 		status.Status.ObservedGeneration = instance.GetGeneration()
 		status.Status.Errors = nil
@@ -362,9 +415,7 @@ func (r *ReconcileConstraint) Reconcile(ctx context.Context, request reconcile.R
 		}
 
 		status.Status.Enforced = true
-		if err = r.writer.Update(ctx, status); err != nil {
-			return reconcile.Result{Requeue: true}, nil
-		}
+		statusBeforeVAPB = status.Status.DeepCopy()
 
 		// adding constraint to cache and sending metrics
 		r.constraintsCache.addConstraintKey(constraintKey, tags{
@@ -569,13 +620,16 @@ func (r *ReconcileConstraint) cacheConstraint(ctx context.Context, instance *uns
 	return nil
 }
 
-func (r *ReconcileConstraint) reportErrorOnConstraintStatus(ctx context.Context, status *constraintstatusv1beta1.ConstraintPodStatus, err error, message string) error {
+func (r *ReconcileConstraint) reportErrorOnConstraintStatus(_ context.Context, status *constraintstatusv1beta1.ConstraintPodStatus, err error, message string) error {
 	status.Status.Errors = append(status.Status.Errors, constraintstatusv1beta1.Error{Message: fmt.Sprintf("%s: %s", message, err)})
-	if err2 := r.writer.Update(ctx, status); err2 != nil {
-		log.Error(err2, message, "error", "could not update constraint status")
-		return errorpkg.Wrapf(err, "%s", fmt.Sprintf("%s, could not update constraint status: %s", message, err2))
+	return &reportedStatusError{err: err, message: message}
+}
+
+func (r *ReconcileConstraint) persistPodStatus(ctx context.Context, status *constraintstatusv1beta1.ConstraintPodStatus, oldStatus *constraintstatusv1beta1.ConstraintPodStatusStatus) error {
+	if apiequality.Semantic.DeepEqual(status.Status, *oldStatus) {
+		return nil
 	}
-	return err
+	return r.writer.Update(ctx, status)
 }
 
 func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction util.EnforcementAction, instance *unstructured.Unstructured, status *constraintstatusv1beta1.ConstraintPodStatus) (time.Duration, error) {
@@ -599,8 +653,37 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 	}
 	intendsVAPB := shouldGenerateVAPB
 
-	isAPIEnabled, groupVersion := transform.IsVapAPIEnabled(&log)
 	generationPathSetStatus := false
+	if shouldGenerateVAPB {
+		unversionedCT := &templates.ConstraintTemplate{}
+		if err := r.scheme.Convert(ct, unversionedCT, nil); err != nil {
+			r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
+			return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, "could not convert ConstraintTemplate to unversioned")
+		}
+		hasVAP, err := ShouldGenerateVAP(unversionedCT)
+		switch {
+		case errors.Is(err, celSchema.ErrCELEngineMissing):
+			updateEnforcementPointStatus(status, util.VAPEnforcementPoint, ErrGenerateVAPBState, err.Error(), instance.GetGeneration())
+			r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
+			generationPathSetStatus = true
+			shouldGenerateVAPB = false
+		case err != nil:
+			log.Error(err, "could not determine if ConstraintTemplate is configured to generate ValidatingAdmissionPolicy", "constraint", instance.GetName(), "constraint_template", unversionedCT.GetName())
+			r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
+			status.Status.Errors = append(status.Status.Errors, constraintstatusv1beta1.Error{Message: fmt.Sprintf("could not determine if ConstraintTemplate is configured to generate ValidatingAdmissionPolicy: %s", err)})
+			shouldGenerateVAPB = false
+		case !hasVAP:
+			log.Error(ErrVAPConditionsNotSatisfied, "Cannot generate ValidatingAdmissionPolicyBinding", "constraint", instance.GetName(), "constraint_template", unversionedCT.GetName())
+			r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
+			status.Status.Errors = append(status.Status.Errors, constraintstatusv1beta1.Error{Message: fmt.Sprintf("cannot generate ValidatingAdmissionPolicyBinding: %s", ErrVAPConditionsNotSatisfied)})
+			shouldGenerateVAPB = false
+		default:
+			cleanEnforcementPointStatusWithState(status, util.VAPEnforcementPoint, ErrGenerateVAPBState)
+		}
+	}
+
+	// The API version is also needed to remove a stale VAPB when generation is no longer eligible.
+	isAPIEnabled, groupVersion := transform.IsVapAPIEnabled(&log)
 	if shouldGenerateVAPB {
 		if !isAPIEnabled {
 			log.Error(ErrValidatingAdmissionPolicyAPIDisabled, "Cannot generate ValidatingAdmissionPolicyBinding", "constraint", instance.GetName())
@@ -608,50 +691,23 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 			status.Status.Errors = append(status.Status.Errors, constraintstatusv1beta1.Error{Message: fmt.Sprintf("cannot generate ValidatingAdmissionPolicyBinding: %s", ErrValidatingAdmissionPolicyAPIDisabled)})
 			shouldGenerateVAPB = false
 		} else {
-			unversionedCT := &templates.ConstraintTemplate{}
-			if err := r.scheme.Convert(ct, unversionedCT, nil); err != nil {
-				r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
-				return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, "could not convert ConstraintTemplate to unversioned")
+			// reconcile for vapb generation if annotation is not set
+			if ct.Annotations == nil || (ct.Annotations[BlockVAPBGenerationUntilAnnotation] == "" && ct.Annotations[VAPBGenerationAnnotation] != "unblocked") {
+				return noDelay, r.reportErrorOnConstraintStatus(ctx, status, errors.New("annotation to wait for ValidatingAdmissionPolicyBinding generation not found"), "could not find annotation to wait for ValidatingAdmissionPolicyBinding generation")
 			}
-			hasVAP, err := ShouldGenerateVAP(unversionedCT)
-			switch {
-			case errors.Is(err, celSchema.ErrCELEngineMissing):
-				updateEnforcementPointStatus(status, util.VAPEnforcementPoint, ErrGenerateVAPBState, err.Error(), instance.GetGeneration())
-				r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
-				generationPathSetStatus = true
-				shouldGenerateVAPB = false
-			case err != nil:
-				log.Error(err, "could not determine if ConstraintTemplate is configured to generate ValidatingAdmissionPolicy", "constraint", instance.GetName(), "constraint_template", unversionedCT.GetName())
-				r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
-				status.Status.Errors = append(status.Status.Errors, constraintstatusv1beta1.Error{Message: fmt.Sprintf("could not determine if ConstraintTemplate is configured to generate ValidatingAdmissionPolicy: %s", err)})
-				shouldGenerateVAPB = false
-			case !hasVAP:
-				log.Error(ErrVAPConditionsNotSatisfied, "Cannot generate ValidatingAdmissionPolicyBinding", "constraint", instance.GetName(), "constraint_template", unversionedCT.GetName())
-				r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
-				status.Status.Errors = append(status.Status.Errors, constraintstatusv1beta1.Error{Message: fmt.Sprintf("cannot generate ValidatingAdmissionPolicyBinding: %s", ErrVAPConditionsNotSatisfied)})
-				shouldGenerateVAPB = false
-			default:
-				// reconcile for vapb generation if annotation is not set
-				if ct.Annotations == nil || (ct.Annotations[BlockVAPBGenerationUntilAnnotation] == "" && ct.Annotations[VAPBGenerationAnnotation] != "unblocked") {
-					return noDelay, r.reportErrorOnConstraintStatus(ctx, status, errors.New("annotation to wait for ValidatingAdmissionPolicyBinding generation not found"), "could not find annotation to wait for ValidatingAdmissionPolicyBinding generation")
-				}
 
-				if ct.Annotations[VAPBGenerationAnnotation] == "" || ct.Annotations[VAPBGenerationAnnotation] == VAPBGenerationBlocked {
-					// waiting for sometime before generating vapbinding, gives api-server time to cache CRDs
-					timestamp := ct.Annotations[BlockVAPBGenerationUntilAnnotation]
-					t, err := time.Parse(time.RFC3339, timestamp)
-					if err != nil {
-						r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
-						return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, "could not parse timestamp")
-					}
-					if t.After(time.Now()) {
-						wait := time.Until(t)
-						changed := updateEnforcementPointStatus(status, util.VAPEnforcementPoint, WaitVAPBState, fmt.Sprintf("waiting until %s before generating ValidatingAdmissionPolicyBinding to make sure api-server has cached constraint CRD", timestamp), instance.GetGeneration())
-						if !changed {
-							return wait, nil
-						}
-						return wait, r.writer.Update(ctx, status)
-					}
+			if ct.Annotations[VAPBGenerationAnnotation] == "" || ct.Annotations[VAPBGenerationAnnotation] == VAPBGenerationBlocked {
+				// waiting for sometime before generating vapbinding, gives api-server time to cache CRDs
+				timestamp := ct.Annotations[BlockVAPBGenerationUntilAnnotation]
+				t, err := time.Parse(time.RFC3339, timestamp)
+				if err != nil {
+					r.reporter.ReportVAPBStatus(vapBindingKey, metrics.VAPStatusError)
+					return noDelay, r.reportErrorOnConstraintStatus(ctx, status, err, "could not parse timestamp")
+				}
+				if t.After(time.Now()) {
+					wait := time.Until(t)
+					updateEnforcementPointStatus(status, util.VAPEnforcementPoint, WaitVAPBState, fmt.Sprintf("waiting until %s before generating ValidatingAdmissionPolicyBinding to make sure api-server has cached constraint CRD", timestamp), instance.GetGeneration())
+					return wait, nil
 				}
 			}
 		}
@@ -749,7 +805,7 @@ func (r *ReconcileConstraint) manageVAPB(ctx context.Context, enforcementAction 
 			r.reporter.DeleteVAPBStatus(vapBindingKey)
 		}
 	}
-	return noDelay, r.writer.Update(ctx, status)
+	return noDelay, nil
 }
 
 func (r *ReconcileConstraint) deleteVAPBIfOwned(ctx context.Context, vapBinding client.Object, instance *unstructured.Unstructured, vapBindingName string) error {
@@ -976,6 +1032,15 @@ func updateEnforcementPointStatus(status *constraintstatusv1beta1.ConstraintPodS
 func cleanEnforcementPointStatus(status *constraintstatusv1beta1.ConstraintPodStatus, enforcementPoint string) {
 	for i, ep := range status.Status.EnforcementPointsStatus {
 		if ep.EnforcementPoint == enforcementPoint {
+			status.Status.EnforcementPointsStatus = append(status.Status.EnforcementPointsStatus[:i], status.Status.EnforcementPointsStatus[i+1:]...)
+			return
+		}
+	}
+}
+
+func cleanEnforcementPointStatusWithState(status *constraintstatusv1beta1.ConstraintPodStatus, enforcementPoint, state string) {
+	for i, ep := range status.Status.EnforcementPointsStatus {
+		if ep.EnforcementPoint == enforcementPoint && ep.State == state {
 			status.Status.EnforcementPointsStatus = append(status.Status.EnforcementPointsStatus[:i], status.Status.EnforcementPointsStatus[i+1:]...)
 			return
 		}

--- a/pkg/controller/constraint/constraint_controller_test.go
+++ b/pkg/controller/constraint/constraint_controller_test.go
@@ -13,16 +13,21 @@ import (
 	apiconstraints "github.com/open-policy-agent/frameworks/constraint/pkg/apis/constraints"
 	templatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	templatesv1beta1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1beta1"
+	constraintclient "github.com/open-policy-agent/frameworks/constraint/pkg/client"
+	regodriver "github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/rego"
 	regoSchema "github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/rego/schema"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/core/templates"
 	constraintstatusv1beta1 "github.com/open-policy-agent/gatekeeper/v3/apis/status/v1beta1"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel"
 	celSchema "github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel/schema"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel/transform"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/metrics"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/target"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -32,6 +37,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func makeTemplateWithRegoAndCELEngine(vapGenerationVal *bool) *templates.ConstraintTemplate {
@@ -525,9 +531,7 @@ func TestShouldGenerateVAP(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			origDefault := GetDefaultGenerateVAP()
-			SetDefaultGenerateVAP(test.vapDefault)
-			t.Cleanup(func() { SetDefaultGenerateVAP(origDefault) })
+			configureVAP(t, vapTestConfig{defaultGenerateVAP: ptr.To(test.vapDefault)})
 			generateVAP, err := ShouldGenerateVAP(test.template)
 			if generateVAP != test.expected {
 				t.Errorf("wanted assumeVAP to be %v; got %v", test.expected, generateVAP)
@@ -540,93 +544,57 @@ func TestShouldGenerateVAP(t *testing.T) {
 }
 
 func TestReportErrorOnConstraintStatus(t *testing.T) {
+	status := &constraintstatusv1beta1.ConstraintPodStatus{
+		Status: constraintstatusv1beta1.ConstraintPodStatusStatus{
+			Errors: []constraintstatusv1beta1.Error{{Message: "existing error"}},
+		},
+	}
+	r := &ReconcileConstraint{}
+	testErr := errors.New("test error")
+
+	if err := r.reportErrorOnConstraintStatus(context.Background(), status, testErr, "test message"); !errors.Is(err, testErr) {
+		t.Fatalf("expected original error %v, got %v", testErr, err)
+	}
+	expected := []constraintstatusv1beta1.Error{
+		{Message: "existing error"},
+		{Message: "test message: test error"},
+	}
+	if !reflect.DeepEqual(status.Status.Errors, expected) {
+		t.Fatalf("expected status errors %v, got %v", expected, status.Status.Errors)
+	}
+}
+
+func TestPersistPodStatus(t *testing.T) {
 	tests := []struct {
-		name                   string
-		status                 *constraintstatusv1beta1.ConstraintPodStatus
-		err                    error
-		message                string
-		updateErr              error
-		expectedError          error
-		expectedStatusErrorLen int
-		expectedStatusError    []constraintstatusv1beta1.Error
+		name        string
+		change      bool
+		writeErr    error
+		wantUpdates int
+		wantErr     bool
 	}{
-		{
-			name: "successful update",
-			status: &constraintstatusv1beta1.ConstraintPodStatus{
-				Status: constraintstatusv1beta1.ConstraintPodStatusStatus{},
-			},
-			err:                    errors.New("test error"),
-			message:                "test message",
-			updateErr:              nil,
-			expectedError:          errors.New("test error"),
-			expectedStatusErrorLen: 1,
-			expectedStatusError: []constraintstatusv1beta1.Error{
-				{
-					Message: "test error",
-				},
-			},
-		},
-		{
-			name: "update error",
-			status: &constraintstatusv1beta1.ConstraintPodStatus{
-				Status: constraintstatusv1beta1.ConstraintPodStatusStatus{},
-			},
-			err:                    errors.New("test error"),
-			message:                "test message",
-			updateErr:              errors.New("update error"),
-			expectedError:          errors.New("test message, could not update constraint status: update error: test error"),
-			expectedStatusErrorLen: 1,
-			expectedStatusError: []constraintstatusv1beta1.Error{
-				{
-					Message: "test error",
-				},
-			},
-		},
-		{
-			name: "append status error",
-			status: &constraintstatusv1beta1.ConstraintPodStatus{
-				Status: constraintstatusv1beta1.ConstraintPodStatusStatus{
-					Errors: []constraintstatusv1beta1.Error{
-						{
-							Message: "existing error",
-						},
-					},
-				},
-			},
-			err:                    errors.New("test error"),
-			message:                "test message",
-			updateErr:              nil,
-			expectedError:          errors.New("test error"),
-			expectedStatusErrorLen: 2,
-			expectedStatusError: []constraintstatusv1beta1.Error{
-				{
-					Message: "existing error",
-				},
-				{
-					Message: "test error",
-				},
-			},
-		},
+		{name: "unchanged"},
+		{name: "changed", change: true, wantUpdates: 1},
+		{name: "update error", change: true, writeErr: errors.New("update error"), wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			writer := &fakeWriter{updateErr: tt.updateErr}
-			r := &ReconcileConstraint{
-				writer: writer,
+			status := &constraintstatusv1beta1.ConstraintPodStatus{
+				Status: constraintstatusv1beta1.ConstraintPodStatusStatus{ID: "test-pod"},
 			}
-
-			err := r.reportErrorOnConstraintStatus(context.TODO(), tt.status, tt.err, tt.message)
-			if err == nil || err.Error() != tt.expectedError.Error() {
-				t.Errorf("expected error %v, got %v", tt.expectedError, err)
+			oldStatus := status.Status.DeepCopy()
+			if tt.change {
+				status.Status.Enforced = true
 			}
+			writer := &trackingWriter{fakeWriter: fakeWriter{updateErr: tt.writeErr}}
+			r := &ReconcileConstraint{writer: writer}
 
-			if len(tt.status.Status.Errors) != tt.expectedStatusErrorLen {
-				t.Errorf("expected %d error in status, got %d", tt.expectedStatusErrorLen, len(tt.status.Status.Errors))
+			err := r.persistPodStatus(context.Background(), status, oldStatus)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("persistPodStatus() error = %v, wantErr %v", err, tt.wantErr)
 			}
-
-			if reflect.DeepEqual(tt.status.Status.Errors, tt.expectedStatusError) {
-				t.Errorf("expected status errors %v, got %v", tt.expectedStatusError, tt.status.Status.Errors)
+			if len(writer.updatedObjects) != tt.wantUpdates {
+				t.Fatalf("expected %d updates, got %d", tt.wantUpdates, len(writer.updatedObjects))
 			}
 		})
 	}
@@ -746,7 +714,6 @@ func TestEventPackerMapFuncFromOwnerRefs_ValidOwner(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("expected 1 request, got %d", len(got))
 	}
-	// Expect packed name format: gvk:Kind.Version.Group:Name
 	expectedPrefix := "gvk:MyConstraint.v1beta1.constraints.gatekeeper.sh:"
 	if got[0].Name[:len(expectedPrefix)] != expectedPrefix {
 		t.Fatalf("packed name not as expected: %s", got[0].Name)
@@ -796,6 +763,18 @@ func (f *fakeReader) Get(_ context.Context, key types.NamespacedName, obj client
 	}
 	// Copy stored object data into the output parameter.
 	switch dst := obj.(type) {
+	case *unstructured.Unstructured:
+		src, ok := stored.(*unstructured.Unstructured)
+		if !ok {
+			return fmt.Errorf("type mismatch: expected *unstructured.Unstructured, got %T", stored)
+		}
+		*dst = *src.DeepCopy()
+	case *constraintstatusv1beta1.ConstraintPodStatus:
+		src, ok := stored.(*constraintstatusv1beta1.ConstraintPodStatus)
+		if !ok {
+			return fmt.Errorf("type mismatch: expected *constraintstatusv1beta1.ConstraintPodStatus, got %T", stored)
+		}
+		*dst = *src.DeepCopy()
 	case *templatesv1beta1.ConstraintTemplate:
 		src, ok := stored.(*templatesv1beta1.ConstraintTemplate)
 		if !ok {
@@ -821,16 +800,28 @@ func (f *fakeReader) List(_ context.Context, _ client.ObjectList, _ ...client.Li
 // trackingWriter records Delete calls for assertions.
 type trackingWriter struct {
 	fakeWriter
-	deletedObjects []client.Object
-	createdObjects []client.Object
-	updatedObjects []client.Object
+	reader                      *fakeReader
+	statusUpdateErr             error
+	statusUpdateErrOnlyOnErrors bool
+	createAttempts              int
+	updateAttempts              int
+	deletedObjects              []client.Object
+	createdObjects              []client.Object
+	updatedObjects              []client.Object
 }
 
 func (t *trackingWriter) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	t.updateAttempts++
+	if status, ok := obj.(*constraintstatusv1beta1.ConstraintPodStatus); ok && t.statusUpdateErr != nil {
+		if !t.statusUpdateErrOnlyOnErrors || len(status.Status.Errors) > 0 {
+			return t.statusUpdateErr
+		}
+	}
 	if err := t.fakeWriter.Update(ctx, obj, opts...); err != nil {
 		return err
 	}
 	t.updatedObjects = append(t.updatedObjects, obj)
+	t.store(obj)
 	return nil
 }
 
@@ -839,9 +830,25 @@ func (t *trackingWriter) Delete(_ context.Context, obj client.Object, _ ...clien
 	return nil
 }
 
-func (t *trackingWriter) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
+func (t *trackingWriter) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	t.createAttempts++
+	if err := t.fakeWriter.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
 	t.createdObjects = append(t.createdObjects, obj)
+	t.store(obj)
 	return nil
+}
+
+func (t *trackingWriter) store(obj client.Object) {
+	if t.reader == nil {
+		return
+	}
+	stored, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		panic(fmt.Sprintf("object %T does not implement client.Object after DeepCopyObject", obj))
+	}
+	t.reader.objects[client.ObjectKeyFromObject(obj)] = stored
 }
 
 // fakeReporter implements StatsReporter for testing.
@@ -862,23 +869,286 @@ func (f *fakeReporter) DeleteVAPBStatus(name types.NamespacedName) {
 	delete(f.vapbStatuses, name)
 }
 
+func newConstraintUnitReconciler(t *testing.T, ct *templates.ConstraintTemplate, instance *unstructured.Unstructured) (*ReconcileConstraint, *fakeReader, *trackingWriter, reconcile.Request) {
+	t.Helper()
+	t.Setenv("POD_NAME", "test-pod")
+
+	scheme := runtime.NewScheme()
+	if err := templatesv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := constraintstatusv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := admissionregistrationv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := admissionregistrationv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	versionedCT := &templatesv1beta1.ConstraintTemplate{}
+	if err := scheme.Convert(ct, versionedCT, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	regoDriver, err := regodriver.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	celDriver, err := k8scel.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfClient, err := constraintclient.NewClient(
+		constraintclient.Targets(&target.K8sValidationTarget{}),
+		constraintclient.Driver(regoDriver),
+		constraintclient.Driver(celDriver),
+		constraintclient.EnforcementPoints(util.AuditEnforcementPoint),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cfClient.AddTemplate(context.Background(), ct); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cfClient.AddConstraint(context.Background(), instance.DeepCopy()); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := &fakeReader{
+		objects: map[types.NamespacedName]client.Object{
+			client.ObjectKeyFromObject(instance): instance.DeepCopy(),
+			{Name: versionedCT.GetName()}:        versionedCT,
+		},
+		getErrs: make(map[types.NamespacedName]error),
+	}
+	writer := &trackingWriter{reader: reader}
+	tracker := readiness.NewTracker(reader, false, false, false)
+	trackerCtx, cancelTracker := context.WithCancel(context.Background())
+	t.Cleanup(cancelTracker)
+	go func() {
+		_ = tracker.Run(trackerCtx)
+	}()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: util.GetNamespace()}}
+	r := &ReconcileConstraint{
+		reader:           reader,
+		writer:           writer,
+		scheme:           scheme,
+		cfClient:         cfClient,
+		log:              logf.Log.WithName("test"),
+		reporter:         &fakeReporter{},
+		constraintsCache: NewConstraintsCache(),
+		tracker:          tracker,
+		getPod:           func(context.Context) (*corev1.Pod, error) { return pod, nil },
+		ifWatching:       func(_ schema.GroupVersionKind, fn func() error) (bool, error) { return true, fn() },
+	}
+	requests := util.EventPackerMapFunc()(context.Background(), instance)
+	if len(requests) != 1 {
+		t.Fatalf("expected one packed request, got %d", len(requests))
+	}
+	return r, reader, writer, requests[0]
+}
+
+func makeUnitConstraint() *unstructured.Unstructured {
+	instance := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"enforcementAction": "dryrun",
+		},
+	}}
+	instance.SetGroupVersionKind(schema.GroupVersionKind{Group: constraintstatusv1beta1.ConstraintsGroup, Version: "v1beta1", Kind: "TestKind"})
+	instance.SetName("test-constraint")
+	instance.SetUID("constraint-uid")
+	instance.SetGeneration(1)
+	return instance
+}
+
+type vapTestConfig struct {
+	apiEnabled          *bool
+	defaultGenerateVAP  *bool
+	defaultGenerateVAPB *bool
+}
+
+func configureVAP(t *testing.T, config vapTestConfig) {
+	t.Helper()
+
+	if config.apiEnabled != nil {
+		transform.SetVapAPIEnabled(config.apiEnabled)
+		if *config.apiEnabled {
+			transform.SetGroupVersion(&admissionregistrationv1.SchemeGroupVersion)
+		} else {
+			transform.SetGroupVersion(nil)
+		}
+		t.Cleanup(func() {
+			transform.SetVapAPIEnabled(nil)
+			transform.SetGroupVersion(nil)
+		})
+	}
+
+	if config.defaultGenerateVAP != nil {
+		original := GetDefaultGenerateVAP()
+		SetDefaultGenerateVAP(*config.defaultGenerateVAP)
+		t.Cleanup(func() { SetDefaultGenerateVAP(original) })
+	}
+
+	if config.defaultGenerateVAPB != nil {
+		original := GetDefaultGenerateVAPB()
+		SetDefaultGenerateVAPB(*config.defaultGenerateVAPB)
+		t.Cleanup(func() { SetDefaultGenerateVAPB(original) })
+	}
+}
+
+func makeUnitCELTemplate() *templates.ConstraintTemplate {
+	ct := makeTemplateWithCELEngine(nil)
+	ct.Spec.CRD.Spec.Names.Kind = "TestKind"
+	ct.Spec.Targets[0].Target = target.Name
+	return ct
+}
+
+func TestReconcileStableVAPAPIErrorSkipsStatusUpdate(t *testing.T) {
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(false),
+		defaultGenerateVAP:  ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
+	})
+
+	ct := makeUnitCELTemplate()
+	instance := makeUnitConstraint()
+	r, reader, writer, request := newConstraintUnitReconciler(t, ct, instance)
+
+	firstResult, firstErr := r.Reconcile(context.Background(), request)
+	if firstErr != nil || firstResult != (reconcile.Result{}) {
+		t.Fatalf("expected successful first reconcile, got result=%v error=%v", firstResult, firstErr)
+	}
+	if writer.createAttempts != 1 || writer.updateAttempts != 1 {
+		t.Fatalf("expected one status create and update, got %d creates and %d updates", writer.createAttempts, writer.updateAttempts)
+	}
+
+	secondResult, secondErr := r.Reconcile(context.Background(), request)
+	if secondErr != nil || secondResult != firstResult {
+		t.Fatalf("expected stable second reconcile, got result=%v error=%v", secondResult, secondErr)
+	}
+	if writer.createAttempts != 1 || writer.updateAttempts != 1 {
+		t.Fatalf("expected identical error to skip a second write, got %d creates and %d updates", writer.createAttempts, writer.updateAttempts)
+	}
+
+	statusName, err := constraintstatusv1beta1.KeyForConstraint("test-pod", instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, ok := reader.objects[types.NamespacedName{Name: statusName, Namespace: util.GetNamespace()}].(*constraintstatusv1beta1.ConstraintPodStatus)
+	if !ok {
+		t.Fatalf("expected stored ConstraintPodStatus, got %T", reader.objects[types.NamespacedName{Name: statusName, Namespace: util.GetNamespace()}])
+	}
+	if len(stored.Status.Errors) != 1 || !strings.Contains(stored.Status.Errors[0].Message, ErrValidatingAdmissionPolicyAPIDisabled.Error()) {
+		t.Fatalf("expected one stable VAP API error, got %v", stored.Status.Errors)
+	}
+}
+
+func TestReconcileStatusCreateErrorIsReturned(t *testing.T) {
+	ct := makeUnitCELTemplate()
+	instance := makeUnitConstraint()
+	r, _, writer, request := newConstraintUnitReconciler(t, ct, instance)
+	statusName, err := constraintstatusv1beta1.KeyForConstraint("test-pod", instance)
+	if err != nil {
+		t.Fatal(err)
+	}
+	createErr := apierrors.NewAlreadyExists(schema.GroupResource{Group: constraintstatusv1beta1.GroupVersion.Group, Resource: "constraintpodstatuses"}, statusName)
+	writer.createErr = createErr
+
+	result, err := r.Reconcile(context.Background(), request)
+	if !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("expected status create error %v, got %v", createErr, err)
+	}
+	if result != (reconcile.Result{}) {
+		t.Fatalf("expected empty result for status create error, got %v", result)
+	}
+	if writer.createAttempts != 1 || writer.updateAttempts != 0 {
+		t.Fatalf("expected one create and no updates, got %d creates and %d updates", writer.createAttempts, writer.updateAttempts)
+	}
+}
+
+func TestReconcileBaseStatusUpdateErrorPreservesRequeueBehavior(t *testing.T) {
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(false),
+		defaultGenerateVAP:  ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
+	})
+	ct := makeUnitCELTemplate()
+	instance := makeUnitConstraint()
+	r, _, writer, request := newConstraintUnitReconciler(t, ct, instance)
+	updateErr := apierrors.NewConflict(schema.GroupResource{Group: constraintstatusv1beta1.GroupVersion.Group, Resource: "constraintpodstatuses"}, instance.GetName(), errors.New("conflict"))
+	writer.updateErr = updateErr
+
+	result, err := r.Reconcile(context.Background(), request)
+	if err != nil {
+		t.Fatalf("expected status update failure to preserve nil error, got %v", err)
+	}
+	if result != (reconcile.Result{Requeue: true}) {
+		t.Fatalf("expected explicit requeue for base status update failure, got %v", result)
+	}
+	if writer.createAttempts != 1 || writer.updateAttempts != 1 {
+		t.Fatalf("expected one create and one update attempt, got %d creates and %d updates", writer.createAttempts, writer.updateAttempts)
+	}
+}
+
+func TestReconcilePreservesBothVAPBAndStatusErrors(t *testing.T) {
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(true),
+		defaultGenerateVAP:  ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
+	})
+
+	ct := makeUnitCELTemplate()
+	ct.SetAnnotations(map[string]string{VAPBGenerationAnnotation: VAPBGenerationUnblocked})
+	instance := makeUnitConstraint()
+	r, reader, writer, request := newConstraintUnitReconciler(t, ct, instance)
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: util.GetNamespace()}}
+	status, err := constraintstatusv1beta1.NewConstraintStatusForPod(pod, instance, r.scheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status.Status.ConstraintUID = instance.GetUID()
+	status.Status.ObservedGeneration = instance.GetGeneration()
+	status.Status.Enforced = true
+	writer.store(status)
+
+	reconcileErr := errors.New("get VAPB")
+	persistErr := apierrors.NewConflict(schema.GroupResource{Group: constraintstatusv1beta1.GroupVersion.Group, Resource: "constraintpodstatuses"}, instance.GetName(), errors.New("conflict"))
+	reader.getErrs[types.NamespacedName{Name: transform.GetVAPBindingName(instance.GetKind(), instance.GetName())}] = reconcileErr
+	writer.statusUpdateErr = persistErr
+	writer.statusUpdateErrOnlyOnErrors = true
+
+	result, err := r.Reconcile(context.Background(), request)
+	if result != (reconcile.Result{}) {
+		t.Fatalf("expected empty result for combined error, got %v", result)
+	}
+	if !errors.Is(err, reconcileErr) {
+		t.Fatalf("expected combined error to preserve VAPB error %v, got %v", reconcileErr, err)
+	}
+	if !errors.Is(err, persistErr) {
+		t.Fatalf("expected combined error to preserve status error %v, got %v", persistErr, err)
+	}
+	wantMessage := fmt.Sprintf("could not get ValidatingAdmissionPolicyBinding, could not update constraint status: %s: %s", persistErr, reconcileErr)
+	if err.Error() != wantMessage {
+		t.Fatalf("expected unchanged combined error message %q, got %q", wantMessage, err)
+	}
+	if writer.createAttempts != 0 || writer.updateAttempts != 1 {
+		t.Fatalf("expected no create and one update attempt, got %d creates and %d updates", writer.createAttempts, writer.updateAttempts)
+	}
+}
+
 func TestManageVAPB_CleansUpStaleVAPB(t *testing.T) {
 	// Regression test for https://github.com/open-policy-agent/gatekeeper/issues/4441
 	// When vap.k8s.io is removed from scopedEnforcementActions, the stale VAPB must be deleted.
 
-	// Set up the VAP API as enabled with v1 group version.
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
 	})
-
-	// Ensure DefaultGenerateVAPB is true (default).
-	origDefault := GetDefaultGenerateVAPB()
-	SetDefaultGenerateVAPB(true)
-	t.Cleanup(func() { SetDefaultGenerateVAPB(origDefault) })
 
 	// Constraint with scoped enforcement — only webhook + audit, no vap.k8s.io.
 	instance := &unstructured.Unstructured{
@@ -964,20 +1234,214 @@ func TestManageVAPB_CleansUpStaleVAPB(t *testing.T) {
 	}
 }
 
+func TestManageVAPB_RegoOnlyTemplateSkipsVAPAPIDisabledError(t *testing.T) {
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(false),
+		defaultGenerateVAP:  ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
+	})
+
+	scheme := runtime.NewScheme()
+	if err := templatesv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	ct := &templatesv1beta1.ConstraintTemplate{}
+	if err := scheme.Convert(makeTemplateWithRegoEngine(), ct, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"generation": int64(1),
+				"name":       "test-constraint",
+				"uid":        "12345",
+			},
+			"spec": map[string]interface{}{
+				"enforcementAction": "dryrun",
+			},
+		},
+	}
+
+	writer := &trackingWriter{}
+	status := &constraintstatusv1beta1.ConstraintPodStatus{
+		Status: constraintstatusv1beta1.ConstraintPodStatusStatus{
+			Errors: []constraintstatusv1beta1.Error{{
+				Message: fmt.Sprintf("cannot generate ValidatingAdmissionPolicyBinding: %s", ErrValidatingAdmissionPolicyAPIDisabled),
+			}},
+		},
+	}
+	r := &ReconcileConstraint{
+		reader: &fakeReader{
+			objects: map[types.NamespacedName]client.Object{
+				{Name: "testkind"}: ct,
+			},
+		},
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+		scheme:   scheme,
+	}
+
+	oldStatus := status.Status.DeepCopy()
+	status.Status.Errors = nil
+	requeueAfter, err := r.manageVAPB(context.Background(), util.Dryrun, instance, status)
+	if err != nil {
+		t.Fatalf("manageVAPB returned unexpected error: %v", err)
+	}
+	if requeueAfter != 0 {
+		t.Fatalf("expected no requeue delay, got %s", requeueAfter)
+	}
+	if len(status.Status.Errors) != 0 {
+		t.Fatalf("expected no VAP API error for Rego-only template, got %v", status.Status.Errors)
+	}
+	if len(status.Status.EnforcementPointsStatus) != 1 {
+		t.Fatalf("expected one enforcement point status, got %d", len(status.Status.EnforcementPointsStatus))
+	}
+	if got := status.Status.EnforcementPointsStatus[0]; got.EnforcementPoint != util.VAPEnforcementPoint || got.State != ErrGenerateVAPBState {
+		t.Fatalf("expected VAP enforcement point state %q, got %#v", ErrGenerateVAPBState, got)
+	}
+	if len(writer.updatedObjects) != 0 {
+		t.Fatalf("expected manageVAPB to leave status persistence to Reconcile, got %d updates", len(writer.updatedObjects))
+	}
+	if err := r.persistPodStatus(context.Background(), status, oldStatus); err != nil {
+		t.Fatalf("persistPodStatus returned unexpected error: %v", err)
+	}
+	if len(writer.updatedObjects) != 1 {
+		t.Fatalf("expected one update to replace the stale API error, got %d", len(writer.updatedObjects))
+	}
+
+	oldStatus = status.Status.DeepCopy()
+	status.Status.Errors = nil
+	if _, err := r.manageVAPB(context.Background(), util.Dryrun, instance, status); err != nil {
+		t.Fatalf("second manageVAPB returned unexpected error: %v", err)
+	}
+	if err := r.persistPodStatus(context.Background(), status, oldStatus); err != nil {
+		t.Fatalf("second persistPodStatus returned unexpected error: %v", err)
+	}
+	if len(writer.updatedObjects) != 1 {
+		t.Fatalf("expected stable status to skip a second update, got %d updates", len(writer.updatedObjects))
+	}
+
+	celCT := &templatesv1beta1.ConstraintTemplate{}
+	if err := scheme.Convert(makeTemplateWithCELEngine(nil), celCT, nil); err != nil {
+		t.Fatal(err)
+	}
+	reader, ok := r.reader.(*fakeReader)
+	if !ok {
+		t.Fatalf("expected fake reader, got %T", r.reader)
+	}
+	reader.objects[types.NamespacedName{Name: "testkind"}] = celCT
+
+	oldStatus = status.Status.DeepCopy()
+	status.Status.Errors = nil
+	if _, err := r.manageVAPB(context.Background(), util.Dryrun, instance, status); err != nil {
+		t.Fatalf("CEL-eligible manageVAPB returned unexpected error: %v", err)
+	}
+	apiError := fmt.Sprintf("cannot generate ValidatingAdmissionPolicyBinding: %s", ErrValidatingAdmissionPolicyAPIDisabled)
+	if len(status.Status.Errors) != 1 || status.Status.Errors[0].Message != apiError {
+		t.Fatalf("expected VAP API error %q, got %v", apiError, status.Status.Errors)
+	}
+	for _, ep := range status.Status.EnforcementPointsStatus {
+		if ep.EnforcementPoint == util.VAPEnforcementPoint {
+			t.Fatalf("expected stale missing-CEL enforcement point status to be removed, got %#v", ep)
+		}
+	}
+	if err := r.persistPodStatus(context.Background(), status, oldStatus); err != nil {
+		t.Fatalf("persisting CEL-eligible status returned unexpected error: %v", err)
+	}
+	if len(writer.updatedObjects) != 2 {
+		t.Fatalf("expected one update for the Rego-to-CEL transition, got %d total updates", len(writer.updatedObjects))
+	}
+
+	oldStatus = status.Status.DeepCopy()
+	status.Status.Errors = nil
+	if _, err := r.manageVAPB(context.Background(), util.Dryrun, instance, status); err != nil {
+		t.Fatalf("stable CEL-eligible manageVAPB returned unexpected error: %v", err)
+	}
+	if err := r.persistPodStatus(context.Background(), status, oldStatus); err != nil {
+		t.Fatalf("persisting stable CEL-eligible status returned unexpected error: %v", err)
+	}
+	if len(writer.updatedObjects) != 2 {
+		t.Fatalf("expected stable CEL-eligible status to skip another update, got %d total updates", len(writer.updatedObjects))
+	}
+}
+
+func TestManageVAPB_VAPAPIDisabledStatusIsIdempotent(t *testing.T) {
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(false),
+		defaultGenerateVAP:  ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
+	})
+
+	scheme := runtime.NewScheme()
+	if err := templatesv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	ct := &templatesv1beta1.ConstraintTemplate{}
+	if err := scheme.Convert(makeTemplateWithCELEngine(nil), ct, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	instance := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "constraints.gatekeeper.sh/v1beta1",
+			"kind":       "TestKind",
+			"metadata": map[string]interface{}{
+				"generation": int64(1),
+				"name":       "test-constraint",
+				"uid":        "12345",
+			},
+			"spec": map[string]interface{}{
+				"enforcementAction": "dryrun",
+			},
+		},
+	}
+
+	errorMessage := fmt.Sprintf("cannot generate ValidatingAdmissionPolicyBinding: %s", ErrValidatingAdmissionPolicyAPIDisabled)
+	status := &constraintstatusv1beta1.ConstraintPodStatus{
+		Status: constraintstatusv1beta1.ConstraintPodStatusStatus{
+			Errors: []constraintstatusv1beta1.Error{{Message: errorMessage}},
+		},
+	}
+	oldStatus := status.Status.DeepCopy()
+	status.Status.Errors = nil
+	writer := &trackingWriter{}
+	r := &ReconcileConstraint{
+		reader: &fakeReader{
+			objects: map[types.NamespacedName]client.Object{
+				{Name: "testkind"}: ct,
+			},
+		},
+		writer:   writer,
+		log:      logf.Log.WithName("test"),
+		reporter: &fakeReporter{},
+		scheme:   scheme,
+	}
+
+	if _, err := r.manageVAPB(context.Background(), util.Dryrun, instance, status); err != nil {
+		t.Fatalf("manageVAPB returned unexpected error: %v", err)
+	}
+	if len(status.Status.Errors) != 1 || status.Status.Errors[0].Message != errorMessage {
+		t.Fatalf("expected stable VAP API error %q, got %v", errorMessage, status.Status.Errors)
+	}
+	if err := r.persistPodStatus(context.Background(), status, oldStatus); err != nil {
+		t.Fatalf("persistPodStatus returned unexpected error: %v", err)
+	}
+	if len(writer.updatedObjects) != 0 {
+		t.Fatalf("expected unchanged API-disabled status to skip update, got %d", len(writer.updatedObjects))
+	}
+}
+
 func TestManageVAPB_NoStaleVAPB_NoDelete(t *testing.T) {
 	// When vap.k8s.io is removed and no VAPB exists, Delete should not be called.
 
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
 	})
-
-	origDefault := GetDefaultGenerateVAPB()
-	SetDefaultGenerateVAPB(true)
-	t.Cleanup(func() { SetDefaultGenerateVAPB(origDefault) })
 
 	instance := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1052,17 +1516,10 @@ func TestManageVAPB_SkipsDeleteIfNotOwner(t *testing.T) {
 	// Regression test: a VAPB owned by a different constraint kind with the same name
 	// must NOT be deleted by this constraint's cleanup path.
 
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
 	})
-
-	origDefault := GetDefaultGenerateVAPB()
-	SetDefaultGenerateVAPB(true)
-	t.Cleanup(func() { SetDefaultGenerateVAPB(origDefault) })
 
 	// This constraint does NOT use vap.k8s.io.
 	instance := &unstructured.Unstructured{
@@ -1211,17 +1668,10 @@ func TestManageVAPB_EnforcementPointStatusCleanup(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-			transform.SetVapAPIEnabled(ptr.To(true))
-			transform.SetGroupVersion(&gv)
-			t.Cleanup(func() {
-				transform.SetVapAPIEnabled(nil)
-				transform.SetGroupVersion(nil)
+			configureVAP(t, vapTestConfig{
+				apiEnabled:          ptr.To(true),
+				defaultGenerateVAPB: ptr.To(true),
 			})
-
-			origDefault := GetDefaultGenerateVAPB()
-			SetDefaultGenerateVAPB(true)
-			t.Cleanup(func() { SetDefaultGenerateVAPB(origDefault) })
 
 			epName := util.WebhookEnforcementPoint
 			if tt.useVAPEnforcement {
@@ -1327,21 +1777,10 @@ func TestManageVAPB_EnforcementPointStatusCleanup(t *testing.T) {
 }
 
 func TestManageVAPB_WaitStatusIsIdempotent(t *testing.T) {
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
-	})
-
-	origGenerateVAP := *DefaultGenerateVAP
-	origGenerateVAPB := *DefaultGenerateVAPB
-	*DefaultGenerateVAP = true
-	*DefaultGenerateVAPB = true
-	t.Cleanup(func() {
-		*DefaultGenerateVAP = origGenerateVAP
-		*DefaultGenerateVAPB = origGenerateVAPB
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(true),
+		defaultGenerateVAP:  ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
 	})
 
 	scheme := runtime.NewScheme()
@@ -1404,8 +1843,8 @@ func TestManageVAPB_WaitStatusIsIdempotent(t *testing.T) {
 	if requeueAfter <= 0 {
 		t.Fatalf("expected positive requeue delay while VAPB generation is blocked, got %s", requeueAfter)
 	}
-	if len(writer.updatedObjects) != 1 {
-		t.Fatalf("expected first wait reconcile to update status once, got %d updates", len(writer.updatedObjects))
+	if len(writer.updatedObjects) != 0 {
+		t.Fatalf("expected manageVAPB to leave status persistence to Reconcile, got %d updates", len(writer.updatedObjects))
 	}
 	if len(status.Status.EnforcementPointsStatus) != 1 {
 		t.Fatalf("expected one enforcement point status, got %d", len(status.Status.EnforcementPointsStatus))
@@ -1426,8 +1865,8 @@ func TestManageVAPB_WaitStatusIsIdempotent(t *testing.T) {
 	if requeueAfter <= 0 {
 		t.Fatalf("expected positive requeue delay on second wait reconcile, got %s", requeueAfter)
 	}
-	if len(writer.updatedObjects) != 1 {
-		t.Fatalf("expected second wait reconcile to skip unchanged status update, got %d total updates", len(writer.updatedObjects))
+	if len(writer.updatedObjects) != 0 {
+		t.Fatalf("expected manageVAPB to leave status persistence to Reconcile, got %d total updates", len(writer.updatedObjects))
 	}
 	if !reflect.DeepEqual(beforeSecondReconcile.Status, status.Status) {
 		t.Fatalf("expected second wait reconcile to leave status unchanged; diff: %s", spew.Sdump(status.Status))
@@ -1435,17 +1874,10 @@ func TestManageVAPB_WaitStatusIsIdempotent(t *testing.T) {
 }
 
 func TestManageVAPB_PreservesErrorMetricWhenGenerationFails(t *testing.T) {
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
+	configureVAP(t, vapTestConfig{
+		apiEnabled:          ptr.To(true),
+		defaultGenerateVAPB: ptr.To(true),
 	})
-
-	origDefault := GetDefaultGenerateVAPB()
-	SetDefaultGenerateVAPB(true)
-	t.Cleanup(func() { SetDefaultGenerateVAPB(origDefault) })
 
 	instance := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1532,6 +1964,7 @@ func TestManageVAPB_PreservesErrorMetricWhenGenerationFails(t *testing.T) {
 
 type fakeWriter struct {
 	updateErr error
+	createErr error
 }
 
 func (f *fakeWriter) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
@@ -1539,7 +1972,7 @@ func (f *fakeWriter) Update(_ context.Context, _ client.Object, _ ...client.Upda
 }
 
 func (f *fakeWriter) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
-	return nil
+	return f.createErr
 }
 
 func (f *fakeWriter) Delete(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
@@ -1633,13 +2066,7 @@ func TestCleanupLegacyVAPB(t *testing.T) {
 	// When a new-format VAPB has been created, the old-format (legacy) VAPB
 	// owned by the same constraint must be cleaned up.
 
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
-	})
+	gv := admissionregistrationv1.SchemeGroupVersion
 
 	instance := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1702,13 +2129,7 @@ func TestCleanupLegacyVAPB(t *testing.T) {
 func TestCleanupLegacyVAPB_SkipsIfNotOwner(t *testing.T) {
 	// Legacy VAPB owned by a different constraint must NOT be deleted.
 
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
-	})
+	gv := admissionregistrationv1.SchemeGroupVersion
 
 	instance := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1761,13 +2182,7 @@ func TestCleanupLegacyVAPB_SkipsIfNotOwner(t *testing.T) {
 }
 
 func TestCleanupLegacyVAPB_FallsBackToOwnerCoordinatesWhenUIDMissing(t *testing.T) {
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
-	})
+	gv := admissionregistrationv1.SchemeGroupVersion
 
 	instance := &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -1817,13 +2232,7 @@ func TestCleanupLegacyVAPB_FallsBackToOwnerCoordinatesWhenUIDMissing(t *testing.
 }
 
 func TestCleanupLegacyVAPB_SkipsFallbackWhenOwnerCoordinatesDoNotMatch(t *testing.T) {
-	gv := schema.GroupVersion{Group: "admissionregistration.k8s.io", Version: "v1"}
-	transform.SetVapAPIEnabled(ptr.To(true))
-	transform.SetGroupVersion(&gv)
-	t.Cleanup(func() {
-		transform.SetVapAPIEnabled(nil)
-		transform.SetGroupVersion(nil)
-	})
+	gv := admissionregistrationv1.SchemeGroupVersion
 
 	instance := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -42,11 +42,11 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/webhook"
-	errorpkg "github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -281,6 +281,21 @@ func add(mgr manager.Manager, r reconcile.Reconciler, events <-chan event.Generi
 
 var _ reconcile.Reconciler = &ReconcileConstraintTemplate{}
 
+type reportedStatusError struct {
+	err error
+}
+
+func (e *reportedStatusError) Error() string { return e.err.Error() }
+func (e *reportedStatusError) Unwrap() error { return e.err }
+
+type combinedStatusError struct {
+	message string
+	errs    []error
+}
+
+func (e *combinedStatusError) Error() string   { return e.message }
+func (e *combinedStatusError) Unwrap() []error { return e.errs }
+
 // ReconcileConstraintTemplate reconciles a ConstraintTemplate object.
 type ReconcileConstraintTemplate struct {
 	client.Client
@@ -307,7 +322,7 @@ type ReconcileConstraintTemplate struct {
 
 // Reconcile reads that state of the cluster for a ConstraintTemplate object and makes changes based on the state read
 // and what is in the ConstraintTemplate.Spec.
-func (r *ReconcileConstraintTemplate) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileConstraintTemplate) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, reconcileErr error) {
 	logger := logger.WithValues("template_name", request.Name)
 
 	defer r.metrics.registry.report(ctx, r.metrics)
@@ -381,6 +396,34 @@ func (r *ReconcileConstraintTemplate) Reconcile(ctx context.Context, request rec
 		logger.Info("could not get/create pod status object", "error", err)
 		return reconcile.Result{}, err
 	}
+	oldStatus := status.Status.DeepCopy()
+	persistStatus := false
+	persistErrorMessage := ""
+	defer func() {
+		var reportedErr *reportedStatusError
+		reported := errors.As(reconcileErr, &reportedErr)
+		if !reported && !persistStatus {
+			return
+		}
+
+		if persistErr := r.persistPodStatus(ctx, status, oldStatus); persistErr != nil {
+			if reported {
+				reconcileErr = &combinedStatusError{
+					message: fmt.Sprintf("Could not update status: %s: %s", persistErr, reportedErr.err),
+					errs:    []error{reportedErr.err, persistErr},
+				}
+				return
+			}
+			logger.Error(persistErr, persistErrorMessage)
+			result = reconcile.Result{Requeue: true}
+			reconcileErr = nil
+			return
+		}
+		if reported {
+			reconcileErr = reportedErr.err
+		}
+	}()
+
 	status.Status.TemplateUID = ct.GetUID()
 	status.Status.ObservedGeneration = ct.GetGeneration()
 	status.Status.Errors = nil
@@ -394,10 +437,8 @@ func (r *ReconcileConstraintTemplate) Reconcile(ctx context.Context, request rec
 		createErr := &v1beta1.CreateCRDError{Code: ErrCreateCode, Message: err.Error()}
 		status.Status.Errors = append(status.Status.Errors, createErr)
 
-		if updateErr := r.Update(ctx, status); updateErr != nil {
-			logger.Error(updateErr, "update status error")
-			return reconcile.Result{Requeue: true}, nil
-		}
+		persistStatus = true
+		persistErrorMessage = "update status error"
 		logError(request.Name)
 		return reconcile.Result{}, nil
 	}
@@ -433,7 +474,7 @@ func (r *ReconcileConstraintTemplate) Reconcile(ctx context.Context, request rec
 		return reconcile.Result{}, err
 	}
 
-	result, err := r.handleUpdate(ctx, ct, unversionedCT, proposedCRD, currentCRD, status)
+	result, err = r.handleUpdate(ctx, ct, unversionedCT, proposedCRD, currentCRD, status)
 	if err != nil {
 		logger.Error(err, "handle update error")
 		logError(request.Name)
@@ -444,20 +485,26 @@ func (r *ReconcileConstraintTemplate) Reconcile(ctx context.Context, request rec
 		logAction(ct, action)
 		r.metrics.registry.add(request.NamespacedName, metrics.ActiveStatus)
 	}
+	persistStatus = true
+	persistErrorMessage = "update ct pod status error"
 	return result, err
 }
 
-func (r *ReconcileConstraintTemplate) reportErrorOnCTStatus(ctx context.Context, code, message string, status *statusv1beta1.ConstraintTemplatePodStatus, err error) error {
+func (r *ReconcileConstraintTemplate) reportErrorOnCTStatus(_ context.Context, code, message string, status *statusv1beta1.ConstraintTemplatePodStatus, err error) error {
 	status.Status.Errors = []*v1beta1.CreateCRDError{}
 	createErr := &v1beta1.CreateCRDError{
 		Code:    code,
 		Message: fmt.Sprintf("%s: %s", message, err),
 	}
 	status.Status.Errors = append(status.Status.Errors, createErr)
-	if err2 := r.Update(ctx, status); err2 != nil {
-		return errorpkg.Wrap(err, fmt.Sprintf("Could not update status: %s", err2))
+	return &reportedStatusError{err: err}
+}
+
+func (r *ReconcileConstraintTemplate) persistPodStatus(ctx context.Context, status *statusv1beta1.ConstraintTemplatePodStatus, oldStatus *statusv1beta1.ConstraintTemplatePodStatusStatus) error {
+	if apiequality.Semantic.DeepEqual(status.Status, *oldStatus) {
+		return nil
 	}
-	return err
+	return r.Update(ctx, status)
 }
 
 func (r *ReconcileConstraintTemplate) handleUpdate(
@@ -521,10 +568,6 @@ func (r *ReconcileConstraintTemplate) handleUpdate(
 	err = r.manageVAP(ctx, ct, unversionedCT, status, logger, generateVap)
 	if err != nil {
 		return reconcile.Result{}, err
-	}
-	if err := r.Update(ctx, status); err != nil {
-		logger.Error(err, "update ct pod status error")
-		return reconcile.Result{Requeue: true}, nil
 	}
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
@@ -903,8 +946,7 @@ func (r *ReconcileConstraintTemplate) manageVAP(ctx context.Context, ct *v1beta1
 	if generateVap && (!isVapAPIEnabled || groupVersion == nil) {
 		r.metrics.ReportVAPStatus(types.NamespacedName{Name: ct.GetName()}, metrics.VAPStatusError)
 		logger.Error(constraint.ErrValidatingAdmissionPolicyAPIDisabled, "ValidatingAdmissionPolicy resource cannot be generated for ConstraintTemplate", "name", ct.GetName())
-		err := r.reportErrorOnCTStatus(ctx, ErrCreateCode, "ValidatingAdmissionPolicy resource cannot be generated for ConstraintTemplate", status, constraint.ErrValidatingAdmissionPolicyAPIDisabled)
-		return err
+		return r.reportErrorOnCTStatus(ctx, ErrCreateCode, "ValidatingAdmissionPolicy resource cannot be generated for ConstraintTemplate", status, constraint.ErrValidatingAdmissionPolicyAPIDisabled)
 	}
 	// generating VAP resources
 	if generateVap && isVapAPIEnabled && groupVersion != nil {

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller_test.go
@@ -41,6 +41,7 @@ import (
 	celSchema "github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel/schema"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel/transform"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/metrics"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/target"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
@@ -66,7 +67,9 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
@@ -77,6 +80,108 @@ const (
 // globalTestMu serializes access to all global variables (webhook.VwhName, transform.SyncVAPScope)
 // across all constraint template tests to prevent race conditions.
 var globalTestMu sync.Mutex
+
+type statusTrackingClient struct {
+	client.Client
+	creates  int
+	updates  int
+	writeErr error
+}
+
+type reconcileTrackingClient struct {
+	client.Client
+	crdGetErr       error
+	crdUpdateErr    error
+	statusCreateErr error
+	statusUpdateErr error
+	statusCreates   int
+	statusUpdates   int
+}
+
+func (c *reconcileTrackingClient) Get(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*apiextensionsv1.CustomResourceDefinition); ok && c.crdGetErr != nil {
+		return c.crdGetErr
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func (c *reconcileTrackingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if _, ok := obj.(*statusv1beta1.ConstraintTemplatePodStatus); ok {
+		c.statusCreates++
+		if c.statusCreateErr != nil {
+			return c.statusCreateErr
+		}
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+func (c *reconcileTrackingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	switch obj.(type) {
+	case *statusv1beta1.ConstraintTemplatePodStatus:
+		c.statusUpdates++
+		if c.statusUpdateErr != nil {
+			return c.statusUpdateErr
+		}
+	case *apiextensionsv1.CustomResourceDefinition:
+		if c.crdUpdateErr != nil {
+			return c.crdUpdateErr
+		}
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+func newUnitReconciler(t *testing.T, objects ...client.Object) (*ReconcileConstraintTemplate, *reconcileTrackingClient) {
+	t.Helper()
+	testutils.Setenv(t, "POD_NAME", "test-pod")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	require.NoError(t, statusv1beta1.AddToScheme(scheme))
+	require.NoError(t, apiextensionsv1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	baseClient := clientfake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	trackingClient := &reconcileTrackingClient{Client: baseClient}
+
+	regoDriver, err := rego.New(rego.Tracing(true))
+	require.NoError(t, err)
+	celDriver, err := k8scel.New()
+	require.NoError(t, err)
+	cfClient, err := constraintclient.NewClient(
+		constraintclient.Targets(&target.K8sValidationTarget{}),
+		constraintclient.Driver(regoDriver),
+		constraintclient.Driver(celDriver),
+		constraintclient.EnforcementPoints(util.AuditEnforcementPoint),
+	)
+	require.NoError(t, err)
+
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("test-pod"),
+	)
+	tracker := readiness.NewTracker(trackingClient, false, false, false)
+	trackerCtx, cancelTracker := context.WithCancel(context.Background())
+	cancelTracker()
+	require.NoError(t, tracker.Run(trackerCtx))
+	return &ReconcileConstraintTemplate{
+		Client:   trackingClient,
+		scheme:   scheme,
+		cfClient: cfClient,
+		metrics:  newStatsReporter(),
+		tracker:  tracker,
+		getPod:   func(context.Context) (*corev1.Pod, error) { return pod, nil },
+	}, trackingClient
+}
+
+func (c *statusTrackingClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	c.updates++
+	return c.writeErr
+}
+
+func (c *statusTrackingClient) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
+	c.creates++
+	return c.writeErr
+}
 
 func makeReconcileConstraintTemplate(suffix string) *v1beta1.ConstraintTemplate {
 	return &v1beta1.ConstraintTemplate{
@@ -1924,6 +2029,267 @@ func TestReconcile(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+}
+
+func TestPersistPodStatus(t *testing.T) {
+	tests := []struct {
+		name        string
+		change      bool
+		writeErr    error
+		wantUpdates int
+		wantErr     bool
+	}{
+		{name: "unchanged"},
+		{name: "changed", change: true, wantUpdates: 1},
+		{name: "update error", change: true, writeErr: errors.New("update error"), wantUpdates: 1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := &statusv1beta1.ConstraintTemplatePodStatus{
+				Status: statusv1beta1.ConstraintTemplatePodStatusStatus{ID: "test-pod"},
+			}
+			oldStatus := status.Status.DeepCopy()
+			if tt.change {
+				status.Status.ObservedGeneration = 1
+			}
+			trackingClient := &statusTrackingClient{writeErr: tt.writeErr}
+			r := &ReconcileConstraintTemplate{Client: trackingClient}
+
+			err := r.persistPodStatus(context.Background(), status, oldStatus)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("persistPodStatus() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if trackingClient.updates != tt.wantUpdates {
+				t.Fatalf("expected %d updates, got %d", tt.wantUpdates, trackingClient.updates)
+			}
+		})
+	}
+
+	t.Run("recomputed error", func(t *testing.T) {
+		testErr := errors.New("validatingAdmissionPolicy API is not enabled")
+		status := &statusv1beta1.ConstraintTemplatePodStatus{
+			Status: statusv1beta1.ConstraintTemplatePodStatusStatus{
+				Errors: []*v1beta1.CreateCRDError{{
+					Code:    ErrCreateCode,
+					Message: fmt.Sprintf("ValidatingAdmissionPolicy resource cannot be generated for ConstraintTemplate: %s", testErr),
+				}},
+			},
+		}
+		oldStatus := status.Status.DeepCopy()
+		status.Status.Errors = nil
+		trackingClient := &statusTrackingClient{}
+		r := &ReconcileConstraintTemplate{Client: trackingClient}
+
+		if err := r.reportErrorOnCTStatus(context.Background(), ErrCreateCode, "ValidatingAdmissionPolicy resource cannot be generated for ConstraintTemplate", status, testErr); !errors.Is(err, testErr) {
+			t.Fatalf("expected original error %v, got %v", testErr, err)
+		}
+		if err := r.persistPodStatus(context.Background(), status, oldStatus); err != nil {
+			t.Fatalf("persistPodStatus() error = %v", err)
+		}
+		if trackingClient.updates != 0 {
+			t.Fatalf("expected recomputed status to skip update, got %d", trackingClient.updates)
+		}
+	})
+}
+
+func TestReconcileRawErrorPreservesPodStatus(t *testing.T) {
+	ct := makeReconcileConstraintTemplate("RawError")
+	ct.SetUID("template-uid")
+	ct.SetGeneration(2)
+	status := &statusv1beta1.ConstraintTemplatePodStatus{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-" + ct.GetName(),
+			Namespace: util.GetNamespace(),
+		},
+		Status: statusv1beta1.ConstraintTemplatePodStatusStatus{
+			ID:                 "test-pod",
+			TemplateUID:        ct.GetUID(),
+			ObservedGeneration: 1,
+			Errors: []*v1beta1.CreateCRDError{{
+				Code:    ErrCreateCode,
+				Message: "existing error",
+			}},
+		},
+	}
+	r, trackingClient := newUnitReconciler(t, ct, status)
+	getErr := errors.New("get CRD")
+	trackingClient.crdGetErr = getErr
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: ct.GetName()}})
+	if !errors.Is(err, getErr) {
+		t.Fatalf("expected CRD get error %v, got %v", getErr, err)
+	}
+	if trackingClient.statusUpdates != 0 {
+		t.Fatalf("expected raw error to skip status update, got %d", trackingClient.statusUpdates)
+	}
+
+	stored := &statusv1beta1.ConstraintTemplatePodStatus{}
+	require.NoError(t, trackingClient.Client.Get(context.Background(), client.ObjectKeyFromObject(status), stored))
+	if len(stored.Status.Errors) != 1 || stored.Status.Errors[0].Message != "existing error" {
+		t.Fatalf("expected existing status error to be preserved, got %v", stored.Status.Errors)
+	}
+}
+
+func TestReconcileStableReportedErrorSkipsStatusUpdate(t *testing.T) {
+	ct := makeReconcileConstraintTemplate("StableError")
+	ct.Spec.Targets[0].Rego = `
+package foo
+
+violation[{"msg": "denied"}] { 1 == 1 }
+invalid[}}
+`
+	r, trackingClient := newUnitReconciler(t, ct)
+	request := reconcile.Request{NamespacedName: types.NamespacedName{Name: ct.GetName()}}
+
+	firstResult, firstErr := r.Reconcile(context.Background(), request)
+	if firstErr == nil {
+		t.Fatal("expected invalid Rego reconcile error")
+	}
+	if firstResult != (reconcile.Result{}) {
+		t.Fatalf("expected empty result for invalid Rego, got %v", firstResult)
+	}
+	if trackingClient.statusCreates != 1 {
+		t.Fatalf("expected one immediate status create, got %d", trackingClient.statusCreates)
+	}
+	if trackingClient.statusUpdates != 1 {
+		t.Fatalf("expected first reconcile to persist one status update, got %d", trackingClient.statusUpdates)
+	}
+
+	trackingClient.statusUpdates = 0
+	secondResult, secondErr := r.Reconcile(context.Background(), request)
+	if firstResult != secondResult {
+		t.Fatalf("expected stable reconcile result %v, got %v", firstResult, secondResult)
+	}
+	if (firstErr == nil) != (secondErr == nil) {
+		t.Fatalf("expected stable reconcile error, got first=%v second=%v", firstErr, secondErr)
+	}
+	if firstErr.Error() != secondErr.Error() {
+		t.Fatalf("expected stable reconcile error %q, got %q", firstErr, secondErr)
+	}
+	if trackingClient.statusUpdates != 0 {
+		t.Fatalf("expected identical reported error to skip status update, got %d", trackingClient.statusUpdates)
+	}
+
+	statusName, err := statusv1beta1.KeyForConstraintTemplate("test-pod", ct.GetName())
+	require.NoError(t, err)
+	stored := &statusv1beta1.ConstraintTemplatePodStatus{}
+	require.NoError(t, trackingClient.Client.Get(context.Background(), types.NamespacedName{Name: statusName, Namespace: util.GetNamespace()}, stored))
+	if len(stored.Status.Errors) != 1 {
+		t.Fatalf("expected one persisted error, got %v", stored.Status.Errors)
+	}
+}
+
+func TestReconcileStatusCreateErrorIsReturned(t *testing.T) {
+	ct := makeReconcileConstraintTemplate("CreateError")
+	r, trackingClient := newUnitReconciler(t, ct)
+	statusName, err := statusv1beta1.KeyForConstraintTemplate("test-pod", ct.GetName())
+	require.NoError(t, err)
+	createErr := apierrors.NewAlreadyExists(schema.GroupResource{Group: statusv1beta1.GroupVersion.Group, Resource: "constrainttemplatepodstatuses"}, statusName)
+	trackingClient.statusCreateErr = createErr
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: ct.GetName()}})
+	if !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("expected status create error %v, got %v", createErr, err)
+	}
+	if result != (reconcile.Result{}) {
+		t.Fatalf("expected empty result for status create error, got %v", result)
+	}
+	if trackingClient.statusCreates != 1 || trackingClient.statusUpdates != 0 {
+		t.Fatalf("expected one create and no updates, got %d creates and %d updates", trackingClient.statusCreates, trackingClient.statusUpdates)
+	}
+}
+
+func TestReconcileStatusUpdateErrorPreservesRequeueBehavior(t *testing.T) {
+	ct := makeReconcileConstraintTemplate("UpdateError")
+	ct.Spec.Targets[0].Target = "unknown.target"
+	r, trackingClient := newUnitReconciler(t, ct)
+	updateErr := apierrors.NewConflict(schema.GroupResource{Group: statusv1beta1.GroupVersion.Group, Resource: "constrainttemplatepodstatuses"}, ct.GetName(), errors.New("conflict"))
+	trackingClient.statusUpdateErr = updateErr
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: ct.GetName()}})
+	if err != nil {
+		t.Fatalf("expected status update failure to preserve nil error, got %v", err)
+	}
+	if result != (reconcile.Result{Requeue: true}) {
+		t.Fatalf("expected explicit requeue for status update failure, got %v", result)
+	}
+	if trackingClient.statusCreates != 1 || trackingClient.statusUpdates != 1 {
+		t.Fatalf("expected one create and one update attempt, got %d creates and %d updates", trackingClient.statusCreates, trackingClient.statusUpdates)
+	}
+}
+
+func TestReconcilePreservesBothReconcileAndStatusErrors(t *testing.T) {
+	ct := makeReconcileConstraintTemplate("CombinedError")
+	ct.SetUID("template-uid")
+	r, trackingClient := newUnitReconciler(t, ct)
+
+	unversionedCT := &templates.ConstraintTemplate{}
+	require.NoError(t, r.scheme.Convert(ct, unversionedCT, nil))
+	unversionedCRD, err := r.cfClient.CreateCRD(context.Background(), unversionedCT)
+	require.NoError(t, err)
+	currentCRD := &apiextensionsv1.CustomResourceDefinition{}
+	require.NoError(t, r.scheme.Convert(unversionedCRD, currentCRD, nil))
+	require.NoError(t, trackingClient.Client.Create(context.Background(), currentCRD))
+
+	reconcileErr := errors.New("update CRD")
+	persistErr := apierrors.NewConflict(schema.GroupResource{Group: statusv1beta1.GroupVersion.Group, Resource: "constrainttemplatepodstatuses"}, ct.GetName(), errors.New("conflict"))
+	trackingClient.crdUpdateErr = reconcileErr
+	trackingClient.statusUpdateErr = persistErr
+
+	result, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: ct.GetName()}})
+	if result != (reconcile.Result{}) {
+		t.Fatalf("expected empty result for combined error, got %v", result)
+	}
+	if !errors.Is(err, reconcileErr) {
+		t.Fatalf("expected combined error to preserve reconcile error %v, got %v", reconcileErr, err)
+	}
+	if !errors.Is(err, persistErr) {
+		t.Fatalf("expected combined error to preserve status error %v, got %v", persistErr, err)
+	}
+	wantMessage := fmt.Sprintf("Could not update status: %s: %s", persistErr, reconcileErr)
+	if err.Error() != wantMessage {
+		t.Fatalf("expected unchanged combined error message %q, got %q", wantMessage, err)
+	}
+	if trackingClient.statusCreates != 1 || trackingClient.statusUpdates != 1 {
+		t.Fatalf("expected one create and one update attempt, got %d creates and %d updates", trackingClient.statusCreates, trackingClient.statusUpdates)
+	}
+}
+
+func TestManageVAP_VAPAPIDisabledPreservesRetry(t *testing.T) {
+	transform.SetVapAPIEnabled(ptr.To(false))
+	transform.SetGroupVersion(nil)
+	t.Cleanup(func() {
+		transform.SetVapAPIEnabled(nil)
+		transform.SetGroupVersion(nil)
+	})
+
+	ct := makeReconcileConstraintTemplateForVap("VAPAPIDisabled", ptr.To(true), nil)
+	scheme := runtime.NewScheme()
+	require.NoError(t, v1beta1.AddToScheme(scheme))
+	unversionedCT := &templates.ConstraintTemplate{}
+	require.NoError(t, scheme.Convert(ct, unversionedCT, nil))
+
+	status := &statusv1beta1.ConstraintTemplatePodStatus{}
+	trackingClient := &statusTrackingClient{}
+	r := &ReconcileConstraintTemplate{
+		Client:  trackingClient,
+		metrics: &reporter{vapRegistry: metrics.NewVAPStatusRegistry()},
+	}
+
+	err := r.manageVAP(context.Background(), ct, unversionedCT, status, logger, true)
+	if !errors.Is(err, constraint.ErrValidatingAdmissionPolicyAPIDisabled) {
+		t.Fatalf("expected unavailable API error, got %v", err)
+	}
+	if len(status.Status.Errors) != 1 {
+		t.Fatalf("expected one status error, got %d", len(status.Status.Errors))
+	}
+	if got := status.Status.Errors[0].Message; !strings.Contains(got, constraint.ErrValidatingAdmissionPolicyAPIDisabled.Error()) {
+		t.Fatalf("expected unavailable API status error, got %q", got)
+	}
+	if trackingClient.updates != 0 || trackingClient.creates != 0 {
+		t.Fatalf("expected manageVAP to leave persistence to Reconcile, got %d creates and %d updates", trackingClient.creates, trackingClient.updates)
+	}
 }
 
 func TestReconcile_VAPV1Beta1RecreatedWhenDeleted(t *testing.T) {

--- a/pkg/target/ns_cache.go
+++ b/pkg/target/ns_cache.go
@@ -34,7 +34,7 @@ func (c *nsCache) Add(key []string, object interface{}) error {
 
 	ns, err := toNamespace(u)
 	if err != nil {
-		return fmt.Errorf("%w: cannot cache Namespace: %v", ErrCachingType, err)
+		return fmt.Errorf("%w: cannot cache Namespace: %w", ErrCachingType, err)
 	}
 
 	c.AddNamespace(toKey(key), ns)

--- a/pkg/target/ns_cache.go
+++ b/pkg/target/ns_cache.go
@@ -34,7 +34,7 @@ func (c *nsCache) Add(key []string, object interface{}) error {
 
 	ns, err := toNamespace(u)
 	if err != nil {
-		return fmt.Errorf("%w: cannot cache Namespace: %v", ErrCachingType, ns)
+		return fmt.Errorf("%w: cannot cache Namespace: %v", ErrCachingType, err)
 	}
 
 	c.AddNamespace(toKey(key), ns)


### PR DESCRIPTION
**What this PR does / why we need it**:
(cherry picked from commit 68079d03c17ba97c16c2d3e6224a95ea695fd8d7)
(cherry picked from commit 6f898febd48b2e7bc109374a2e92c491e7668b55)

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #

<!--
**Is the PR title following semantic convention?**
Please refer to [Semantic types](https://github.com/open-policy-agent/gatekeeper/blob/master/.github/semantic.yml) to view accepted title convention to satisfy this status check.  
-->

<!--
**Are you making changes to Gatekeeper Helm chart?**
Please refer to [Contributing to Helm Chart](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-helm-chart) for modifying the Helm chart.
-->

<!--
**Are you making changes to Gatekeeper docs?**
Please see [Contributing to Docs](https://open-policy-agent.github.io/gatekeeper/website/docs/help#contributing-to-docs) 
-->

**Special notes for your reviewer**:
