### PR TITLE
fix(gator): preserve YAML block scalar content

### DIFF
--- a/pkg/gator/reader/block_scalar_test.go
+++ b/pkg/gator/reader/block_scalar_test.go
@@ -1,0 +1,44 @@
+package reader
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestReadUnstructuredsPreservesBlockScalar(t *testing.T) {
+	input := []byte("apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: example\ndata:\n  script: |\n    first\n\n    # literal content\n    last\n")
+	objects, err := ReadUnstructureds(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("got %d objects, want 1", len(objects))
+	}
+	got, found, err := unstructured.NestedString(objects[0].Object, "data", "script")
+	if err != nil || !found {
+		t.Fatalf("reading script: found=%v, err=%v", found, err)
+	}
+	want := "first\n\n# literal content\nlast\n"
+	if got != want {
+		t.Fatalf("block scalar = %q, want %q", got, want)
+	}
+}
+
+func TestReadUnstructuredsSkipsEmptyDocuments(t *testing.T) {
+	input := []byte("# comment only\n\n---\n\n# another comment\n---\napiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: example\ndata:\n  script: |+\n    # literal content\n\n\n---\n# trailing comment\n")
+	objects, err := ReadUnstructureds(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("got %d objects, want 1", len(objects))
+	}
+	got, found, err := unstructured.NestedString(objects[0].Object, "data", "script")
+	if err != nil || !found {
+		t.Fatalf("reading script: found=%v, err=%v", found, err)
+	}
+	if want := "# literal content\n\n"; got != want {
+		t.Fatalf("block scalar = %q, want %q", got, want)
+	}
+}

--- a/pkg/gator/reader/read_resources.go
+++ b/pkg/gator/reader/read_resources.go
@@ -56,8 +56,7 @@ func ReadUnstructureds(bytes []byte) ([]*unstructured.Unstructured, error) {
 	var result []*unstructured.Unstructured
 
 	for _, split := range splits {
-		split = clean(split)
-		if len(split) == 0 {
+		if len(clean(split)) == 0 {
 			continue
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`gator verify` removes blank lines and lines beginning with `#` from YAML block scalars before evaluating resources. For a ConfigMap script, this changes the data passed to the policy:

```yaml
data:
  script: |
    first

    # literal content
    last
```

The reader currently turns that value into `first\nlast\n`. Use the cleaned text only to detect empty documents, and pass the original document to the YAML parser.

Two regression tests cover literal content, retained trailing blank lines, and comment-only documents. The content-preservation regression fails before the fix.

**Special notes for your reviewer**:

Linux validation on this exact commit: `make native-test` and `make lint` pass ([run](https://github.com/Hanabi9248/gatekeeper/actions/runs/34634269555)). The reader and verify package tests also pass locally on Windows. Kubernetes end-to-end tests were not run; this change is limited to the Gator YAML reader.