### PR TITLE
fix(helm): stop the chart generator folding template actions across lines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,7 +416,7 @@ manifests: __controller-gen
 		/gatekeeper/config/default -o /gatekeeper/manifest_staging/deploy/gatekeeper.yaml
 	docker run --rm -v $(shell pwd):/gatekeeper \
 		registry.k8s.io/kustomize/kustomize:v${KUSTOMIZE_VERSION} build \
-		--load-restrictor LoadRestrictionsNone /gatekeeper/cmd/build/helmify | go run cmd/build/helmify/*.go
+		--load-restrictor LoadRestrictionsNone /gatekeeper/cmd/build/helmify | go run ./cmd/build/helmify
 
 # lint runs a dockerized golangci-lint, and should give consistent results
 # across systems.

--- a/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -60,19 +60,16 @@ spec:
         {{- end }}
         args:
         - --audit-interval={{ .Values.auditInterval }}
-        - --log-level={{ (.Values.audit.logLevel | empty | not) | ternary .Values.audit.logLevel
-          .Values.logLevel }}
+        - --log-level={{ (.Values.audit.logLevel | empty | not) | ternary .Values.audit.logLevel .Values.logLevel }}
         - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
-        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName
-          }}
+        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName }}
         - --mutating-webhook-configuration-name={{ .Values.mutatingWebhookName }}
         - --audit-from-cache={{ .Values.auditFromCache }}
         {{ if hasKey .Values "auditChunkSize" }}- --audit-chunk-size={{ .Values.auditChunkSize }}{{- end }}
         - --audit-match-kind-only={{ .Values.auditMatchKindOnly }}
         {{ if hasKey .Values "emitAuditEvents" }}- --emit-audit-events={{ .Values.emitAuditEvents }}{{- end }}
         {{ if hasKey .Values "logStatsAudit" }}- --log-stats-audit={{ .Values.logStatsAudit }}{{- end }}
-        - --audit-events-involved-namespace={{ .Values.auditEventsInvolvedNamespace
-          }}
+        - --audit-events-involved-namespace={{ .Values.auditEventsInvolvedNamespace }}
         
         {{- if not .Values.audit.disableGenerateOperation }}
         - --operation=generate
@@ -98,8 +95,7 @@ spec:
         - --health-addr=:{{ .Values.audit.healthPort }}
         - --prometheus-port={{ .Values.audit.metricsPort }}
         - --enable-external-data={{ .Values.enableExternalData }}
-        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion
-          }}
+        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion }}
         
         {{- range .Values.metricsBackends}}
         - --metrics-backend={{ . }}
@@ -121,10 +117,8 @@ spec:
         {{- if .Values.audit.logFile}}
         - --log-file={{ .Values.audit.logFile }}
         {{- end }}
-        - --disable-cert-rotation={{ or .Values.audit.disableCertRotation .Values.externalCertInjection.enabled
-          }}
-        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL
-          }}
+        - --disable-cert-rotation={{ or .Values.audit.disableCertRotation .Values.externalCertInjection.enabled }}
+        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL }}
         - --enable-k8s-native-validation={{ .Values.enableK8sNativeValidation }}
         
         {{- if hasKey .Values "defaultCreateVAPForTemplates"}}

--- a/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -68,10 +68,8 @@ spec:
         - --log-denies={{ .Values.logDenies }}
         {{ if hasKey .Values "emitAdmissionEvents" }}- --emit-admission-events={{ .Values.emitAdmissionEvents }}{{- end }}
         {{ if hasKey .Values "logStatsAdmission" }}- --log-stats-admission={{ .Values.logStatsAdmission }}{{- end }}
-        - --admission-events-involved-namespace={{ .Values.admissionEventsInvolvedNamespace
-          }}
-        - --log-level={{ (.Values.controllerManager.logLevel | empty | not) | ternary
-          .Values.controllerManager.logLevel .Values.logLevel }}
+        - --admission-events-involved-namespace={{ .Values.admissionEventsInvolvedNamespace }}
+        - --log-level={{ (.Values.controllerManager.logLevel | empty | not) | ternary .Values.controllerManager.logLevel .Values.logLevel }}
         {{ if hasKey .Values "logLevelKey" }}- --log-level-key={{ .Values.logLevelKey }}{{- end }}
         {{ if hasKey .Values "logLevelEncoder" }}- --log-level-encoder={{ .Values.logLevelEncoder }}{{- end }}
         - --exempt-namespace={{ .Release.Namespace }}
@@ -83,21 +81,17 @@ spec:
         - --operation=generate
         {{- end }}
         - --enable-external-data={{ .Values.enableExternalData }}
-        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion
-          }}
+        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion }}
         - --log-mutations={{ .Values.logMutations }}
         - --mutation-annotations={{ .Values.mutationAnnotations }}
-        - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation
-          }}
+        - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation }}
         - --max-serving-threads={{ .Values.maxServingThreads }}
         - --tls-min-version={{ .Values.controllerManager.tlsMinVersion }}
-        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName
-          }}
+        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName }}
         {{ if .Values.additionalValidatingWebhookConfigsToRotateCerts | empty | not }}- --additional-validating-webhook-configs-to-rotate-certs={{ .Values.additionalValidatingWebhookConfigsToRotateCerts | join "," }}{{- end }}
         - --mutating-webhook-configuration-name={{ .Values.mutatingWebhookName }}
         {{ if .Values.additionalMutatingWebhookConfigsToRotateCerts | empty | not }}- --additional-mutating-webhook-configs-to-rotate-certs={{ .Values.additionalMutatingWebhookConfigsToRotateCerts | join "," }}{{- end }}
-        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL
-          }}
+        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL }}
         - --enable-k8s-native-validation={{ .Values.enableK8sNativeValidation }}
         {{ if ne .Values.controllerManager.clientCertName "" }}- --client-cert-name={{ .Values.controllerManager.clientCertName }}{{- end }}
         

--- a/cmd/build/helmify/main.go
+++ b/cmd/build/helmify/main.go
@@ -21,6 +21,29 @@ var kindRegex = regexp.MustCompile(`(?m)^kind:[\s]+([\S]+)[\s]*$`)
 // use exactly two spaces to be sure we are capturing metadata.name.
 var nameRegex = regexp.MustCompile(`(?m)^  name:[\s]+([\S]+)[\s]*$`)
 
+// foldedActionRegex matches a single Helm template action, spanning newlines if
+// the action was wrapped.
+var foldedActionRegex = regexp.MustCompile(`(?s)\{\{.*?\}\}`)
+
+// actionLineBreakRegex matches a line break together with the indentation the
+// emitter adds around it.
+var actionLineBreakRegex = regexp.MustCompile(`\s*\n\s*`)
+
+// rejoinFoldedActions removes the line breaks that the YAML emitter used while
+// building the chart (kustomize) introduces inside a template action when it
+// wraps a long plain scalar. YAML folding turns such a break back into a single
+// space, so collapsing the break to one space is lossless; it keeps the
+// generated chart readable and legible to strict template lexers that reject a
+// newline inside an action (Helm < 3.6, Go < 1.16).
+func rejoinFoldedActions(obj string) string {
+	return foldedActionRegex.ReplaceAllStringFunc(obj, func(action string) string {
+		if !strings.ContainsRune(action, '\n') {
+			return action
+		}
+		return actionLineBreakRegex.ReplaceAllString(action, " ")
+	})
+}
+
 const (
 	DeploymentKind     = "Deployment"
 	ServiceAccountKind = "ServiceAccount"
@@ -179,6 +202,7 @@ func (ks *kindSet) Write() error {
 
 			fmt.Printf("Writing %s\n", destFile)
 
+			obj = rejoinFoldedActions(obj)
 			addSeparator := "---\n" + obj
 			if err := os.WriteFile(destFile, []byte(addSeparator), 0o600); err != nil {
 				return err

--- a/cmd/build/helmify/main_test.go
+++ b/cmd/build/helmify/main_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestRejoinFoldedActions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "line break before closing braces",
+			in:   "        - --admission-events-involved-namespace={{ .Values.admissionEventsInvolvedNamespace\n          }}\n",
+			want: "        - --admission-events-involved-namespace={{ .Values.admissionEventsInvolvedNamespace }}\n",
+		},
+		{
+			name: "line break inside a pipeline",
+			in:   "        - --log-level={{ (.Values.controllerManager.logLevel | empty | not) | ternary\n          .Values.controllerManager.logLevel .Values.logLevel }}\n",
+			want: "        - --log-level={{ (.Values.controllerManager.logLevel | empty | not) | ternary .Values.controllerManager.logLevel .Values.logLevel }}\n",
+		},
+		{
+			name: "single line action is untouched",
+			in:   "        - --log-denies={{ .Values.logDenies }}\n",
+			want: "        - --log-denies={{ .Values.logDenies }}\n",
+		},
+		{
+			name: "separate actions on their own lines are untouched",
+			in:   "{{- if .Values.rbac.create }}\nkind: Role\n{{- end }}\n",
+			want: "{{- if .Values.rbac.create }}\nkind: Role\n{{- end }}\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rejoinFoldedActions(tc.in); got != tc.want {
+				t.Errorf("rejoinFoldedActions() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-audit-deployment.yaml
@@ -60,19 +60,16 @@ spec:
         {{- end }}
         args:
         - --audit-interval={{ .Values.auditInterval }}
-        - --log-level={{ (.Values.audit.logLevel | empty | not) | ternary .Values.audit.logLevel
-          .Values.logLevel }}
+        - --log-level={{ (.Values.audit.logLevel | empty | not) | ternary .Values.audit.logLevel .Values.logLevel }}
         - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
-        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName
-          }}
+        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName }}
         - --mutating-webhook-configuration-name={{ .Values.mutatingWebhookName }}
         - --audit-from-cache={{ .Values.auditFromCache }}
         {{ if hasKey .Values "auditChunkSize" }}- --audit-chunk-size={{ .Values.auditChunkSize }}{{- end }}
         - --audit-match-kind-only={{ .Values.auditMatchKindOnly }}
         {{ if hasKey .Values "emitAuditEvents" }}- --emit-audit-events={{ .Values.emitAuditEvents }}{{- end }}
         {{ if hasKey .Values "logStatsAudit" }}- --log-stats-audit={{ .Values.logStatsAudit }}{{- end }}
-        - --audit-events-involved-namespace={{ .Values.auditEventsInvolvedNamespace
-          }}
+        - --audit-events-involved-namespace={{ .Values.auditEventsInvolvedNamespace }}
         
         {{- if not .Values.audit.disableGenerateOperation }}
         - --operation=generate
@@ -98,8 +95,7 @@ spec:
         - --health-addr=:{{ .Values.audit.healthPort }}
         - --prometheus-port={{ .Values.audit.metricsPort }}
         - --enable-external-data={{ .Values.enableExternalData }}
-        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion
-          }}
+        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion }}
         
         {{- range .Values.metricsBackends}}
         - --metrics-backend={{ . }}
@@ -121,10 +117,8 @@ spec:
         {{- if .Values.audit.logFile}}
         - --log-file={{ .Values.audit.logFile }}
         {{- end }}
-        - --disable-cert-rotation={{ or .Values.audit.disableCertRotation .Values.externalCertInjection.enabled
-          }}
-        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL
-          }}
+        - --disable-cert-rotation={{ or .Values.audit.disableCertRotation .Values.externalCertInjection.enabled }}
+        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL }}
         - --enable-k8s-native-validation={{ .Values.enableK8sNativeValidation }}
 
         {{- if hasKey .Values "defaultK8sNativeValidationFailurePolicy"}}

--- a/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
+++ b/manifest_staging/charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml
@@ -68,10 +68,8 @@ spec:
         - --log-denies={{ .Values.logDenies }}
         {{ if hasKey .Values "emitAdmissionEvents" }}- --emit-admission-events={{ .Values.emitAdmissionEvents }}{{- end }}
         {{ if hasKey .Values "logStatsAdmission" }}- --log-stats-admission={{ .Values.logStatsAdmission }}{{- end }}
-        - --admission-events-involved-namespace={{ .Values.admissionEventsInvolvedNamespace
-          }}
-        - --log-level={{ (.Values.controllerManager.logLevel | empty | not) | ternary
-          .Values.controllerManager.logLevel .Values.logLevel }}
+        - --admission-events-involved-namespace={{ .Values.admissionEventsInvolvedNamespace }}
+        - --log-level={{ (.Values.controllerManager.logLevel | empty | not) | ternary .Values.controllerManager.logLevel .Values.logLevel }}
         {{ if hasKey .Values "logLevelKey" }}- --log-level-key={{ .Values.logLevelKey }}{{- end }}
         {{ if hasKey .Values "logLevelEncoder" }}- --log-level-encoder={{ .Values.logLevelEncoder }}{{- end }}
         - --exempt-namespace={{ .Release.Namespace }}
@@ -87,21 +85,17 @@ spec:
         - --audit-channel={{ .Values.audit.channel }}
   {{- end }}{{- end }}
         - --enable-external-data={{ .Values.enableExternalData }}
-        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion
-          }}
+        - --enable-generator-resource-expansion={{ .Values.enableGeneratorResourceExpansion }}
         - --log-mutations={{ .Values.logMutations }}
         - --mutation-annotations={{ .Values.mutationAnnotations }}
-        - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation
-          }}
+        - --disable-cert-rotation={{ .Values.controllerManager.disableCertRotation }}
         - --max-serving-threads={{ .Values.maxServingThreads }}
         - --tls-min-version={{ .Values.controllerManager.tlsMinVersion }}
-        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName
-          }}
+        - --validating-webhook-configuration-name={{ .Values.validatingWebhookName }}
         {{ if .Values.additionalValidatingWebhookConfigsToRotateCerts | empty | not }}- --additional-validating-webhook-configs-to-rotate-certs={{ .Values.additionalValidatingWebhookConfigsToRotateCerts | join "," }}{{- end }}
         - --mutating-webhook-configuration-name={{ .Values.mutatingWebhookName }}
         {{ if .Values.additionalMutatingWebhookConfigsToRotateCerts | empty | not }}- --additional-mutating-webhook-configs-to-rotate-certs={{ .Values.additionalMutatingWebhookConfigsToRotateCerts | join "," }}{{- end }}
-        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL
-          }}
+        - --external-data-provider-response-cache-ttl={{ .Values.externaldataProviderResponseCacheTTL }}
         - --enable-k8s-native-validation={{ .Values.enableK8sNativeValidation }}
 
         {{- if hasKey .Values "defaultK8sNativeValidationFailurePolicy"}}


### PR DESCRIPTION
## Problem

The chart contains twelve `{{ ... }}` template actions split across a line break, for example `charts/gatekeeper/templates/gatekeeper-controller-manager-deployment.yaml:71`. Template lexers that predate Go 1.16 (Helm 3.5 and older) reject a newline inside an action with:

```
parse error at (.../gatekeeper-controller-manager-deployment.yaml:71): unclosed action
```

## Root cause

The folds are generated, not written by hand. `cmd/build/helmify/kustomize-for-helm.yaml` keeps each action on a single line, but the `kustomize build` step re-serialises the YAML and its emitter wraps long plain scalars at roughly eighty columns, breaking at the space before the closing braces. helmify copies that output through verbatim, so the fold lands in `manifest_staging/charts`, and `promote-staging-manifest` copies it into `charts`.

Patching `charts/` on its own does not hold: `make manifests` rebuilds `manifest_staging/charts`, and `make promote-staging-manifest` overwrites `charts/` from it.

## Approach

Normalise the stream inside helmify right before each object is written, so every generation comes out clean. The rewrite replaces only a line break inside an action with the single space YAML folding already produces. Also move the helmify invocation to the package form (`go run ./cmd/build/helmify`) so it keeps working with the added test file, add a unit test for the normalisation, and regenerate `manifest_staging/charts` and `charts`.

## Verification

- Helm 3.4.2 (Go 1.14, the strict lexer): `parse error ... unclosed action` before, `1 chart(s) linted, 0 chart(s) failed` after.
- Helm 3.19.4: still lints clean.
- `helm template` output is byte-identical before and after, so no behaviour changes.
- `go test ./cmd/build/helmify/` passes, and the new test fails if the normalisation is removed.
- Regenerating with the fixed generator matches the committed `manifest_staging/charts` exactly.

Fixes #4822
