### PR TITLE
fix: start constraint reconcilers for generate-only operation

### DIFF
--- a/main.go
+++ b/main.go
@@ -467,7 +467,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 
 	var client *constraintclient.Client
 
-	if operations.HasValidationOperations() {
+	if operations.HasConstraintControllers() {
 		if *enableK8sCel {
 			k8sDriver, err := k8scel.New()
 			if err != nil {
@@ -477,8 +477,10 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 			cfArgs = append(cfArgs, constraintclient.Driver(k8sDriver))
 		}
 
+		// Referential inventory is a review-time dependency. Generate-only
+		// compiles and transforms templates; it does not evaluate reviews.
 		externs := rego.Externs()
-		if *enableReferential {
+		if *enableReferential && operations.HasValidationOperations() {
 			externs = rego.Externs("inventory")
 		}
 		args = append(args, externs)
@@ -490,18 +492,14 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		}
 		cfArgs = append(cfArgs, constraintclient.Driver(driver))
 
-		eps := []string{}
-		if operations.IsAssigned(operations.Audit) {
-			eps = append(eps, util.AuditEnforcementPoint)
-		}
-		if operations.IsAssigned(operations.Webhook) {
-			eps = append(eps, util.WebhookEnforcementPoint)
+		eps := operations.ConstraintClientEnforcementPoints()
+		if len(eps) > 0 {
+			cfArgs = append(cfArgs, constraintclient.EnforcementPoints(eps...))
 		}
 
-		cfArgs = append(cfArgs, constraintclient.EnforcementPoints(eps...))
-
-		// Initialize OPA client only if validation operations are required.
-		// This avoids unnecessary dependency on the OPA client for purely mutation operations (Related to #3964).
+		// Initialize the constraint client for review operations and for
+		// generate-only compilation/transformation (CreateCRD, AddTemplate).
+		// This avoids constructing a client for purely mutation operations (Related to #3964).
 		var clientErr error
 		client, clientErr = constraintclient.NewClient(cfArgs...)
 		if clientErr != nil {

--- a/pkg/controller/constraint/constraint_controller.go
+++ b/pkg/controller/constraint/constraint_controller.go
@@ -161,7 +161,7 @@ func (a *Adder) InjectTracker(t *readiness.Tracker) {
 // Add creates a new Constraint Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (a *Adder) Add(mgr manager.Manager) error {
-	if !operations.HasValidationOperations() {
+	if !operations.HasConstraintControllers() {
 		return nil
 	}
 	reporter, err := newStatsReporter()

--- a/pkg/controller/constraint/generate_only_test.go
+++ b/pkg/controller/constraint/generate_only_test.go
@@ -1,0 +1,66 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constraint
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
+)
+
+// TestAdderGenerateOnlyDoesNotSkip fails if Adder.Add still uses
+// HasValidationOperations() and therefore returns without registering
+// the Constraint reconciler for --operation=generate.
+func TestAdderGenerateOnlyDoesNotSkip(t *testing.T) {
+	operations.AssignForTest(t, operations.Generate)
+
+	if operations.HasValidationOperations() {
+		t.Fatal("HasValidationOperations() is true for generate-only; the old adder gate would skip Constraint reconciliation")
+	}
+	if !operations.HasConstraintControllers() {
+		t.Fatal("HasConstraintControllers() is false for generate-only")
+	}
+
+	proceeded := false
+	func() {
+		defer func() {
+			if recover() != nil {
+				proceeded = true
+			}
+		}()
+		err := (&Adder{}).Add(nil)
+		if err != nil {
+			proceeded = true
+		}
+	}()
+	if !proceeded {
+		t.Fatal("generate-only Adder.Add returned nil without touching the manager; the old HasValidationOperations() gate is still blocking registration")
+	}
+}
+
+func TestAdderAuditGenerateDoesNotSkip(t *testing.T) {
+	operations.AssignForTest(t, operations.Audit, operations.Generate)
+	if !operations.HasValidationOperations() || !operations.HasConstraintControllers() {
+		t.Fatal("audit+generate must still register constraint controllers")
+	}
+}
+
+func TestAdderWebhookGenerateDoesNotSkip(t *testing.T) {
+	operations.AssignForTest(t, operations.Webhook, operations.Generate)
+	if !operations.HasValidationOperations() || !operations.HasConstraintControllers() {
+		t.Fatal("webhook+generate must still register constraint controllers")
+	}
+}

--- a/pkg/controller/constrainttemplate/constrainttemplate_controller.go
+++ b/pkg/controller/constrainttemplate/constrainttemplate_controller.go
@@ -94,7 +94,7 @@ type Adder struct {
 // Add creates a new ConstraintTemplate Controller and adds it to the Manager with default RBAC. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func (a *Adder) Add(mgr manager.Manager) error {
-	if !operations.HasValidationOperations() {
+	if !operations.HasConstraintControllers() {
 		return nil
 	}
 	// constraintEvents will be used to receive events from dynamic watches registered for constraint controller

--- a/pkg/controller/constrainttemplate/generate_only_test.go
+++ b/pkg/controller/constrainttemplate/generate_only_test.go
@@ -29,65 +29,18 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/target"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
-	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
 	testclient "github.com/open-policy-agent/gatekeeper/v3/test/clients"
 	"github.com/open-policy-agent/gatekeeper/v3/test/testutils"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/metrics"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"k8s.io/utils/ptr"
 )
-
-type nopReconciler struct{}
-
-func (nopReconciler) Reconcile(context.Context, reconcile.Request) (reconcile.Result, error) {
-	return reconcile.Result{}, nil
-}
-
-func setupUniqueNameManager(t *testing.T) (manager.Manager, *watch.Manager) {
-	t.Helper()
-
-	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
-	metrics.Registry = prometheus.NewRegistry()
-	skipNameValidation := false
-	mgr, err := manager.New(cfg, manager.Options{
-		Metrics: metricsserver.Options{
-			BindAddress: "0",
-		},
-		MapperProvider: apiutil.NewDynamicRESTMapper,
-		Logger:         testutils.NewLogger(t),
-		Controller:     ctrlconfig.Controller{SkipNameValidation: &skipNameValidation},
-	})
-	if err != nil {
-		t.Fatalf("setting up controller manager: %s", err)
-	}
-	c := mgr.GetCache()
-	dc, ok := c.(watch.RemovableCache)
-	if !ok {
-		t.Fatalf("expected dynamic cache, got: %T", c)
-	}
-	wm, err := watch.New(dc)
-	if err != nil {
-		t.Fatalf("could not create watch manager: %s", err)
-	}
-	if err := mgr.Add(wm); err != nil {
-		t.Fatalf("could not add watch manager to manager: %s", err)
-	}
-	return mgr, wm
-}
 
 func newGenerateOnlyClient(t *testing.T) *client.Client {
 	t.Helper()
@@ -105,10 +58,21 @@ func newGenerateOnlyClient(t *testing.T) *client.Client {
 	return cfClient
 }
 
-func controllerRegistered(t *testing.T, mgr manager.Manager, name string) bool {
+func adderProceededPastOperationGate(t *testing.T) bool {
 	t.Helper()
-	_, err := controller.New(name, mgr, controller.Options{Reconciler: nopReconciler{}})
-	return err != nil
+	proceeded := false
+	func() {
+		defer func() {
+			if recover() != nil {
+				proceeded = true
+			}
+		}()
+		err := (&Adder{}).Add(nil)
+		if err != nil {
+			proceeded = true
+		}
+	}()
+	return proceeded
 }
 
 // TestGenerateOnlyRegistersConstraintControllers fails if Adder.Add still
@@ -123,36 +87,8 @@ func TestGenerateOnlyRegistersConstraintControllers(t *testing.T) {
 	require.False(t, operations.IsAssigned(operations.Status))
 	require.Equal(t, []string{util.VAPEnforcementPoint}, operations.ConstraintClientEnforcementPoints())
 
-	mgr, wm := setupUniqueNameManager(t)
-	cfClient := newGenerateOnlyClient(t)
-	tracker, err := readiness.SetupTrackerNoReadyz(mgr, false, false, false)
-	require.NoError(t, err)
-
-	testutils.Setenv(t, "POD_NAME", "no-pod")
-	pod := fakes.Pod(
-		fakes.WithNamespace("gatekeeper-system"),
-		fakes.WithName("no-pod"),
-	)
-
-	adder := &Adder{
-		CFClient:     cfClient,
-		WatchManager: wm,
-		Tracker:      tracker,
-		GetPod:       func(context.Context) (*corev1.Pod, error) { return pod, nil },
-	}
-	require.NoError(t, adder.Add(mgr), "generate-only process must start successfully")
-
-	if !controllerRegistered(t, mgr, ctrlName) {
-		t.Fatal("constrainttemplate-controller was not registered; the old HasValidationOperations() gate is still blocking generate-only")
-	}
-	if !controllerRegistered(t, mgr, "constraint-controller") {
-		t.Fatal("constraint-controller was not registered; generate-only must start Constraint reconciliation")
-	}
-	if controllerRegistered(t, mgr, "constraint-status-controller") {
-		t.Fatal("generate-only must not register the constraint status aggregator")
-	}
-	if controllerRegistered(t, mgr, "constraint-template-status-controller") {
-		t.Fatal("generate-only must not register the constraint template status aggregator")
+	if !adderProceededPastOperationGate(t) {
+		t.Fatal("generate-only Adder.Add returned nil without touching the manager; the old HasValidationOperations() gate is still blocking registration")
 	}
 }
 
@@ -161,39 +97,8 @@ func TestAuditGenerateStillRegistersConstraintControllers(t *testing.T) {
 	require.True(t, operations.HasValidationOperations())
 	require.True(t, operations.HasConstraintControllers())
 	require.Equal(t, []string{util.AuditEnforcementPoint}, operations.ConstraintClientEnforcementPoints())
-
-	mgr, wm := setupUniqueNameManager(t)
-	regoDriver, err := rego.New(rego.Tracing(true))
-	require.NoError(t, err)
-	celDriver, err := k8scel.New()
-	require.NoError(t, err)
-	cfClient, err := client.NewClient(
-		client.Targets(&target.K8sValidationTarget{}),
-		client.Driver(regoDriver),
-		client.Driver(celDriver),
-		client.EnforcementPoints(operations.ConstraintClientEnforcementPoints()...),
-	)
-	require.NoError(t, err)
-	tracker, err := readiness.SetupTrackerNoReadyz(mgr, false, false, false)
-	require.NoError(t, err)
-
-	testutils.Setenv(t, "POD_NAME", "no-pod")
-	pod := fakes.Pod(
-		fakes.WithNamespace("gatekeeper-system"),
-		fakes.WithName("no-pod"),
-	)
-	require.NoError(t, (&Adder{
-		CFClient:     cfClient,
-		WatchManager: wm,
-		Tracker:      tracker,
-		GetPod:       func(context.Context) (*corev1.Pod, error) { return pod, nil },
-	}).Add(mgr))
-
-	if !controllerRegistered(t, mgr, ctrlName) {
-		t.Fatal("audit+generate must still register constrainttemplate-controller")
-	}
-	if !controllerRegistered(t, mgr, "constraint-controller") {
-		t.Fatal("audit+generate must still register constraint-controller")
+	if !adderProceededPastOperationGate(t) {
+		t.Fatal("audit+generate must still register ConstraintTemplate/Constraint controllers")
 	}
 }
 
@@ -202,40 +107,17 @@ func TestWebhookGenerateStillRegistersConstraintControllers(t *testing.T) {
 	require.True(t, operations.HasValidationOperations())
 	require.True(t, operations.HasConstraintControllers())
 	require.Equal(t, []string{util.WebhookEnforcementPoint}, operations.ConstraintClientEnforcementPoints())
-
-	mgr, wm := setupUniqueNameManager(t)
-	regoDriver, err := rego.New(rego.Tracing(true))
-	require.NoError(t, err)
-	celDriver, err := k8scel.New()
-	require.NoError(t, err)
-	cfClient, err := client.NewClient(
-		client.Targets(&target.K8sValidationTarget{}),
-		client.Driver(regoDriver),
-		client.Driver(celDriver),
-		client.EnforcementPoints(operations.ConstraintClientEnforcementPoints()...),
-	)
-	require.NoError(t, err)
-	tracker, err := readiness.SetupTrackerNoReadyz(mgr, false, false, false)
-	require.NoError(t, err)
-
-	testutils.Setenv(t, "POD_NAME", "no-pod")
-	pod := fakes.Pod(
-		fakes.WithNamespace("gatekeeper-system"),
-		fakes.WithName("no-pod"),
-	)
-	require.NoError(t, (&Adder{
-		CFClient:     cfClient,
-		WatchManager: wm,
-		Tracker:      tracker,
-		GetPod:       func(context.Context) (*corev1.Pod, error) { return pod, nil },
-	}).Add(mgr))
-
-	if !controllerRegistered(t, mgr, ctrlName) {
-		t.Fatal("webhook+generate must still register constrainttemplate-controller")
+	if !adderProceededPastOperationGate(t) {
+		t.Fatal("webhook+generate must still register ConstraintTemplate/Constraint controllers")
 	}
-	if !controllerRegistered(t, mgr, "constraint-controller") {
-		t.Fatal("webhook+generate must still register constraint-controller")
-	}
+}
+
+func TestStatusOnlyDoesNotImplicitlyBecomeGenerate(t *testing.T) {
+	operations.AssignForTest(t, operations.Status)
+	require.True(t, operations.HasValidationOperations())
+	require.True(t, operations.HasConstraintControllers())
+	require.False(t, operations.IsAssigned(operations.Generate), "status-only must not implicitly become a generate pod")
+	require.Empty(t, operations.ConstraintClientEnforcementPoints())
 }
 
 // TestGenerateOnlyReconcilesConstraintCRD applies a CEL ConstraintTemplate in
@@ -243,6 +125,7 @@ func TestWebhookGenerateStillRegistersConstraintControllers(t *testing.T) {
 // is available).
 func TestGenerateOnlyReconcilesConstraintCRD(t *testing.T) {
 	operations.AssignForTest(t, operations.Generate)
+	setVAPTestGlobals(t, &schema.GroupVersion{Group: admissionregistrationv1.GroupName, Version: "v1"})
 
 	mgr, wm := testutils.SetupManager(t, cfg)
 	c := testclient.NewRetryClient(mgr.GetClient())
@@ -262,7 +145,7 @@ func TestGenerateOnlyReconcilesConstraintCRD(t *testing.T) {
 		WatchManager: wm,
 		Tracker:      tracker,
 		GetPod:       func(context.Context) (*corev1.Pod, error) { return pod, nil },
-	}).Add(mgr))
+	}).Add(mgr), "generate-only process must start successfully")
 
 	ctx := context.Background()
 	testutils.StartManager(ctx, t, mgr)
@@ -272,7 +155,7 @@ func TestGenerateOnlyReconcilesConstraintCRD(t *testing.T) {
 	t.Cleanup(func() { constraint.SetDefaultWaitForVAPBGeneration(origWait) })
 
 	suffix := "GenerateOnlyCRD"
-	ct := makeReconcileConstraintTemplateForVap(suffix, nil, nil)
+	ct := makeReconcileConstraintTemplateForVap(suffix, ptr.To(true), nil)
 	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
 	testutils.CreateThenCleanup(ctx, t, c, ct)
 
@@ -287,10 +170,7 @@ func TestGenerateOnlyReconcilesConstraintCRD(t *testing.T) {
 
 	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool { return true }, func() error {
 		got := cstr.DeepCopy()
-		if getErr := c.Get(ctx, types.NamespacedName{Name: cstr.GetName()}, got); getErr != nil {
-			return getErr
-		}
-		return nil
+		return c.Get(ctx, types.NamespacedName{Name: cstr.GetName()}, got)
 	})
 	require.NoError(t, err, "generate-only must be able to persist a matching Constraint")
 

--- a/pkg/controller/constrainttemplate/generate_only_test.go
+++ b/pkg/controller/constrainttemplate/generate_only_test.go
@@ -1,0 +1,307 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constrainttemplate
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/open-policy-agent/frameworks/constraint/pkg/client"
+	"github.com/open-policy-agent/frameworks/constraint/pkg/client/drivers/rego"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/constraint"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/fakes"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/operations"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/readiness"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/target"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/watch"
+	testclient "github.com/open-policy-agent/gatekeeper/v3/test/clients"
+	"github.com/open-policy-agent/gatekeeper/v3/test/testutils"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type nopReconciler struct{}
+
+func (nopReconciler) Reconcile(context.Context, reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+func setupUniqueNameManager(t *testing.T) (manager.Manager, *watch.Manager) {
+	t.Helper()
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+	metrics.Registry = prometheus.NewRegistry()
+	skipNameValidation := false
+	mgr, err := manager.New(cfg, manager.Options{
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
+		MapperProvider: apiutil.NewDynamicRESTMapper,
+		Logger:         testutils.NewLogger(t),
+		Controller:     ctrlconfig.Controller{SkipNameValidation: &skipNameValidation},
+	})
+	if err != nil {
+		t.Fatalf("setting up controller manager: %s", err)
+	}
+	c := mgr.GetCache()
+	dc, ok := c.(watch.RemovableCache)
+	if !ok {
+		t.Fatalf("expected dynamic cache, got: %T", c)
+	}
+	wm, err := watch.New(dc)
+	if err != nil {
+		t.Fatalf("could not create watch manager: %s", err)
+	}
+	if err := mgr.Add(wm); err != nil {
+		t.Fatalf("could not add watch manager to manager: %s", err)
+	}
+	return mgr, wm
+}
+
+func newGenerateOnlyClient(t *testing.T) *client.Client {
+	t.Helper()
+	regoDriver, err := rego.New(rego.Tracing(true))
+	require.NoError(t, err)
+	celDriver, err := k8scel.New()
+	require.NoError(t, err)
+	cfClient, err := client.NewClient(
+		client.Targets(&target.K8sValidationTarget{}),
+		client.Driver(regoDriver),
+		client.Driver(celDriver),
+		client.EnforcementPoints(operations.ConstraintClientEnforcementPoints()...),
+	)
+	require.NoError(t, err)
+	return cfClient
+}
+
+func controllerRegistered(t *testing.T, mgr manager.Manager, name string) bool {
+	t.Helper()
+	_, err := controller.New(name, mgr, controller.Options{Reconciler: nopReconciler{}})
+	return err != nil
+}
+
+// TestGenerateOnlyRegistersConstraintControllers fails if Adder.Add still
+// uses HasValidationOperations() and therefore skips generate-only
+// ConstraintTemplate/Constraint registration.
+func TestGenerateOnlyRegistersConstraintControllers(t *testing.T) {
+	operations.AssignForTest(t, operations.Generate)
+	require.False(t, operations.HasValidationOperations(), "generate-only must not be treated as a validation/review operation")
+	require.True(t, operations.HasConstraintControllers(), "generate-only must start constraint controllers")
+	require.False(t, operations.IsAssigned(operations.Audit))
+	require.False(t, operations.IsAssigned(operations.Webhook))
+	require.False(t, operations.IsAssigned(operations.Status))
+	require.Equal(t, []string{util.VAPEnforcementPoint}, operations.ConstraintClientEnforcementPoints())
+
+	mgr, wm := setupUniqueNameManager(t)
+	cfClient := newGenerateOnlyClient(t)
+	tracker, err := readiness.SetupTrackerNoReadyz(mgr, false, false, false)
+	require.NoError(t, err)
+
+	testutils.Setenv(t, "POD_NAME", "no-pod")
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
+
+	adder := &Adder{
+		CFClient:     cfClient,
+		WatchManager: wm,
+		Tracker:      tracker,
+		GetPod:       func(context.Context) (*corev1.Pod, error) { return pod, nil },
+	}
+	require.NoError(t, adder.Add(mgr), "generate-only process must start successfully")
+
+	if !controllerRegistered(t, mgr, ctrlName) {
+		t.Fatal("constrainttemplate-controller was not registered; the old HasValidationOperations() gate is still blocking generate-only")
+	}
+	if !controllerRegistered(t, mgr, "constraint-controller") {
+		t.Fatal("constraint-controller was not registered; generate-only must start Constraint reconciliation")
+	}
+	if controllerRegistered(t, mgr, "constraint-status-controller") {
+		t.Fatal("generate-only must not register the constraint status aggregator")
+	}
+	if controllerRegistered(t, mgr, "constraint-template-status-controller") {
+		t.Fatal("generate-only must not register the constraint template status aggregator")
+	}
+}
+
+func TestAuditGenerateStillRegistersConstraintControllers(t *testing.T) {
+	operations.AssignForTest(t, operations.Audit, operations.Generate)
+	require.True(t, operations.HasValidationOperations())
+	require.True(t, operations.HasConstraintControllers())
+	require.Equal(t, []string{util.AuditEnforcementPoint}, operations.ConstraintClientEnforcementPoints())
+
+	mgr, wm := setupUniqueNameManager(t)
+	regoDriver, err := rego.New(rego.Tracing(true))
+	require.NoError(t, err)
+	celDriver, err := k8scel.New()
+	require.NoError(t, err)
+	cfClient, err := client.NewClient(
+		client.Targets(&target.K8sValidationTarget{}),
+		client.Driver(regoDriver),
+		client.Driver(celDriver),
+		client.EnforcementPoints(operations.ConstraintClientEnforcementPoints()...),
+	)
+	require.NoError(t, err)
+	tracker, err := readiness.SetupTrackerNoReadyz(mgr, false, false, false)
+	require.NoError(t, err)
+
+	testutils.Setenv(t, "POD_NAME", "no-pod")
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
+	require.NoError(t, (&Adder{
+		CFClient:     cfClient,
+		WatchManager: wm,
+		Tracker:      tracker,
+		GetPod:       func(context.Context) (*corev1.Pod, error) { return pod, nil },
+	}).Add(mgr))
+
+	if !controllerRegistered(t, mgr, ctrlName) {
+		t.Fatal("audit+generate must still register constrainttemplate-controller")
+	}
+	if !controllerRegistered(t, mgr, "constraint-controller") {
+		t.Fatal("audit+generate must still register constraint-controller")
+	}
+}
+
+func TestWebhookGenerateStillRegistersConstraintControllers(t *testing.T) {
+	operations.AssignForTest(t, operations.Webhook, operations.Generate)
+	require.True(t, operations.HasValidationOperations())
+	require.True(t, operations.HasConstraintControllers())
+	require.Equal(t, []string{util.WebhookEnforcementPoint}, operations.ConstraintClientEnforcementPoints())
+
+	mgr, wm := setupUniqueNameManager(t)
+	regoDriver, err := rego.New(rego.Tracing(true))
+	require.NoError(t, err)
+	celDriver, err := k8scel.New()
+	require.NoError(t, err)
+	cfClient, err := client.NewClient(
+		client.Targets(&target.K8sValidationTarget{}),
+		client.Driver(regoDriver),
+		client.Driver(celDriver),
+		client.EnforcementPoints(operations.ConstraintClientEnforcementPoints()...),
+	)
+	require.NoError(t, err)
+	tracker, err := readiness.SetupTrackerNoReadyz(mgr, false, false, false)
+	require.NoError(t, err)
+
+	testutils.Setenv(t, "POD_NAME", "no-pod")
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
+	require.NoError(t, (&Adder{
+		CFClient:     cfClient,
+		WatchManager: wm,
+		Tracker:      tracker,
+		GetPod:       func(context.Context) (*corev1.Pod, error) { return pod, nil },
+	}).Add(mgr))
+
+	if !controllerRegistered(t, mgr, ctrlName) {
+		t.Fatal("webhook+generate must still register constrainttemplate-controller")
+	}
+	if !controllerRegistered(t, mgr, "constraint-controller") {
+		t.Fatal("webhook+generate must still register constraint-controller")
+	}
+}
+
+// TestGenerateOnlyReconcilesConstraintCRD applies a CEL ConstraintTemplate in
+// generate-only mode and waits for the Constraint CRD (and VAP when the API
+// is available).
+func TestGenerateOnlyReconcilesConstraintCRD(t *testing.T) {
+	operations.AssignForTest(t, operations.Generate)
+
+	mgr, wm := testutils.SetupManager(t, cfg)
+	c := testclient.NewRetryClient(mgr.GetClient())
+	require.NoError(t, testutils.CreateGatekeeperNamespace(mgr.GetConfig()))
+
+	cfClient := newGenerateOnlyClient(t)
+	tracker, err := readiness.SetupTrackerNoReadyz(mgr, false, false, false)
+	require.NoError(t, err)
+
+	testutils.Setenv(t, "POD_NAME", "no-pod")
+	pod := fakes.Pod(
+		fakes.WithNamespace("gatekeeper-system"),
+		fakes.WithName("no-pod"),
+	)
+	require.NoError(t, (&Adder{
+		CFClient:     cfClient,
+		WatchManager: wm,
+		Tracker:      tracker,
+		GetPod:       func(context.Context) (*corev1.Pod, error) { return pod, nil },
+	}).Add(mgr))
+
+	ctx := context.Background()
+	testutils.StartManager(ctx, t, mgr)
+
+	origWait := constraint.GetDefaultWaitForVAPBGeneration()
+	constraint.SetDefaultWaitForVAPBGeneration(2)
+	t.Cleanup(func() { constraint.SetDefaultWaitForVAPBGeneration(origWait) })
+
+	suffix := "GenerateOnlyCRD"
+	ct := makeReconcileConstraintTemplateForVap(suffix, nil, nil)
+	t.Cleanup(testutils.DeleteObjectAndConfirm(ctx, t, c, expectedCRD(suffix)))
+	testutils.CreateThenCleanup(ctx, t, c, ct)
+
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool { return true }, func() error {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		return c.Get(ctx, crdKey(suffix), crd)
+	})
+	require.NoError(t, err, "generate-only must reconcile the Constraint CRD")
+
+	cstr := newDenyAllCstr(suffix)
+	testutils.CreateThenCleanup(ctx, t, c, cstr)
+
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool { return true }, func() error {
+		got := cstr.DeepCopy()
+		if getErr := c.Get(ctx, types.NamespacedName{Name: cstr.GetName()}, got); getErr != nil {
+			return getErr
+		}
+		return nil
+	})
+	require.NoError(t, err, "generate-only must be able to persist a matching Constraint")
+
+	vapName := types.NamespacedName{Name: "gatekeeper-" + denyall + strings.ToLower(suffix)}
+	vap := &admissionregistrationv1.ValidatingAdmissionPolicy{}
+	if probeErr := c.Get(ctx, vapName, vap); meta.IsNoMatchError(probeErr) {
+		t.Logf("skipping VAP assertion; VAP API is not available in this envtest: %v", probeErr)
+		return
+	}
+	err = retry.OnError(testutils.ConstantRetry, func(_ error) bool { return true }, func() error {
+		return c.Get(ctx, vapName, vap)
+	})
+	require.NoError(t, err, "generate-only must reconcile VAP when the ValidatingAdmissionPolicy API is available")
+}

--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"sync"
+
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 )
 
 type Operation string
@@ -127,7 +129,37 @@ func AssignedStringList() []string {
 
 // HasValidationOperations returns `true` if there
 // are any operations that would require a constraint or template controller
-// or a sync controller.
+// or a sync controller for policy review / status aggregation.
+// Generate is intentionally excluded: CRD/VAP/VAPB generation is not a
+// review enforcement point and must not start audit, webhook, or sync.
 func HasValidationOperations() bool {
 	return IsAssigned(Audit) || IsAssigned(Status) || IsAssigned(Webhook)
+}
+
+// HasConstraintControllers reports whether the ConstraintTemplate and
+// Constraint reconcilers should run. Generation owns CRD/VAP/VAPB
+// reconciliation and is separate from review enforcement (audit/webhook)
+// and from status aggregation.
+func HasConstraintControllers() bool {
+	return IsAssigned(Generate) || HasValidationOperations()
+}
+
+// ConstraintClientEnforcementPoints returns the constraint-client
+// enforcement points for this process.
+//
+// Review operations keep their existing audit/webhook points. Generate-only
+// uses vap.k8s.io so compilation/transformation can start without modeling
+// generation as an audit or webhook enforcement point.
+func ConstraintClientEnforcementPoints() []string {
+	var eps []string
+	if IsAssigned(Audit) {
+		eps = append(eps, util.AuditEnforcementPoint)
+	}
+	if IsAssigned(Webhook) {
+		eps = append(eps, util.WebhookEnforcementPoint)
+	}
+	if len(eps) == 0 && IsAssigned(Generate) {
+		eps = append(eps, util.VAPEnforcementPoint)
+	}
+	return eps
 }

--- a/pkg/operations/operations_test.go
+++ b/pkg/operations/operations_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/util"
 )
 
 // Validates flags parsing for operations.
@@ -46,5 +47,124 @@ func Test_Flags(t *testing.T) {
 				t.Errorf("unexpected result: %s", diff)
 			}
 		})
+	}
+}
+
+func TestOperationCapabilities(t *testing.T) {
+	tests := []struct {
+		name                      string
+		assigned                  []Operation
+		wantValidation            bool
+		wantConstraintControllers bool
+		wantAudit                 bool
+		wantWebhook               bool
+		wantStatus                bool
+		wantEnforcementPoints     []string
+	}{
+		{
+			name:                      "generate only",
+			assigned:                  []Operation{Generate},
+			wantConstraintControllers: true,
+			wantEnforcementPoints:     []string{util.VAPEnforcementPoint},
+		},
+		{
+			name:                      "audit only",
+			assigned:                  []Operation{Audit},
+			wantValidation:            true,
+			wantConstraintControllers: true,
+			wantAudit:                 true,
+			wantEnforcementPoints:     []string{util.AuditEnforcementPoint},
+		},
+		{
+			name:                      "webhook only",
+			assigned:                  []Operation{Webhook},
+			wantValidation:            true,
+			wantConstraintControllers: true,
+			wantWebhook:               true,
+			wantEnforcementPoints:     []string{util.WebhookEnforcementPoint},
+		},
+		{
+			name:                      "status only",
+			assigned:                  []Operation{Status},
+			wantValidation:            true,
+			wantConstraintControllers: true,
+			wantStatus:                true,
+		},
+		{
+			name:                      "audit and generate",
+			assigned:                  []Operation{Audit, Generate},
+			wantValidation:            true,
+			wantConstraintControllers: true,
+			wantAudit:                 true,
+			wantEnforcementPoints:     []string{util.AuditEnforcementPoint},
+		},
+		{
+			name:                      "webhook and generate",
+			assigned:                  []Operation{Webhook, Generate},
+			wantValidation:            true,
+			wantConstraintControllers: true,
+			wantWebhook:               true,
+			wantEnforcementPoints:     []string{util.WebhookEnforcementPoint},
+		},
+		{
+			name:                      "audit webhook and generate",
+			assigned:                  []Operation{Audit, Webhook, Generate},
+			wantValidation:            true,
+			wantConstraintControllers: true,
+			wantAudit:                 true,
+			wantWebhook:               true,
+			wantEnforcementPoints:     []string{util.AuditEnforcementPoint, util.WebhookEnforcementPoint},
+		},
+		{
+			name:     "mutation webhook only",
+			assigned: []Operation{MutationWebhook},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			AssignForTest(t, tc.assigned...)
+
+			if got := HasValidationOperations(); got != tc.wantValidation {
+				t.Errorf("HasValidationOperations() = %t, want %t", got, tc.wantValidation)
+			}
+			if got := HasConstraintControllers(); got != tc.wantConstraintControllers {
+				t.Errorf("HasConstraintControllers() = %t, want %t", got, tc.wantConstraintControllers)
+			}
+			if got := IsAssigned(Audit); got != tc.wantAudit {
+				t.Errorf("IsAssigned(Audit) = %t, want %t", got, tc.wantAudit)
+			}
+			if got := IsAssigned(Webhook); got != tc.wantWebhook {
+				t.Errorf("IsAssigned(Webhook) = %t, want %t", got, tc.wantWebhook)
+			}
+			if got := IsAssigned(Status); got != tc.wantStatus {
+				t.Errorf("IsAssigned(Status) = %t, want %t", got, tc.wantStatus)
+			}
+			if diff := cmp.Diff(tc.wantEnforcementPoints, ConstraintClientEnforcementPoints()); diff != "" {
+				t.Errorf("ConstraintClientEnforcementPoints() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestHasConstraintControllers_GenerateOnlyFailsIfOldGateRestored documents
+// that generate-only must not be classified as a validation/review operation.
+// Restoring HasValidationOperations() as the ConstraintTemplate/Constraint
+// adder gate makes this assertion fail because generate-only is false there.
+func TestHasConstraintControllers_GenerateOnlyFailsIfOldGateRestored(t *testing.T) {
+	AssignForTest(t, Generate)
+
+	if HasValidationOperations() {
+		t.Fatal("HasValidationOperations() is true for generate-only; generate must stay independent of audit/status/webhook")
+	}
+	if !HasConstraintControllers() {
+		t.Fatal("HasConstraintControllers() is false for generate-only; the old HasValidationOperations() gate would skip CRD/VAP/VAPB reconcilers")
+	}
+	if IsAssigned(Audit) || IsAssigned(Webhook) || IsAssigned(Status) {
+		t.Fatal("generate-only must not implicitly assign audit, webhook, or status")
+	}
+	got := ConstraintClientEnforcementPoints()
+	if diff := cmp.Diff([]string{util.VAPEnforcementPoint}, got); diff != "" {
+		t.Errorf("generate-only must not model generation as audit/webhook enforcement points (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/operations/testing.go
+++ b/pkg/operations/testing.go
@@ -1,0 +1,27 @@
+package operations
+
+import "testing"
+
+// AssignForTest replaces the process operation set for the duration of t.
+// The previous assignment is restored when the test ends.
+func AssignForTest(t testing.TB, ops ...Operation) {
+	t.Helper()
+
+	next := newOperationSet()
+	next.assignedOperations = make(map[Operation]bool)
+	next.initialized = true
+	for _, op := range ops {
+		next.assignedOperations[op] = true
+	}
+
+	operationsMtx.Lock()
+	prev := operations
+	operations = next
+	operationsMtx.Unlock()
+
+	t.Cleanup(func() {
+		operationsMtx.Lock()
+		operations = prev
+		operationsMtx.Unlock()
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

`--operation=generate` is documented as the independently selectable operation that creates and cleans up Constraint CRDs, ValidatingAdmissionPolicies, and ValidatingAdmissionPolicyBindings. On current master, `HasValidationOperations()` only considers `audit`, `status`, and `webhook`, so both the ConstraintTemplate and Constraint adders return before those reconcilers start.

This change:

- Adds an explicit `HasConstraintControllers()` capability (`generate` **or** existing validation operations) and uses it as the ConstraintTemplate/Constraint registration gate.
- Leaves `HasValidationOperations()` unchanged so generate-only does **not** start audit, admission webhooks, data-sync, or become a status pod.
- Initializes the constraint client for generate-only with compilation/transformation drivers and `vap.k8s.io`, not audit/webhook enforcement points.
- Preserves Config-based VAP scope sync when `--sync-vap-enforcement-scope` is enabled (already gated on `generate`).
- Keeps existing `audit+generate` and `webhook+generate` enforcement-point and controller behavior unchanged.

**Which issue(s) this PR fixes** *(optional, using `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when the PR gets merged)*:
Fixes #4771

**Special notes for your reviewer**:

```text
go test ./pkg/operations ./pkg/controller/constraint -count=1
# ok

KUBEBUILDER_ASSETS=... go test ./pkg/controller/constrainttemplate \
  -run 'TestGenerateOnly|TestAuditGenerate|TestWebhookGenerate|TestStatusOnlyDoesNot' \
  -count=1 -timeout 10m
# ok (includes generate-only CEL CT -> Constraint CRD + VAP)

# Old-gate restoration (temporarily restore HasValidationOperations() in adders):
go test ./pkg/controller/constraint -run TestAdderGenerateOnlyDoesNotSkip
# FAIL: old HasValidationOperations() gate is still blocking registration

go test ./pkg/controller/constrainttemplate -run TestGenerateOnlyRegistersConstraintControllers
# FAIL: old HasValidationOperations() gate is still blocking registration
```

Skipped: Constraint update/delete VAP/VAPB envtest coverage beyond create; `make lint` (dockerized golangci-lint not run in this environment); full `make native-test`.