### PR TITLE
refactor: extract operation-to-capability wiring plan with table-driven tests

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,8 +51,10 @@ import (
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/controller/webhookconfig/webhookconfigcache"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel"
 	celSchema "github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel/schema"
+	"github.com/open-policy-agent/gatekeeper/v3/pkg/drivers/k8scel/transform"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/expansion"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/export"
+	exportutil "github.com/open-policy-agent/gatekeeper/v3/pkg/export/util"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/externaldata"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/metrics"
 	"github.com/open-policy-agent/gatekeeper/v3/pkg/mutation"
@@ -420,10 +422,23 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 	// Block until the setup (certificate generation) finishes.
 	<-setupFinished
 
+	plan := operations.CurrentPlan(operations.Features{
+		ExpansionEnabled:          *expansion.ExpansionEnabled,
+		ExternalDataEnabled:       *externaldata.ExternalDataEnabled,
+		ViolationExportEnabled:    *exportutil.ExportEnabled,
+		AdmissionExportEnabled:    *exportutil.AdmissionExportEnabled,
+		SyncVAPEnforcementScope:   *transform.SyncVAPScope,
+		EnableK8sNativeValidation: *enableK8sCel,
+	})
+	if err := plan.Validate(); err != nil {
+		setupLog.Error(err, "invalid controller wiring plan")
+		return err
+	}
+
 	var providerCache *frameworksexternaldata.ProviderCache
 	args := []rego.Arg{rego.Tracing(false), rego.DisableBuiltins(disabledBuiltins.ToSlice()...)}
 	mutationOpts := mutation.SystemOpts{Reporter: mutation.NewStatsReporter()}
-	if *externaldata.ExternalDataEnabled {
+	if plan.Systems.ProviderCache {
 		providerCache = frameworksexternaldata.NewCache()
 		args = append(args, rego.AddExternalDataProviderCache(providerCache))
 		mutationOpts.ProviderCache = providerCache
@@ -441,35 +456,37 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 			return err
 		}
 
-		certFile := filepath.Join(*certDir, certName)
-		keyFile := filepath.Join(*certDir, keyName)
+		if plan.Runnables.ClientCertWatcher {
+			certFile := filepath.Join(*certDir, certName)
+			keyFile := filepath.Join(*certDir, keyName)
 
-		// certWatcher is used to watch for changes to Gatekeeper's certificate and key files.
-		certWatcher, err := certwatcher.New(certFile, keyFile)
-		if err != nil {
-			setupLog.Error(err, "unable to create client cert watcher")
-			return err
+			// certWatcher is used to watch for changes to Gatekeeper's certificate and key files.
+			certWatcher, err := certwatcher.New(certFile, keyFile)
+			if err != nil {
+				setupLog.Error(err, "unable to create client cert watcher")
+				return err
+			}
+
+			setupLog.Info("setting up client cert watcher")
+			if err := mgr.Add(certWatcher); err != nil {
+				setupLog.Error(err, "unable to register client cert watcher")
+				return err
+			}
+
+			// register the client cert watcher to the driver
+			args = append(args, rego.EnableExternalDataClientAuth(), rego.AddExternalDataClientCertWatcher(certWatcher))
+
+			// register the client cert watcher to the mutation system
+			mutationOpts.ClientCertWatcher = certWatcher
 		}
-
-		setupLog.Info("setting up client cert watcher")
-		if err := mgr.Add(certWatcher); err != nil {
-			setupLog.Error(err, "unable to register client cert watcher")
-			return err
-		}
-
-		// register the client cert watcher to the driver
-		args = append(args, rego.EnableExternalDataClientAuth(), rego.AddExternalDataClientCertWatcher(certWatcher))
-
-		// register the client cert watcher to the mutation system
-		mutationOpts.ClientCertWatcher = certWatcher
 	}
 
 	cfArgs := []constraintclient.Opt{constraintclient.Targets(&target.K8sValidationTarget{})}
 
 	var client *constraintclient.Client
 
-	if operations.HasValidationOperations() {
-		if *enableK8sCel {
+	if plan.Clients.ConstraintClient {
+		if plan.Clients.K8sCelDriver {
 			k8sDriver, err := k8scel.New()
 			if err != nil {
 				setupLog.Error(err, "unable to set up K8s native driver")
@@ -492,10 +509,10 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		cfArgs = append(cfArgs, constraintclient.Driver(driver))
 
 		eps := []string{}
-		if operations.IsAssigned(operations.Audit) {
+		if plan.Clients.AuditEnforcement {
 			eps = append(eps, util.AuditEnforcementPoint)
 		}
-		if operations.IsAssigned(operations.Webhook) {
+		if plan.Clients.WebhookEnforcement {
 			eps = append(eps, util.WebhookEnforcementPoint)
 		}
 
@@ -511,9 +528,18 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		}
 	}
 
-	mutationSystem := mutation.NewSystem(mutationOpts)
-	expansionSystem := expansion.NewSystem(mutationSystem)
-	exportSystem := export.NewSystem()
+	var mutationSystem *mutation.System
+	if plan.Systems.MutationSystem {
+		mutationSystem = mutation.NewSystem(mutationOpts)
+	}
+	var expansionSystem *expansion.System
+	if plan.Systems.ExpansionSystem {
+		expansionSystem = expansion.NewSystem(mutationSystem)
+	}
+	var exportSystem *export.System
+	if plan.Systems.ExportSystem {
+		exportSystem = export.NewSystem()
+	}
 
 	c := mgr.GetCache()
 	dc, ok := c.(watch.RemovableCache)
@@ -523,63 +549,78 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		return err
 	}
 
-	setupLog.Info("setting up metrics")
-	if err := metrics.AddToManager(mgr); err != nil {
-		setupLog.Error(err, "unable to register metrics with the manager")
-		return err
+	if plan.Runnables.Metrics {
+		setupLog.Info("setting up metrics")
+		if err := metrics.AddToManager(mgr); err != nil {
+			setupLog.Error(err, "unable to register metrics with the manager")
+			return err
+		}
 	}
 
-	wm, err := watch.New(dc)
-	if err != nil {
-		setupLog.Error(err, "unable to create watch manager")
-		return err
-	}
-	if err := mgr.Add(wm); err != nil {
-		setupLog.Error(err, "unable to register watch manager with the manager")
-		return err
+	var wm *watch.Manager
+	if plan.Runnables.WatchManager {
+		var err error
+		wm, err = watch.New(dc)
+		if err != nil {
+			setupLog.Error(err, "unable to create watch manager")
+			return err
+		}
+		if err := mgr.Add(wm); err != nil {
+			setupLog.Error(err, "unable to register watch manager with the manager")
+			return err
+		}
 	}
 
-	// processExcluder is used for namespace exclusion for specified processes in config
-	processExcluder := process.Get()
+	var processExcluder *process.Excluder
+	if plan.Systems.ProcessExcluder {
+		// processExcluder is used for namespace exclusion for specified processes in config
+		processExcluder = process.Get()
+	}
 
 	// Setup all Controllers
 	setupLog.Info("setting up controllers")
 
-	// Events ch will be used to receive events from dynamic watches registered
-	// via the registrar below.
-	events := make(chan event.GenericEvent, 1024)
-	reg, err := wm.NewRegistrar(
-		cachemanager.RegistrarName,
-		events)
-	if err != nil {
-		setupLog.Error(err, "unable to set up watch registrar for cache manager")
-		return err
+	var events chan event.GenericEvent
+	var cm *cachemanager.CacheManager
+	if plan.Runnables.CacheManager {
+		// Events ch will be used to receive events from dynamic watches registered
+		// via the registrar below.
+		events = make(chan event.GenericEvent, 1024)
+		reg, err := wm.NewRegistrar(
+			cachemanager.RegistrarName,
+			events)
+		if err != nil {
+			setupLog.Error(err, "unable to set up watch registrar for cache manager")
+			return err
+		}
+
+		syncMetricsCache := syncutil.NewMetricsCache()
+
+		cmConfig := &cachemanager.Config{
+			SyncMetricsCache: syncMetricsCache,
+			Tracker:          tracker,
+			ProcessExcluder:  processExcluder,
+			Registrar:        reg,
+			Reader:           mgr.GetCache(),
+		}
+
+		if client != nil {
+			cmConfig.CfClient = client
+		}
+
+		cm, err = cachemanager.NewCacheManager(cmConfig)
+		if err != nil {
+			setupLog.Error(err, "unable to create cache manager")
+			return err
+		}
 	}
 
-	syncMetricsCache := syncutil.NewMetricsCache()
-
-	cmConfig := &cachemanager.Config{
-		SyncMetricsCache: syncMetricsCache,
-		Tracker:          tracker,
-		ProcessExcluder:  processExcluder,
-		Registrar:        reg,
-		Reader:           mgr.GetCache(),
-	}
-
-	if client != nil {
-		cmConfig.CfClient = client
-	}
-
-	cm, err := cachemanager.NewCacheManager(cmConfig)
-	if err != nil {
-		setupLog.Error(err, "unable to create cache manager")
-		return err
-	}
-
-	err = mgr.Add(pruner.NewExpectationsPruner(cm, tracker))
-	if err != nil {
-		setupLog.Error(err, "adding expectations pruner to manager")
-		return err
+	if plan.Runnables.ExpectationsPruner {
+		err := mgr.Add(pruner.NewExpectationsPruner(cm, tracker))
+		if err != nil {
+			setupLog.Error(err, "adding expectations pruner to manager")
+			return err
+		}
 	}
 
 	opts := controller.Dependencies{
@@ -595,7 +636,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		ExportSystem:    exportSystem,
 	}
 
-	if operations.IsAssigned(operations.Generate) {
+	if plan.Systems.ConstraintTemplateEvents || plan.Systems.WebhookConfigCache {
 		opts.CtEvents = make(chan event.GenericEvent, 1024)
 		opts.WebhookConfigCache = webhookconfigcache.NewWebhookConfigCache()
 	}
@@ -605,7 +646,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		return err
 	}
 
-	if operations.IsAssigned(operations.Webhook) || operations.IsAssigned(operations.MutationWebhook) {
+	if plan.Webhooks.Validation || plan.Webhooks.Mutation || plan.Webhooks.NamespaceLabel {
 		setupLog.Info("setting up webhooks")
 		webhookDeps := webhook.Dependencies{
 			OpaClient:       client,
@@ -621,7 +662,7 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		}
 	}
 
-	if operations.IsAssigned(operations.Audit) {
+	if plan.Runnables.Audit {
 		setupLog.Info("setting up audit")
 		auditCache := audit.NewAuditCacheLister(mgr.GetCache(), cm)
 		auditDeps := audit.Dependencies{
@@ -638,10 +679,12 @@ func setupControllers(ctx context.Context, mgr ctrl.Manager, tracker *readiness.
 		}
 	}
 
-	setupLog.Info("setting up upgrade")
-	if err := upgrade.AddToManager(mgr); err != nil {
-		setupLog.Error(err, "unable to register upgrade with the manager")
-		return err
+	if plan.Runnables.Upgrade {
+		setupLog.Info("setting up upgrade")
+		if err := upgrade.AddToManager(mgr); err != nil {
+			setupLog.Error(err, "unable to register upgrade with the manager")
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -96,6 +96,20 @@ func IsAssigned(op Operation) bool {
 	return operations.assignedOperations[op]
 }
 
+// AssignedSet returns a copy of the operations assigned to this process.
+func AssignedSet() Set {
+	operationsMtx.RLock()
+	defer operationsMtx.RUnlock()
+
+	out := make(Set, len(operations.assignedOperations))
+	for k, v := range operations.assignedOperations {
+		if v {
+			out[k] = true
+		}
+	}
+	return out
+}
+
 // AssignedStringList returns a list of all operations assigned to the pod
 // as a sorted list of strings.
 func AssignedStringList() []string {
@@ -128,6 +142,16 @@ func AssignedStringList() []string {
 // HasValidationOperations returns `true` if there
 // are any operations that would require a constraint or template controller
 // or a sync controller.
+//
+// This matches Plan.Clients.ConstraintClient for the assigned operations.
 func HasValidationOperations() bool {
-	return IsAssigned(Audit) || IsAssigned(Status) || IsAssigned(Webhook)
+	return hasValidationOperations(AssignedSet())
+}
+
+func hasValidationOperations(ops Set) bool {
+	return ops[Audit] || ops[Status] || ops[Webhook]
+}
+
+func hasMutationOperations(ops Set) bool {
+	return ops[MutationStatus] || ops[MutationWebhook] || ops[MutationController]
 }

--- a/pkg/operations/plan.go
+++ b/pkg/operations/plan.go
@@ -1,0 +1,238 @@
+package operations
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Features captures the feature flags that affect controller wiring.
+// Values should match the corresponding command-line flags.
+type Features struct {
+	ExpansionEnabled          bool
+	ExternalDataEnabled       bool
+	ViolationExportEnabled    bool
+	AdmissionExportEnabled    bool
+	SyncVAPEnforcementScope   bool
+	EnableK8sNativeValidation bool
+}
+
+// DefaultFeatures returns the feature-flag defaults used when Gatekeeper is
+// started without overriding those flags.
+func DefaultFeatures() Features {
+	return Features{
+		ExpansionEnabled:          true,
+		ExternalDataEnabled:       true,
+		ViolationExportEnabled:    false,
+		AdmissionExportEnabled:    false,
+		SyncVAPEnforcementScope:   true,
+		EnableK8sNativeValidation: true,
+	}
+}
+
+// Set is the collection of operations assigned to a process.
+type Set map[Operation]bool
+
+// Plan is the operation-to-capability mapping consumed by setupControllers.
+// It is the single source of truth for which clients, systems, runnables,
+// webhooks, and controllers a process constructs for a given --operation set
+// and feature flags.
+type Plan struct {
+	Clients     ClientPlan
+	Systems     SystemPlan
+	Runnables   RunnablePlan
+	Webhooks    WebhookPlan
+	Controllers ControllerPlan
+}
+
+// ClientPlan describes constraint-client construction.
+type ClientPlan struct {
+	ConstraintClient   bool
+	K8sCelDriver       bool
+	AuditEnforcement   bool
+	WebhookEnforcement bool
+}
+
+// SystemPlan describes in-process systems and shared objects.
+type SystemPlan struct {
+	ProviderCache            bool
+	MutationSystem           bool
+	ExpansionSystem          bool
+	ExportSystem             bool
+	ProcessExcluder          bool
+	WebhookConfigCache       bool
+	ConstraintTemplateEvents bool
+}
+
+// RunnablePlan describes manager.Runnable registrations.
+type RunnablePlan struct {
+	WatchManager          bool
+	CacheManager          bool
+	ExpectationsPruner    bool
+	Metrics               bool
+	Upgrade               bool
+	Audit                 bool
+	ClientCertWatcher     bool
+	MutatorConflictRouter bool
+}
+
+// WebhookPlan describes admission webhook servers.
+type WebhookPlan struct {
+	Validation     bool
+	Mutation       bool
+	NamespaceLabel bool
+}
+
+// ControllerPlan describes controller registration.
+type ControllerPlan struct {
+	ConstraintTemplate       bool
+	Constraint               bool
+	Config                   bool
+	Sync                     bool
+	SyncSet                  bool
+	ExpansionTemplate        bool
+	ExpansionStatus          bool
+	ExternalData             bool
+	ExternalDataStatus       bool
+	ExportConnection         bool
+	Mutators                 bool
+	MutatorStatus            bool
+	WebhookConfig            bool
+	ConfigStatus             bool
+	ConnectionStatus         bool
+	ConstraintStatus         bool
+	ConstraintTemplateStatus bool
+}
+
+// NewPlan returns the controller/dependency plan for ops and f.
+// Production wiring in setupControllers must call this function (via
+// CurrentPlan) so tests and process startup cannot drift.
+func NewPlan(ops Set, f Features) Plan {
+	if ops == nil {
+		ops = Set{}
+	}
+
+	hasValidation := hasValidationOperations(ops)
+	hasMutation := hasMutationOperations(ops)
+	exportEnabled := f.ViolationExportEnabled || f.AdmissionExportEnabled
+
+	p := Plan{
+		Clients: ClientPlan{
+			ConstraintClient:   hasValidation,
+			K8sCelDriver:       hasValidation && f.EnableK8sNativeValidation,
+			AuditEnforcement:   ops[Audit],
+			WebhookEnforcement: ops[Webhook],
+		},
+		Systems: SystemPlan{
+			ProviderCache: f.ExternalDataEnabled,
+			// Mutation, expansion, export, and process exclusion are constructed
+			// for every operation set today. Later operation-alignment work can
+			// narrow these; setupControllers follows this plan.
+			MutationSystem:           true,
+			ExpansionSystem:          true,
+			ExportSystem:             true,
+			ProcessExcluder:          true,
+			WebhookConfigCache:       ops[Generate],
+			ConstraintTemplateEvents: ops[Generate],
+		},
+		Runnables: RunnablePlan{
+			WatchManager:       true,
+			CacheManager:       true,
+			ExpectationsPruner: true,
+			Metrics:            true,
+			Upgrade:            true,
+			Audit:              ops[Audit],
+			ClientCertWatcher:  f.ExternalDataEnabled,
+			// routeConflictEvents is registered before mutation.Enabled() is checked.
+			MutatorConflictRouter: true,
+		},
+		Webhooks: WebhookPlan{
+			Validation:     ops[Webhook],
+			Mutation:       ops[MutationWebhook],
+			NamespaceLabel: ops[Webhook] || ops[MutationWebhook],
+		},
+		Controllers: ControllerPlan{
+			ConstraintTemplate:       hasValidation,
+			Constraint:               hasValidation,
+			Config:                   true,
+			Sync:                     hasValidation,
+			SyncSet:                  hasValidation,
+			ExpansionTemplate:        f.ExpansionEnabled,
+			ExpansionStatus:          ops[Status] && f.ExpansionEnabled,
+			ExternalData:             f.ExternalDataEnabled,
+			ExternalDataStatus:       ops[Status],
+			ExportConnection:         exportEnabled,
+			Mutators:                 hasMutation,
+			MutatorStatus:            ops[MutationStatus],
+			WebhookConfig:            ops[Generate] && f.SyncVAPEnforcementScope,
+			ConfigStatus:             ops[Status],
+			ConnectionStatus:         ops[Status],
+			ConstraintStatus:         ops[Status] && hasValidation,
+			ConstraintTemplateStatus: ops[Status] && hasValidation,
+		},
+	}
+	return p
+}
+
+// CurrentPlan returns NewPlan for the operations assigned to this process.
+func CurrentPlan(f Features) Plan {
+	return NewPlan(AssignedSet(), f)
+}
+
+type namedDep struct {
+	name    string
+	present bool
+}
+
+// Validate reports registered consumers that are missing a required dependency.
+func (p Plan) Validate() error {
+	var errs []error
+	require := func(consumer string, registered bool, deps ...namedDep) {
+		if !registered {
+			return
+		}
+		for _, d := range deps {
+			if !d.present {
+				errs = append(errs, fmt.Errorf("%s requires %s", consumer, d.name))
+			}
+		}
+	}
+
+	constraintClient := namedDep{name: "ConstraintClient", present: p.Clients.ConstraintClient}
+	processExcluder := namedDep{name: "ProcessExcluder", present: p.Systems.ProcessExcluder}
+	cacheManager := namedDep{name: "CacheManager", present: p.Runnables.CacheManager}
+	watchManager := namedDep{name: "WatchManager", present: p.Runnables.WatchManager}
+	expansionSystem := namedDep{name: "ExpansionSystem", present: p.Systems.ExpansionSystem}
+	mutationSystem := namedDep{name: "MutationSystem", present: p.Systems.MutationSystem}
+	exportSystem := namedDep{name: "ExportSystem", present: p.Systems.ExportSystem}
+	providerCache := namedDep{name: "ProviderCache", present: p.Systems.ProviderCache}
+	webhookConfigCache := namedDep{name: "WebhookConfigCache", present: p.Systems.WebhookConfigCache}
+	ctEvents := namedDep{name: "ConstraintTemplateEvents", present: p.Systems.ConstraintTemplateEvents}
+
+	require("audit", p.Runnables.Audit, constraintClient, processExcluder, cacheManager, expansionSystem)
+	require("validationWebhook", p.Webhooks.Validation, constraintClient, processExcluder, expansionSystem)
+	require("mutationWebhook", p.Webhooks.Mutation, mutationSystem)
+	require("constraintTemplate", p.Controllers.ConstraintTemplate, constraintClient, watchManager, processExcluder)
+	require("constraint", p.Controllers.Constraint, constraintClient)
+	require("config", p.Controllers.Config, cacheManager)
+	require("sync", p.Controllers.Sync, cacheManager)
+	require("syncSet", p.Controllers.SyncSet, cacheManager)
+	require("expansionTemplate", p.Controllers.ExpansionTemplate, expansionSystem)
+	require("externalData", p.Controllers.ExternalData, providerCache)
+	require("exportConnection", p.Controllers.ExportConnection, exportSystem)
+	require("mutators", p.Controllers.Mutators, mutationSystem)
+	require("webhookConfig", p.Controllers.WebhookConfig, webhookConfigCache, ctEvents)
+	require("cacheManager", p.Runnables.CacheManager, watchManager)
+	require("expectationsPruner", p.Runnables.ExpectationsPruner, cacheManager)
+	require("clientCertWatcher", p.Runnables.ClientCertWatcher, providerCache)
+	require("k8sCelDriver", p.Clients.K8sCelDriver, constraintClient)
+	if p.Controllers.ExportConnection {
+		if p.Runnables.Audit {
+			require("auditExport", true, exportSystem)
+		}
+		if p.Webhooks.Validation {
+			require("admissionExport", true, exportSystem)
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/pkg/operations/plan_test.go
+++ b/pkg/operations/plan_test.go
@@ -1,0 +1,401 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// wantPlan returns the capabilities that setupControllers always constructs,
+// then applies modify for operation- and feature-specific fields.
+func wantPlan(modify func(*Plan)) Plan {
+	p := Plan{
+		Systems: SystemPlan{
+			MutationSystem:  true,
+			ExpansionSystem: true,
+			ExportSystem:    true,
+			ProcessExcluder: true,
+		},
+		Runnables: RunnablePlan{
+			WatchManager:          true,
+			CacheManager:          true,
+			ExpectationsPruner:    true,
+			Metrics:               true,
+			Upgrade:               true,
+			MutatorConflictRouter: true,
+		},
+		Controllers: ControllerPlan{
+			Config: true,
+		},
+	}
+	modify(&p)
+	return p
+}
+
+func withDefaultFeatures(p *Plan) {
+	p.Systems.ProviderCache = true
+	p.Runnables.ClientCertWatcher = true
+	p.Controllers.ExpansionTemplate = true
+	p.Controllers.ExternalData = true
+}
+
+func withValidationIngestion(p *Plan) {
+	p.Clients.ConstraintClient = true
+	p.Clients.K8sCelDriver = true
+	p.Controllers.ConstraintTemplate = true
+	p.Controllers.Constraint = true
+	p.Controllers.Sync = true
+	p.Controllers.SyncSet = true
+}
+
+func TestNewPlan(t *testing.T) {
+	tests := []struct {
+		name     string
+		ops      Set
+		features Features
+		want     Plan
+	}{
+		{
+			name:     "audit",
+			ops:      Set{Audit: true},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				withValidationIngestion(p)
+				p.Clients.AuditEnforcement = true
+				p.Runnables.Audit = true
+			}),
+		},
+		{
+			name:     "webhook",
+			ops:      Set{Webhook: true},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				withValidationIngestion(p)
+				p.Clients.WebhookEnforcement = true
+				p.Webhooks.Validation = true
+				p.Webhooks.NamespaceLabel = true
+			}),
+		},
+		{
+			name:     "mutation-webhook",
+			ops:      Set{MutationWebhook: true},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				p.Webhooks.Mutation = true
+				p.Webhooks.NamespaceLabel = true
+				p.Controllers.Mutators = true
+			}),
+		},
+		{
+			name:     "mutation-controller",
+			ops:      Set{MutationController: true},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				p.Controllers.Mutators = true
+			}),
+		},
+		{
+			name:     "mutation-status",
+			ops:      Set{MutationStatus: true},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				p.Controllers.Mutators = true
+				p.Controllers.MutatorStatus = true
+			}),
+		},
+		{
+			// Status currently initializes a constraint client (HasValidationOperations
+			// includes Status) but adds no enforcement points. See #4770.
+			name:     "status",
+			ops:      Set{Status: true},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				withValidationIngestion(p)
+				p.Controllers.ExpansionStatus = true
+				p.Controllers.ExternalDataStatus = true
+				p.Controllers.ConfigStatus = true
+				p.Controllers.ConnectionStatus = true
+				p.Controllers.ConstraintStatus = true
+				p.Controllers.ConstraintTemplateStatus = true
+			}),
+		},
+		{
+			// Generate currently does not start ConstraintTemplate/Constraint
+			// reconcilers because HasValidationOperations excludes Generate. See #4771.
+			name:     "generate",
+			ops:      Set{Generate: true},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				p.Systems.WebhookConfigCache = true
+				p.Systems.ConstraintTemplateEvents = true
+				p.Controllers.WebhookConfig = true
+			}),
+		},
+		{
+			name: "audit+status+mutation-status+generate",
+			ops: Set{
+				Audit:          true,
+				Status:         true,
+				MutationStatus: true,
+				Generate:       true,
+			},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				withValidationIngestion(p)
+				p.Clients.AuditEnforcement = true
+				p.Systems.WebhookConfigCache = true
+				p.Systems.ConstraintTemplateEvents = true
+				p.Runnables.Audit = true
+				p.Controllers.ExpansionStatus = true
+				p.Controllers.ExternalDataStatus = true
+				p.Controllers.Mutators = true
+				p.Controllers.MutatorStatus = true
+				p.Controllers.WebhookConfig = true
+				p.Controllers.ConfigStatus = true
+				p.Controllers.ConnectionStatus = true
+				p.Controllers.ConstraintStatus = true
+				p.Controllers.ConstraintTemplateStatus = true
+			}),
+		},
+		{
+			name: "webhook+mutation-webhook",
+			ops: Set{
+				Webhook:         true,
+				MutationWebhook: true,
+			},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				withValidationIngestion(p)
+				p.Clients.WebhookEnforcement = true
+				p.Webhooks.Validation = true
+				p.Webhooks.Mutation = true
+				p.Webhooks.NamespaceLabel = true
+				p.Controllers.Mutators = true
+			}),
+		},
+		{
+			name: "all operations",
+			ops: Set{
+				Audit:              true,
+				Webhook:            true,
+				Status:             true,
+				MutationStatus:     true,
+				MutationWebhook:    true,
+				MutationController: true,
+				Generate:           true,
+			},
+			features: DefaultFeatures(),
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				withValidationIngestion(p)
+				p.Clients.AuditEnforcement = true
+				p.Clients.WebhookEnforcement = true
+				p.Systems.WebhookConfigCache = true
+				p.Systems.ConstraintTemplateEvents = true
+				p.Runnables.Audit = true
+				p.Webhooks.Validation = true
+				p.Webhooks.Mutation = true
+				p.Webhooks.NamespaceLabel = true
+				p.Controllers.ExpansionStatus = true
+				p.Controllers.ExternalDataStatus = true
+				p.Controllers.Mutators = true
+				p.Controllers.MutatorStatus = true
+				p.Controllers.WebhookConfig = true
+				p.Controllers.ConfigStatus = true
+				p.Controllers.ConnectionStatus = true
+				p.Controllers.ConstraintStatus = true
+				p.Controllers.ConstraintTemplateStatus = true
+			}),
+		},
+		{
+			name: "webhook expansion disabled",
+			ops:  Set{Webhook: true},
+			features: Features{
+				ExpansionEnabled:          false,
+				ExternalDataEnabled:       true,
+				SyncVAPEnforcementScope:   true,
+				EnableK8sNativeValidation: true,
+			},
+			want: wantPlan(func(p *Plan) {
+				p.Systems.ProviderCache = true
+				p.Runnables.ClientCertWatcher = true
+				p.Controllers.ExternalData = true
+				withValidationIngestion(p)
+				p.Clients.WebhookEnforcement = true
+				p.Webhooks.Validation = true
+				p.Webhooks.NamespaceLabel = true
+			}),
+		},
+		{
+			name: "webhook external data disabled",
+			ops:  Set{Webhook: true},
+			features: Features{
+				ExpansionEnabled:          true,
+				ExternalDataEnabled:       false,
+				SyncVAPEnforcementScope:   true,
+				EnableK8sNativeValidation: true,
+			},
+			want: wantPlan(func(p *Plan) {
+				p.Controllers.ExpansionTemplate = true
+				withValidationIngestion(p)
+				p.Clients.WebhookEnforcement = true
+				p.Webhooks.Validation = true
+				p.Webhooks.NamespaceLabel = true
+			}),
+		},
+		{
+			name: "audit violation export enabled",
+			ops:  Set{Audit: true},
+			features: Features{
+				ExpansionEnabled:          true,
+				ExternalDataEnabled:       true,
+				ViolationExportEnabled:    true,
+				SyncVAPEnforcementScope:   true,
+				EnableK8sNativeValidation: true,
+			},
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				withValidationIngestion(p)
+				p.Clients.AuditEnforcement = true
+				p.Runnables.Audit = true
+				p.Controllers.ExportConnection = true
+			}),
+		},
+		{
+			name: "webhook admission export enabled",
+			ops:  Set{Webhook: true},
+			features: Features{
+				ExpansionEnabled:          true,
+				ExternalDataEnabled:       true,
+				AdmissionExportEnabled:    true,
+				SyncVAPEnforcementScope:   true,
+				EnableK8sNativeValidation: true,
+			},
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				withValidationIngestion(p)
+				p.Clients.WebhookEnforcement = true
+				p.Webhooks.Validation = true
+				p.Webhooks.NamespaceLabel = true
+				p.Controllers.ExportConnection = true
+			}),
+		},
+		{
+			name: "generate vap scope sync disabled",
+			ops:  Set{Generate: true},
+			features: Features{
+				ExpansionEnabled:          true,
+				ExternalDataEnabled:       true,
+				SyncVAPEnforcementScope:   false,
+				EnableK8sNativeValidation: true,
+			},
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				p.Systems.WebhookConfigCache = true
+				p.Systems.ConstraintTemplateEvents = true
+			}),
+		},
+		{
+			name: "status external data disabled",
+			ops:  Set{Status: true},
+			features: Features{
+				ExpansionEnabled:          true,
+				ExternalDataEnabled:       false,
+				SyncVAPEnforcementScope:   true,
+				EnableK8sNativeValidation: true,
+			},
+			want: wantPlan(func(p *Plan) {
+				p.Controllers.ExpansionTemplate = true
+				withValidationIngestion(p)
+				p.Controllers.ExpansionStatus = true
+				p.Controllers.ExternalDataStatus = true
+				p.Controllers.ConfigStatus = true
+				p.Controllers.ConnectionStatus = true
+				p.Controllers.ConstraintStatus = true
+				p.Controllers.ConstraintTemplateStatus = true
+			}),
+		},
+		{
+			name: "status expansion disabled",
+			ops:  Set{Status: true},
+			features: Features{
+				ExpansionEnabled:          false,
+				ExternalDataEnabled:       true,
+				SyncVAPEnforcementScope:   true,
+				EnableK8sNativeValidation: true,
+			},
+			want: wantPlan(func(p *Plan) {
+				p.Systems.ProviderCache = true
+				p.Runnables.ClientCertWatcher = true
+				p.Controllers.ExternalData = true
+				withValidationIngestion(p)
+				p.Controllers.ExternalDataStatus = true
+				p.Controllers.ConfigStatus = true
+				p.Controllers.ConnectionStatus = true
+				p.Controllers.ConstraintStatus = true
+				p.Controllers.ConstraintTemplateStatus = true
+			}),
+		},
+		{
+			name: "webhook k8s native validation disabled",
+			ops:  Set{Webhook: true},
+			features: Features{
+				ExpansionEnabled:          true,
+				ExternalDataEnabled:       true,
+				SyncVAPEnforcementScope:   true,
+				EnableK8sNativeValidation: false,
+			},
+			want: wantPlan(func(p *Plan) {
+				withDefaultFeatures(p)
+				p.Clients.ConstraintClient = true
+				p.Clients.WebhookEnforcement = true
+				p.Webhooks.Validation = true
+				p.Webhooks.NamespaceLabel = true
+				p.Controllers.ConstraintTemplate = true
+				p.Controllers.Constraint = true
+				p.Controllers.Sync = true
+				p.Controllers.SyncSet = true
+			}),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NewPlan(tc.ops, tc.features)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("NewPlan() mismatch (-want +got):\n%s", diff)
+			}
+			if err := got.Validate(); err != nil {
+				t.Errorf("Validate() registered consumers missing dependencies: %v", err)
+			}
+		})
+	}
+}
+
+func TestPlanValidateRejectsIncompleteConsumer(t *testing.T) {
+	p := NewPlan(Set{Audit: true}, DefaultFeatures())
+	p.Clients.ConstraintClient = false
+	if err := p.Validate(); err == nil {
+		t.Fatal("expected Validate() error when audit is registered without a constraint client")
+	}
+}
+
+func TestCurrentPlanUsesAssignedSet(t *testing.T) {
+	got := CurrentPlan(DefaultFeatures())
+	want := NewPlan(AssignedSet(), DefaultFeatures())
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("CurrentPlan() mismatch (-want +got):\n%s", diff)
+	}
+	if err := got.Validate(); err != nil {
+		t.Errorf("Validate() registered consumers missing dependencies: %v", err)
+	}
+}


### PR DESCRIPTION
### Description

Fixes #4776.

Extracts a testable `operations.Plan` that maps `--operation` values and feature flags to the clients/systems/runnables/webhooks/controllers constructed by `setupControllers`. Production wiring now consumes `operations.CurrentPlan`, so tests and process startup cannot drift.

The plan makes previously-undetected wiring contradictions explicit and testable, e.g.:
- `status` builds the constraint client with no enforcement point.
- `generate` owns CRD/VAP/VAPB behavior but does not start the ConstraintTemplate/Constraint reconcilers.

### Changes

- `pkg/operations/plan.go` — new `Plan`, `Features`, `NewPlan`, `CurrentPlan`, and `Plan.Validate`.
- `pkg/operations/plan_test.go` — table-driven suite covering all 7 isolated operations, shipped combinations (`audit+status+mutation-status+generate`, `webhook+mutation-webhook`, default all-operations), and feature toggles (expansion, external data, violation/admission export, VAP scope sync, k8s native validation).
- `pkg/operations/operations.go` — add `AssignedSet()` and shared `hasValidationOperations`/`hasMutationOperations` helpers.
- `main.go` — `setupControllers` now consumes `CurrentPlan`.

### Tests

- `go test ./pkg/operations/... -count=1` — pass
- `go build .` — pass
- `go vet ./pkg/operations/... .` — pass

(Controller tests requiring envtest/kubebuilder binaries were not run — those assets aren't present in this environment; unrelated to this change.)
