### PR TITLE
fix(operations): decouple status from validation operations

### DIFF
--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -129,5 +129,5 @@ func AssignedStringList() []string {
 // are any operations that would require a constraint or template controller
 // or a sync controller.
 func HasValidationOperations() bool {
-	return IsAssigned(Audit) || IsAssigned(Status) || IsAssigned(Webhook)
+	return IsAssigned(Audit) || IsAssigned(Webhook)
 }


### PR DESCRIPTION
HasValidationOperations() included Status, causing the constraint
client and template ingestion to initialize even when only status
aggregation is requested. This fails with 'must specify at least
one enforcement point' when running --operation=status alone.

Remove Status from HasValidationOperations(). The status controller
has its own initialization path and should not trigger constraint
client setup.

fixes #4770